### PR TITLE
Add PR automation with evidence collection

### DIFF
--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -1,5 +1,10 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+handoffs:
+  - label: Create Pull Request
+    agent: speckit.pr
+    prompt: Create PR with evidence from implementation
+    send: true
 ---
 
 ## User Input
@@ -102,6 +107,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Task dependencies**: Sequential vs parallel execution rules
    - **Task details**: ID, description, file paths, parallel markers [P]
    - **Execution flow**: Order and dependency requirements
+   - **Evidence requirements**: Check for Evidence Requirements section and note what artifacts to capture
 
 6. Execute implementation following the task plan:
    - **Phase-by-phase execution**: Complete each phase before moving to the next
@@ -116,6 +122,11 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Core development**: Implement models, services, CLI commands, endpoints
    - **Integration work**: Database connections, middleware, logging, external services
    - **Polish and validation**: Unit tests, performance optimization, documentation
+   - **Evidence collection**: During Polish phase, capture evidence artifacts as specified in tasks.md:
+     - Create `FEATURE_DIR/evidence/` directory
+     - Capture test-summary.md with test results
+     - Create usage-example.md demonstrating the feature
+     - Capture any feature-specific artifacts (screenshots, API samples, CLI output, etc.)
 
 8. Progress tracking and error handling:
    - Report progress after each completed task
@@ -131,5 +142,17 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Validate that tests pass and coverage meets requirements
    - Confirm the implementation follows the technical plan
    - Report final status with summary of completed work
+
+10. **Evidence verification and PR preparation**:
+    - Verify evidence directory exists: `FEATURE_DIR/evidence/`
+    - Check that required evidence files are present:
+      - `evidence/test-summary.md` - REQUIRED
+      - `evidence/usage-example.md` - REQUIRED
+      - Feature-specific artifacts as defined in tasks.md
+    - If evidence is missing, WARN the user and recommend completing evidence tasks
+    - If all evidence is present:
+      - Commit any uncommitted changes
+      - Push to the feature branch
+      - Prompt user: "Implementation complete with evidence. Run `/speckit.pr` to create a pull request with the collected evidence."
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.

