### PR TITLE
feat(speckit): Integrate media agents for content creation

### DIFF
--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -33,7 +33,18 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Phase 1: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
-4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+4. **Media content - Planning Post**: After design artifacts are complete, create a planning announcement:
+   - Read the Content Specialist agent definition from `.claude/agents/media/content.md`
+   - Use the Task tool with `subagent_type: "general-purpose"` to spawn the Content Specialist
+   - Provide the specialist with:
+     - Feature name and goal from spec.md
+     - Key technical decisions from research.md
+     - Architecture overview from plan.md
+   - Request a "Planning Post" following the template in the agent definition
+   - Save the draft post to `FEATURE_DIR/media/planning-post.md`
+   - Generate a LinkedIn summary and save to `FEATURE_DIR/media/linkedin-planning.md`
+
+5. **Stop and report**: Command ends after planning. Report branch, IMPL_PLAN path, generated artifacts, and media content drafts.
 
 ## Phases
 
@@ -82,6 +93,34 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Preserve manual additions between markers
 
 **Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+### Phase 2: Media Content Creation
+
+**Prerequisites:** Phase 1 complete (design artifacts exist)
+
+1. **Create media directory**: `mkdir -p FEATURE_DIR/media/`
+
+2. **Spawn Content Specialist** via Task tool:
+   - Read `.claude/agents/media/content.md` for agent definition
+   - Provide context:
+     ```text
+     Feature: [name from spec.md]
+     Goal: [goal statement from spec.md]
+     Key Decisions: [from research.md]
+     Architecture: [summary from plan.md]
+     Audience: DSTL scientists, potential contributors, defence maritime analysis community
+     ```
+   - Request: "Write a Planning Post announcing this feature"
+
+3. **Generate planning post**: Save to `FEATURE_DIR/media/planning-post.md`
+   - Must follow the Planning Post template from content.md
+   - Include sections: What We're Building, How It Fits, Key Decisions, What We'd Love Feedback On
+
+4. **Generate LinkedIn summary**: Save to `FEATURE_DIR/media/linkedin-planning.md`
+   - 150-200 words, strong hook, link placeholder
+   - Follow LinkedIn template from content.md
+
+**Output**: media/planning-post.md, media/linkedin-planning.md
 
 ## Key rules
 

--- a/.claude/commands/speckit.pr.md
+++ b/.claude/commands/speckit.pr.md
@@ -76,7 +76,19 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Tasks: `specs/[feature]/tasks.md`
    ```
 
-6. **Collect evidence artifacts**:
+6. **Generate or verify media content**:
+   - Check for `FEATURE_DIR/media/` directory
+   - If shipped-post.md is missing or incomplete:
+     - Read Content Specialist agent from `.claude/agents/media/content.md`
+     - Spawn Content Specialist via Task tool with:
+       - Feature summary from spec.md
+       - Evidence artifacts from evidence/
+       - Lessons learned from implementation
+     - Generate shipped-post.md following the Shipped Post template
+     - Generate linkedin-shipped.md (150-200 words)
+   - Save media content to `FEATURE_DIR/media/`
+
+7. **Collect evidence artifacts**:
    - Check for `FEATURE_DIR/evidence/` directory
    - If exists, list all files and incorporate into PR description:
      - `.md` files: Include content directly (formatted)
@@ -86,13 +98,13 @@ You **MUST** consider the user input before proceeding (if not empty).
      - `.csv` files: Convert to markdown tables
    - If evidence directory is missing or empty, add a note: "⚠️ No evidence artifacts captured. Consider running evidence collection tasks."
 
-7. **Check git and branch status**:
+8. **Check git and branch status**:
    - Verify all changes are committed
    - Check current branch name
    - Determine target branch (usually `main` or as specified in arguments)
    - If there are uncommitted changes, STOP and ask user to commit first
 
-8. **Create the pull request**:
+9. **Create the pull request**:
    - Use `gh pr create` with generated title and body
    - Use HEREDOC for body to preserve formatting:
 
@@ -104,17 +116,21 @@ You **MUST** consider the user input before proceeding (if not empty).
    )"
    ```
 
-9. **Handle existing PR**:
+10. **Handle existing PR**:
    - If a PR already exists for this branch, offer to UPDATE it instead:
      - Use `gh pr edit` to update title and body
    - Display the PR URL to the user
 
-10. **Report**:
+11. **Report**:
     - Display the PR URL
     - Show summary of what was included:
       - Number of completed tasks referenced
       - Evidence artifacts included
       - Any warnings about missing evidence
+    - **Media content status**:
+      - List media files created/updated in `FEATURE_DIR/media/`
+      - Remind user: "Blog posts are ready for review in media/ directory"
+      - Provide next steps: "Copy shipped-post.md to debrief.github.io/_posts/ and linkedin-shipped.md for social sharing"
 
 ## Evidence Integration Guidelines
 