--- a/.claude/commands/speckit.pr.md
+++ b/.claude/commands/speckit.pr.md
@@ -1,0 +1,185 @@
+---
+description: Create a pull request with a well-structured title, description, and evidence artifacts from the completed implementation.
+handoffs:
+  - label: View PR
+    agent: none
+    prompt: PR created successfully
+    send: false
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+
+2. **Verify implementation is complete**:
+   - Read tasks.md and count completed vs incomplete tasks
+   - If more than 10% of tasks are incomplete, WARN the user and ask if they want to proceed
+   - If evidence collection tasks are incomplete, STRONGLY recommend completing them first
+
+3. **Load context for PR generation**:
+   - **REQUIRED**: Read spec.md for feature name and description
+   - **REQUIRED**: Read tasks.md for completed work summary
+   - **IF EXISTS**: Read plan.md for technical context
+   - **IF EXISTS**: Read evidence/ directory for captured artifacts
+
+4. **Generate PR title**:
+   - Format: `feat(scope): Brief description of the feature`
+   - Extract scope from feature directory name (e.g., `002-debrief-io` → `debrief-io`)
+   - Keep title under 72 characters
+   - Use conventional commit format:
+     - `feat`: New feature
+     - `fix`: Bug fix
+     - `refactor`: Code restructuring
+     - `docs`: Documentation only
+     - `test`: Adding tests
+     - `chore`: Maintenance tasks
+
+5. **Generate PR description** using this structure:
+
+   ```markdown
+   ## Summary
+
+   [2-4 bullet points describing what this PR delivers]
+
+   ## Changes
+
+   ### [Phase/Category Name]
+   - [Grouped list of completed tasks by phase]
+
+   ## Evidence
+
+   ### Test Results
+   [Include test-summary.md content or test output summary]
+
+   ### Usage Example
+   [Include usage-example.md content or demonstrate feature usage]
+
+   ### [Additional Evidence]
+   [Include any feature-specific evidence: screenshots, API samples, CLI output, etc.]
+
+   ## Test Plan
+
+   - [x] [List key test scenarios that were verified]
+   - [x] [Include coverage information if available]
+
+   ## Related
+
+   - Spec: `specs/[feature]/spec.md`
+   - Tasks: `specs/[feature]/tasks.md`
+   ```
+
+6. **Collect evidence artifacts**:
+   - Check for `FEATURE_DIR/evidence/` directory
+   - If exists, list all files and incorporate into PR description:
+     - `.md` files: Include content directly (formatted)
+     - `.txt` files: Include in code blocks
+     - `.json` files: Include as collapsible JSON blocks
+     - `.png`, `.jpg`, `.gif` images: Reference with relative paths (will need to be added to repo)
+     - `.csv` files: Convert to markdown tables
+   - If evidence directory is missing or empty, add a note: "⚠️ No evidence artifacts captured. Consider running evidence collection tasks."
+
+7. **Check git and branch status**:
+   - Verify all changes are committed
+   - Check current branch name
+   - Determine target branch (usually `main` or as specified in arguments)
+   - If there are uncommitted changes, STOP and ask user to commit first
+
+8. **Create the pull request**:
+   - Use `gh pr create` with generated title and body
+   - Use HEREDOC for body to preserve formatting:
+
+   ```bash
+   gh pr create --title "feat(scope): Title here" --body "$(cat <<'EOF'
+   ## Summary
+   ...PR body content...
+   EOF
+   )"
+   ```
+
+9. **Handle existing PR**:
+   - If a PR already exists for this branch, offer to UPDATE it instead:
+     - Use `gh pr edit` to update title and body
+   - Display the PR URL to the user
+
+10. **Report**:
+    - Display the PR URL
+    - Show summary of what was included:
+      - Number of completed tasks referenced
+      - Evidence artifacts included
+      - Any warnings about missing evidence
+
+## Evidence Integration Guidelines
+
+When incorporating evidence into the PR:
+
+### Test Summary (test-summary.md)
+```markdown
+### Test Results
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | XX |
+| Passed | XX |
+| Failed | 0 |
+| Coverage | XX% |
+
+**Key scenarios verified:**
+- [List from test-summary.md]
+```
+
+### Usage Example (usage-example.md or usage-demo.txt)
+```markdown
+### Usage Example
+
+\`\`\`python
+# Code example from usage-example.md
+\`\`\`
+
+**Output:**
+\`\`\`
+# Expected output
+\`\`\`
+```
+
+### Screenshots/Images
+```markdown
+### Screenshots
+
+![Description](./specs/[feature]/evidence/screenshot.png)
+```
+
+### API Samples (*.json)
+```markdown
+### API Response Sample
+
+<details>
+<summary>Click to expand</summary>
+
+\`\`\`json
+{ ... }
+\`\`\`
+
+</details>
+```
+
+## Error Handling
+
+- **No `gh` CLI**: Provide instructions to install: `brew install gh` or `apt install gh`, then `gh auth login`
+- **Not authenticated**: Run `gh auth login` first
+- **No upstream branch**: Push first with `git push -u origin <branch>`
+- **Missing evidence**: Proceed with warning, but strongly recommend capturing evidence
+
+## Notes
+
+- Always include a link back to the spec and tasks files
+- Evidence makes PRs more reviewable and documents behavior for future reference
+- Screenshots and demos are especially valuable for UI changes or complex behaviors
+- The PR description serves as documentation that persists with the codebase

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -41,24 +41,38 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
    - Correct feature name from plan.md
+   - **Evidence Requirements section** (see Evidence Planning Rules below)
    - Phase 1: Setup tasks (project initialization)
    - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
    - Phase 3+: One phase per user story (in priority order from spec.md)
    - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
-   - Final Phase: Polish & cross-cutting concerns
+   - Final Phase: Polish & cross-cutting concerns (MUST include evidence collection tasks)
    - All tasks must follow the strict checklist format (see Task Generation Rules below)
    - Clear file paths for each task
    - Dependencies section showing story completion order
    - Parallel execution examples per story
    - Implementation strategy section (MVP first, incremental delivery)
 