@@ -169,6 +185,45 @@ When incorporating evidence into the PR:
 
 </details>
 ```
+
+## Media Content Integration
+
+When creating media content for the shipped feature:
+
+### Shipped Post Generation
+
+Spawn the Content Specialist agent via Task tool:
+
+```text
+subagent_type: "general-purpose"
+prompt: |
+  You are the Content Specialist for Future Debrief.
+
+  [Include .claude/agents/media/content.md content]
+
+  Create a Shipped Post for:
+  - Feature: [name from spec.md]
+  - What was built: [summary from evidence/usage-example.md]
+  - Test results: [from evidence/test-summary.md]
+  - Key decisions: [from research.md if exists]
+
+  Follow the Shipped Post template exactly.
+```
+
+### LinkedIn Summary
+
+Generate alongside the shipped post:
+- 150-200 words
+- Hook opening (not "I'm excited to announce...")
+- Key accomplishment highlight
+- Link placeholder: `[Read the full post: LINK]`
+- Tags: `#FutureDebrief #MaritimeAnalysis #OpenSource`
+
+### Output Files
+
+Save to `FEATURE_DIR/media/`:
+- `shipped-post.md` - Full blog post
+- `linkedin-shipped.md` - LinkedIn summary
 
 ## Error Handling
 

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -46,7 +46,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
    - Phase 3+: One phase per user story (in priority order from spec.md)
    - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
-   - Final Phase: Polish & cross-cutting concerns (MUST include evidence collection tasks)
+   - Final Phase: Polish & cross-cutting concerns (MUST include evidence collection AND media content tasks)
    - All tasks must follow the strict checklist format (see Task Generation Rules below)
    - Clear file paths for each task
    - Dependencies section showing story completion order
@@ -148,7 +148,7 @@ Every task MUST strictly follow this format:
 - **Phase 3+**: User Stories in priority order (P1, P2, P3...)
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
-- **Final Phase**: Polish & Cross-Cutting Concerns (MUST include evidence collection)
+- **Final Phase**: Polish & Cross-Cutting Concerns (MUST include evidence collection AND media content)
 
 ## Evidence Planning Rules
 
@@ -198,6 +198,20 @@ For the Polish phase, ALWAYS generate these tasks:
    - [ ] TXXX [P] Capture [specific artifact] in specs/[feature]/evidence/[filename]
    ```
 
+4. **Shipped Post Task** (REQUIRED - for media announcement):
+   ```markdown
+   - [ ] TXXX Create shipped blog post in specs/[feature]/media/shipped-post.md
+   ```
+   Use Content Specialist agent (`.claude/agents/media/content.md`) to generate:
+   - Shipped Post following the template
+   - Include: What We Built, Screenshots (if applicable), Lessons Learned, What's Next
+
+5. **LinkedIn Shipped Summary Task** (REQUIRED):
+   ```markdown
+   - [ ] TXXX [P] Create LinkedIn shipped summary in specs/[feature]/media/linkedin-shipped.md
+   ```
+   150-200 words, hook opening, link to full post
+
 ### Evidence Quality Guidelines
 
 Good evidence should be:
@@ -212,6 +226,7 @@ Good evidence should be:
 ## Evidence Requirements
 
 **Evidence Directory**: `specs/002-debrief-io/evidence/`
+**Media Directory**: `specs/002-debrief-io/media/`
 
 ### Planned Artifacts
 
@@ -221,4 +236,51 @@ Good evidence should be:
 | usage-example.md | Python code parsing REP file | After parser complete |
 | cli-demo.txt | Terminal session showing parse command | After CLI works |
 | sample-output.json | GeoJSON output from boat1.rep | After parsing works |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| media/planning-post.md | Blog post announcing the feature | During /speckit.plan |
+| media/linkedin-planning.md | LinkedIn summary for planning | During /speckit.plan |
+| media/shipped-post.md | Blog post celebrating completion | During Polish phase |
+| media/linkedin-shipped.md | LinkedIn summary for shipped | During Polish phase |
+```
+
+## Media Content Rules
+
+**Purpose**: Create blog posts and social content to announce planning and celebrate shipped features.
+
+### Media Agents
+
+Use the agents in `.claude/agents/media/` via the Task tool:
+
+1. **Content Specialist** (`.claude/agents/media/content.md`):
+   - Planning posts (announce what we're building)
+   - Shipped posts (celebrate what we built)
+   - LinkedIn summaries
+   - Voice & tone guidelines
+
+2. **Technical Specialist** (`.claude/agents/media/technical.md`):
+   - Technical context for posts
+   - Diagram descriptions
+   - Architecture summaries
+
+### Spawning Media Agents
+
+To create media content, spawn a subagent via Task tool:
+
+```text
+Task tool call:
+  subagent_type: "general-purpose"
+  prompt: |
+    You are the Content Specialist for Future Debrief.
+
+    [Include full content of .claude/agents/media/content.md]
+
+    Create a [Planning/Shipped] Post for:
+    - Feature: [name]
+    - Goal: [from spec.md]
+    - Key accomplishments: [from evidence/]
+    - Lessons learned: [notable challenges/decisions]
 ```


### PR DESCRIPTION
Updates SpecKit commands to use media agents for creating blog posts and LinkedIn summaries at each stage of the spec workflow:

- speckit.plan: Adds Phase 2 for creating planning posts announcing upcoming features, using Content Specialist agent

- speckit.tasks: Adds media content tasks to Polish phase for creating shipped posts and LinkedIn summaries after implementation

- speckit.pr: Adds step 6 to generate/verify shipped post and LinkedIn summary before PR creation, with media content reporting

Media content is saved to FEATURE_DIR/media/ with planning-post.md, linkedin-planning.md, shipped-post.md, and linkedin-shipped.md.