-5. **Report**: Output path to generated tasks.md and summary:
+5. **Plan evidence artifacts**: Determine what evidence should be captured to demonstrate the feature works:
+   - **Test evidence**: What test output/summary will prove correctness?
+   - **Usage evidence**: What example demonstrates the feature in action?
+   - **Feature-specific evidence**: Based on feature type:
+     - CLI tools → Terminal session recordings, command output
+     - APIs → Sample request/response JSON
+     - UI components → Screenshots of key states
+     - Data processing → Before/after data samples
+     - Libraries → Code examples with output
+   - Add specific evidence collection tasks to the Polish phase
+
+6. **Report**: Output path to generated tasks.md and summary:
    - Total task count
    - Task count per user story
    - Parallel opportunities identified
    - Independent test criteria for each story
+   - **Evidence artifacts planned** (list what will be captured)
    - Suggested MVP scope (typically just User Story 1)
    - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+   - Reminder: Run `/speckit.pr` after implementation to create PR with evidence
 
 Context for task generation: $ARGUMENTS
 
@@ -134,4 +148,77 @@ Every task MUST strictly follow this format:
 - **Phase 3+**: User Stories in priority order (P1, P2, P3...)
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
-- **Final Phase**: Polish & Cross-Cutting Concerns
+- **Final Phase**: Polish & Cross-Cutting Concerns (MUST include evidence collection)
+
+## Evidence Planning Rules
+
+**Purpose**: Plan artifacts that demonstrate the feature works. These are used in PR descriptions, documentation, and blog posts.
+
+### Evidence Directory Structure
+
+```text
+specs/[###-feature-name]/evidence/
+├── test-summary.md      # REQUIRED: Test pass/fail counts, coverage
+├── usage-example.md     # REQUIRED: Concrete usage demonstration
+└── [feature-specific]   # Varies by feature type
+```
+
+### Determining Feature-Specific Evidence
+
+Based on the feature type detected from spec.md and plan.md:
+
+| Feature Type | Evidence to Plan | Example Files |
+|--------------|------------------|---------------|
+| **CLI Tool** | Command examples with output | `cli-demo.txt`, `help-output.txt` |
+| **API/Service** | Request/response samples | `api-sample.json`, `endpoints.md` |
+| **Library/SDK** | Code examples with results | `usage-example.py`, `output.txt` |
+| **Data Processing** | Before/after samples | `input-sample.json`, `output-sample.json` |
+| **UI Component** | Screenshots of states | `initial.png`, `completed.png` |
+| **Parser/Converter** | Input/output file pairs | `sample-input.rep`, `parsed-output.json` |
+| **Integration** | End-to-end flow demo | `integration-flow.md`, `sequence.mermaid` |
+
+### Evidence Task Generation
+
+For the Polish phase, ALWAYS generate these tasks:
+
+1. **Test Summary Task** (REQUIRED):
+   ```markdown
+   - [ ] TXXX Capture test results in specs/[feature]/evidence/test-summary.md
+   ```
+   Content should include: total tests, passed, failed, coverage %, key scenarios.
+
+2. **Usage Example Task** (REQUIRED):
+   ```markdown
+   - [ ] TXXX Create usage demonstration in specs/[feature]/evidence/usage-example.md
+   ```
+   Content should include: code/command example, expected output, explanation.
+
+3. **Feature-Specific Tasks** (based on feature type):
+   ```markdown
+   - [ ] TXXX [P] Capture [specific artifact] in specs/[feature]/evidence/[filename]
+   ```
+
+### Evidence Quality Guidelines
+
+Good evidence should be:
+- **Reproducible**: Others can follow the example and get the same result
+- **Concise**: Shows the key behavior without unnecessary complexity
+- **Visual when possible**: Screenshots, diagrams, or formatted output
+- **Self-contained**: Includes all context needed to understand it
+
+### Example Evidence Section in tasks.md
+
+```markdown
+## Evidence Requirements
+
+**Evidence Directory**: `specs/002-debrief-io/evidence/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| test-summary.md | pytest results with 47 tests | After all tests pass |
+| usage-example.md | Python code parsing REP file | After parser complete |
+| cli-demo.txt | Terminal session showing parse command | After CLI works |
+| sample-output.json | GeoJSON output from boat1.rep | After parsing works |
+```

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -12,6 +12,56 @@ description: "Task list template for feature implementation"
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
+---
+
+## Evidence Requirements
+
+> **Purpose**: Capture artifacts that demonstrate the feature works as expected. These are used in PR descriptions, documentation, and future blog posts.
+
+**Evidence Directory**: `specs/[###-feature-name]/evidence/`
+
+### Evidence Types
+
+| Type | Format | When to Capture | Example |
+|------|--------|-----------------|---------|
+| **Test Output** | `.txt`, `.md` | After test suite passes | `pytest-output.txt`, `test-summary.md` |
+| **CLI Demo** | `.txt`, `.gif` | After CLI features work | `cli-demo.txt`, `usage.gif` |
+| **Screenshot** | `.png`, `.jpg` | After UI renders correctly | `dashboard.png`, `before-after.png` |
+| **API Response** | `.json` | After endpoint works | `sample-response.json` |
+| **Performance** | `.md`, `.csv` | After benchmarks run | `benchmarks.md`, `metrics.csv` |
+| **Architecture** | `.md`, `.mermaid` | After design is implemented | `data-flow.md`, `sequence.mermaid` |
+
+### Minimum Evidence Per Feature
+
+Every completed feature MUST include:
+
+1. **Test Summary** (`evidence/test-summary.md`):
+   - Total tests: passed/failed/skipped
+   - Coverage percentage (if applicable)
+   - Key test scenarios verified
+
+2. **Usage Example** (`evidence/usage-example.md` or `evidence/usage-demo.txt`):
+   - A concrete example of using the feature
+   - Expected output/behavior
+   - Can be CLI output, API call, or code snippet
+
+3. **Feature-Specific Evidence** (varies by feature type):
+   - CLI tools: Terminal session showing commands and output
+   - APIs: Sample request/response JSON
+   - UI: Screenshots of key states
+   - Libraries: Code example with output
+   - Data processing: Before/after data samples
+
+### Evidence Collection Tasks
+
+Include these as final tasks in the Polish phase:
+
+```markdown
+- [ ] TXXX Capture test summary in specs/[feature]/evidence/test-summary.md
+- [ ] TXXX Record usage example in specs/[feature]/evidence/usage-example.md
+- [ ] TXXX [Add feature-specific evidence task]
+```
+
 ## Format: `[ID] [P?] [Story] Description`
 
 - **[P]**: Can run in parallel (different files, no dependencies)
@@ -157,6 +207,17 @@ Examples of foundational tasks (adjust based on your project):
 - [ ] TXXX Security hardening
 - [ ] TXXX Run quickstart.md validation
 
+### Evidence Collection (REQUIRED)
+
+> **Purpose**: Capture artifacts for PR description and future documentation
+
+- [ ] TXXX Create evidence directory: specs/[feature]/evidence/
+- [ ] TXXX Capture test summary with pass/fail counts in evidence/test-summary.md
+- [ ] TXXX Record usage example demonstrating feature in evidence/usage-example.md
+- [ ] TXXX [Add feature-specific evidence - screenshots, CLI output, API samples, etc.]
+
+**Checkpoint**: Evidence collected - ready for PR creation via `/speckit.pr`
+
 ---
 
 ## Dependencies & Execution Order
@@ -249,3 +310,5 @@ With multiple developers:
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently
 - Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence
+- **Evidence is required** - capture artifacts that prove the feature works
+- Run `/speckit.pr` after all tasks complete to create PR with evidence


### PR DESCRIPTION
- Add /speckit.pr command to create PRs with structured descriptions
  - Generates title using conventional commit format
  - Includes summary, changes, evidence, and test plan sections
  - Incorporates evidence artifacts from specs/[feature]/evidence/

- Update /speckit.tasks to plan evidence requirements
  - Add Evidence Planning Rules section
  - Generate evidence collection tasks in Polish phase
  - Define evidence types based on feature type

- Update /speckit.implement to collect evidence during execution
  - Check for evidence requirements in tasks.md
  - Create evidence directory and capture artifacts
  - Verify evidence before prompting for PR creation
  - Add handoff to /speckit.pr command

- Update tasks-template.md with evidence framework
  - Add Evidence Requirements section with types table
  - Define minimum required evidence per feature
  - Add evidence collection tasks to Polish phase

This enables automated PR creation with test summaries, usage examples, and feature-specific artifacts for documentation and blog posts.