### PR TITLE
Implement Debrief config specification 003

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ Three approaches required:
 - N/A (schema package produces generated code, not persisted data) (000-schemas)
 - Python 3.11+ + Pydantic >=2.0.0, debrief-schemas (workspace), mcp >=1.0.0 (optional) (002-debrief-io)
 - N/A (pure transformation service - no persistence) (002-debrief-io)
+- Python 3.11+ (primary), TypeScript 5.x (mirror library) + Pydantic >=2.0.0 (Python), platformdirs (XDG paths), zod (TypeScript validation) (003-debrief-config)
+- JSON file at XDG config location (~/.config/debrief/config.json on Linux) (003-debrief-config)
 
 ## Recent Changes
 - 000-schemas: Added Python 3.11+ (generators, Pydantic models), TypeScript 5.x (generated interfaces) + LinkML, linkml-runtime, Pydantic v2, AJV (JSON Schema validation in JS)

--- a/specs/003-debrief-config/contracts/python-api.md
+++ b/specs/003-debrief-config/contracts/python-api.md
@@ -1,0 +1,231 @@
+# Python API Contract: debrief-config
+
+**Package**: `debrief_config`
+**Version**: 0.1.0
+
+This document defines the public API for the Python debrief-config library.
+
+---
+
+## Module: `debrief_config`
+
+### Functions
+
+#### `get_config_dir() -> Path`
+
+Get the platform-specific configuration directory.
+
+**Returns**: Path to config directory (creates if `ensure_exists=True`)
+
+**Platform Paths**:
+- Linux: `~/.config/debrief` or `$XDG_CONFIG_HOME/debrief`
+- macOS: `~/Library/Application Support/debrief`
+- Windows: `%APPDATA%\debrief`
+
+---
+
+#### `register_store(path: Path | str, name: str, notes: str | None = None) -> StoreRegistration`
+
+Register a STAC catalog location.
+
+**Parameters**:
+- `path`: Absolute path to STAC catalog directory
+- `name`: Human-readable display name
+- `notes`: Optional notes about the store
+
+**Returns**: The created StoreRegistration
+
+**Raises**:
+- `InvalidCatalogError`: If path is not a valid STAC catalog
+- `StoreExistsError`: If path is already registered
+- `ValueError`: If path or name is empty
+
+**Example**:
+```python
+from debrief_config import register_store
+
+store = register_store(
+    path="/data/exercise-2024",
+    name="Exercise 2024",
+    notes="Main analysis catalog"
+)
+```
+
+---
+
+#### `list_stores() -> list[StoreRegistration]`
+
+List all registered STAC stores.
+
+**Returns**: List of StoreRegistration objects (empty list if none registered)
+
+**Example**:
+```python
+from debrief_config import list_stores
+
+for store in list_stores():
+    print(f"{store.name}: {store.path}")
+```
+
+---
+
+#### `remove_store(path: Path | str) -> None`
+
+Remove a store registration (does not delete the catalog).
+
+**Parameters**:
+- `path`: Path of the store to remove
+
+**Raises**:
+- `StoreNotFoundError`: If path is not registered
+
+**Example**:
+```python
+from debrief_config import remove_store
+
+remove_store("/data/old-catalog")
+```
+
+---
+
+#### `get_preference(key: str, default: T = None) -> T | PreferenceValue`
+
+Get a user preference value.
+
+**Parameters**:
+- `key`: Preference key
+- `default`: Value to return if key not found
+
+**Returns**: Preference value or default
+
+**Example**:
+```python
+from debrief_config import get_preference
+
+theme = get_preference("theme", default="system")
+```
+
+---
+
+#### `set_preference(key: str, value: PreferenceValue) -> None`
+
+Set a user preference value.
+
+**Parameters**:
+- `key`: Preference key
+- `value`: Value to store (string, number, boolean, or None)
+
+**Example**:
+```python
+from debrief_config import set_preference
+
+set_preference("theme", "dark")
+set_preference("defaultStore", "/data/main-catalog")
+```
+
+---
+
+### Classes
+
+#### `StoreRegistration`
+
+Pydantic model representing a registered STAC store.
+
+**Attributes**:
+- `path: str` - Absolute path to catalog
+- `name: str` - Display name
+- `last_accessed: datetime` - When store was last accessed
+- `notes: str | None` - Optional notes
+
+---
+
+#### `Config`
+
+Pydantic model representing the full configuration.
+
+**Attributes**:
+- `version: str` - Schema version
+- `stores: list[StoreRegistration]` - Registered stores
+- `preferences: dict[str, PreferenceValue]` - User preferences
+
+---
+
+### Exceptions
+
+#### `InvalidCatalogError`
+
+Raised when a path is not a valid STAC catalog.
+
+```python
+class InvalidCatalogError(Exception):
+    """Path is not a valid STAC catalog."""
+    pass
+```
+
+---
+
+#### `StoreNotFoundError`
+
+Raised when attempting to access an unregistered store.
+
+```python
+class StoreNotFoundError(Exception):
+    """Store is not registered."""
+    pass
+```
+
+---
+
+#### `StoreExistsError`
+
+Raised when attempting to register a store that already exists.
+
+```python
+class StoreExistsError(Exception):
+    """Store is already registered."""
+    pass
+```
+
+---
+
+## Types
+
+```python
+PreferenceValue = str | int | float | bool | None
+```
+
+---
+
+## Usage Example
+
+```python
+from pathlib import Path
+from debrief_config import (
+    register_store,
+    list_stores,
+    remove_store,
+    get_preference,
+    set_preference,
+)
+
+# Register a new store
+store = register_store(
+    path=Path("/data/exercise-2024"),
+    name="Exercise 2024"
+)
+print(f"Registered: {store.name}")
+
+# List all stores
+for s in list_stores():
+    print(f"  - {s.name}: {s.path}")
+
+# Set default store
+set_preference("defaultStore", str(store.path))
+
+# Get default store
+default = get_preference("defaultStore")
+print(f"Default store: {default}")
+
+# Remove a store (keeps files, just removes registration)
+remove_store(store.path)
+```

--- a/specs/003-debrief-config/contracts/typescript-api.md
+++ b/specs/003-debrief-config/contracts/typescript-api.md
@@ -1,0 +1,304 @@
+# TypeScript API Contract: debrief-config
+
+**Package**: `@debrief/config`
+**Version**: 0.1.0
+
+This document defines the public API for the TypeScript debrief-config library.
+
+---
+
+## Module Exports
+
+```typescript
+import {
+  getConfigDir,
+  registerStore,
+  listStores,
+  removeStore,
+  getPreference,
+  setPreference,
+  StoreRegistration,
+  Config,
+  InvalidCatalogError,
+  StoreNotFoundError,
+  StoreExistsError,
+} from '@debrief/config';
+```
+
+---
+
+## Functions
+
+### `getConfigDir(): string`
+
+Get the platform-specific configuration directory.
+
+**Returns**: Path to config directory (creates if not exists)
+
+**Platform Paths**:
+- Linux: `~/.config/debrief` or `$XDG_CONFIG_HOME/debrief`
+- macOS: `~/Library/Application Support/debrief`
+- Windows: `%APPDATA%\debrief`
+
+---
+
+### `registerStore(path: string, name: string, notes?: string): Promise<StoreRegistration>`
+
+Register a STAC catalog location.
+
+**Parameters**:
+- `path`: Absolute path to STAC catalog directory
+- `name`: Human-readable display name
+- `notes`: Optional notes about the store
+
+**Returns**: Promise resolving to the created StoreRegistration
+
+**Throws**:
+- `InvalidCatalogError`: If path is not a valid STAC catalog
+- `StoreExistsError`: If path is already registered
+- `Error`: If path or name is empty
+
+**Example**:
+```typescript
+import { registerStore } from '@debrief/config';
+
+const store = await registerStore(
+  '/data/exercise-2024',
+  'Exercise 2024',
+  'Main analysis catalog'
+);
+console.log(`Registered: ${store.name}`);
+```
+
+---
+
+### `listStores(): Promise<StoreRegistration[]>`
+
+List all registered STAC stores.
+
+**Returns**: Promise resolving to array of StoreRegistration objects
+
+**Example**:
+```typescript
+import { listStores } from '@debrief/config';
+
+const stores = await listStores();
+for (const store of stores) {
+  console.log(`${store.name}: ${store.path}`);
+}
+```
+
+---
+
+### `removeStore(path: string): Promise<void>`
+
+Remove a store registration (does not delete the catalog).
+
+**Parameters**:
+- `path`: Path of the store to remove
+
+**Throws**:
+- `StoreNotFoundError`: If path is not registered
+
+**Example**:
+```typescript
+import { removeStore } from '@debrief/config';
+
+await removeStore('/data/old-catalog');
+```
+
+---
+
+### `getPreference<T>(key: string, defaultValue?: T): Promise<T | PreferenceValue>`
+
+Get a user preference value.
+
+**Parameters**:
+- `key`: Preference key
+- `defaultValue`: Value to return if key not found
+
+**Returns**: Promise resolving to preference value or default
+
+**Example**:
+```typescript
+import { getPreference } from '@debrief/config';
+
+const theme = await getPreference('theme', 'system');
+```
+
+---
+
+### `setPreference(key: string, value: PreferenceValue): Promise<void>`
+
+Set a user preference value.
+
+**Parameters**:
+- `key`: Preference key
+- `value`: Value to store (string, number, boolean, or null)
+
+**Example**:
+```typescript
+import { setPreference } from '@debrief/config';
+
+await setPreference('theme', 'dark');
+await setPreference('defaultStore', '/data/main-catalog');
+```
+
+---
+
+## Interfaces
+
+### `StoreRegistration`
+
+```typescript
+interface StoreRegistration {
+  /** Absolute path to STAC catalog */
+  path: string;
+  /** Human-readable display name */
+  name: string;
+  /** ISO 8601 datetime of last access */
+  lastAccessed: string;
+  /** Optional user notes */
+  notes?: string;
+}
+```
+
+---
+
+### `Config`
+
+```typescript
+interface Config {
+  /** Schema version (semver) */
+  version: string;
+  /** Registered STAC stores */
+  stores: StoreRegistration[];
+  /** User preferences */
+  preferences: Record<string, PreferenceValue>;
+}
+```
+
+---
+
+## Types
+
+### `PreferenceValue`
+
+```typescript
+type PreferenceValue = string | number | boolean | null;
+```
+
+---
+
+## Error Classes
+
+### `InvalidCatalogError`
+
+Thrown when a path is not a valid STAC catalog.
+
+```typescript
+class InvalidCatalogError extends Error {
+  constructor(message: string);
+}
+```
+
+---
+
+### `StoreNotFoundError`
+
+Thrown when attempting to access an unregistered store.
+
+```typescript
+class StoreNotFoundError extends Error {
+  constructor(path: string);
+}
+```
+
+---
+
+### `StoreExistsError`
+
+Thrown when attempting to register a store that already exists.
+
+```typescript
+class StoreExistsError extends Error {
+  constructor(path: string);
+}
+```
+
+---
+
+## Synchronous Variants
+
+For use in contexts where async is inconvenient (e.g., app initialization):
+
+```typescript
+import {
+  getConfigDirSync,
+  listStoresSync,
+  getPreferenceSync,
+} from '@debrief/config';
+
+// Read-only sync operations
+const configDir = getConfigDirSync();
+const stores = listStoresSync();
+const theme = getPreferenceSync('theme', 'system');
+```
+
+**Note**: Write operations (`registerStore`, `removeStore`, `setPreference`) are async-only due to file locking requirements.
+
+---
+
+## Usage Example
+
+```typescript
+import {
+  registerStore,
+  listStores,
+  removeStore,
+  getPreference,
+  setPreference,
+} from '@debrief/config';
+
+async function main() {
+  // Register a new store
+  const store = await registerStore(
+    '/data/exercise-2024',
+    'Exercise 2024'
+  );
+  console.log(`Registered: ${store.name}`);
+
+  // List all stores
+  const stores = await listStores();
+  for (const s of stores) {
+    console.log(`  - ${s.name}: ${s.path}`);
+  }
+
+  // Set default store
+  await setPreference('defaultStore', store.path);
+
+  // Get default store
+  const defaultStore = await getPreference('defaultStore');
+  console.log(`Default store: ${defaultStore}`);
+
+  // Remove a store (keeps files, just removes registration)
+  await removeStore(store.path);
+}
+
+main().catch(console.error);
+```
+
+---
+
+## API Parity with Python
+
+| Python | TypeScript | Notes |
+|--------|------------|-------|
+| `get_config_dir()` | `getConfigDir()` | Sync in both |
+| `register_store()` | `registerStore()` | Async in TS |
+| `list_stores()` | `listStores()` | Sync + async variants in TS |
+| `remove_store()` | `removeStore()` | Async in TS |
+| `get_preference()` | `getPreference()` | Sync + async variants in TS |
+| `set_preference()` | `setPreference()` | Async in TS |
+
+Both libraries read/write the same `config.json` file format.

--- a/specs/003-debrief-config/data-model.md
+++ b/specs/003-debrief-config/data-model.md
@@ -1,0 +1,285 @@
+# Data Model: debrief-config
+
+**Date**: 2026-01-11
+**Spec**: [spec.md](./spec.md)
+
+This document defines the data model for the debrief-config service.
+
+---
+
+## Entity Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         Config                              │
+├─────────────────────────────────────────────────────────────┤
+│ version: string                                             │
+│ stores: StoreRegistration[]                                 │
+│ preferences: Record<string, PreferenceValue>                │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ 1:N
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    StoreRegistration                        │
+├─────────────────────────────────────────────────────────────┤
+│ path: string (unique key)                                   │
+│ name: string                                                │
+│ lastAccessed: ISO8601 datetime                              │
+│ notes?: string                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Entities
+
+### Config
+
+Root configuration object stored in `config.json`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | Yes | Schema version for forward compatibility (e.g., "1.0.0") |
+| `stores` | StoreRegistration[] | Yes | List of registered STAC store locations |
+| `preferences` | Record<string, PreferenceValue> | Yes | User preferences as key-value pairs |
+
+**Validation Rules**:
+- `version` must be a valid semver string
+- `stores` must be an array (empty array if no stores registered)
+- `preferences` must be an object (empty object if no preferences set)
+
+**State Transitions**:
+- Created with defaults on first access
+- Reset to defaults if JSON is corrupted
+
+---
+
+### StoreRegistration
+
+Entry for a known STAC catalog location.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Absolute path to STAC catalog directory |
+| `name` | string | Yes | Human-readable display name |
+| `lastAccessed` | string | Yes | ISO 8601 datetime of last access |
+| `notes` | string | No | Optional user notes about the store |
+
+**Validation Rules**:
+- `path` must be a non-empty string (not validated as existing path at load time)
+- `name` must be a non-empty string
+- `lastAccessed` must be a valid ISO 8601 datetime string
+- `path` must be unique within the stores array
+
+**Invariants**:
+- A store can only be registered once (path is the unique key)
+- Registration does not imply the catalog still exists on disk
+
+---
+
+### PreferenceValue
+
+Union type for preference values.
+
+```typescript
+type PreferenceValue = string | number | boolean | null;
+```
+
+**Supported preference keys** (extensible):
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `defaultStore` | string | null | Path to default STAC store |
+| `locale` | string | "en-GB" | User locale for formatting |
+| `theme` | string | "system" | UI theme preference |
+
+---
+
+## JSON Schema
+
+### config.json
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["version", "stores", "preferences"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Schema version (semver)"
+    },
+    "stores": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/StoreRegistration" },
+      "description": "Registered STAC stores"
+    },
+    "preferences": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" },
+          { "type": "null" }
+        ]
+      },
+      "description": "User preferences"
+    }
+  },
+  "$defs": {
+    "StoreRegistration": {
+      "type": "object",
+      "required": ["path", "name", "lastAccessed"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to STAC catalog"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Display name"
+        },
+        "lastAccessed": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 datetime"
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional user notes"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Default Config
+
+When config file is missing or corrupted, create with these defaults:
+
+```json
+{
+  "version": "1.0.0",
+  "stores": [],
+  "preferences": {}
+}
+```
+
+---
+
+## Python Models (Pydantic)
+
+```python
+from datetime import datetime
+from pathlib import Path
+from pydantic import BaseModel, Field
+
+class StoreRegistration(BaseModel):
+    """A registered STAC catalog location."""
+    path: str = Field(..., min_length=1, description="Absolute path to catalog")
+    name: str = Field(..., min_length=1, description="Display name")
+    last_accessed: datetime = Field(..., alias="lastAccessed")
+    notes: str | None = Field(default=None)
+
+    class Config:
+        populate_by_name = True
+
+PreferenceValue = str | int | float | bool | None
+
+class Config(BaseModel):
+    """Root configuration object."""
+    version: str = Field(default="1.0.0", pattern=r"^\d+\.\d+\.\d+$")
+    stores: list[StoreRegistration] = Field(default_factory=list)
+    preferences: dict[str, PreferenceValue] = Field(default_factory=dict)
+```
+
+---
+
+## TypeScript Types
+
+```typescript
+interface StoreRegistration {
+  path: string;          // Absolute path to catalog
+  name: string;          // Display name
+  lastAccessed: string;  // ISO 8601 datetime
+  notes?: string;        // Optional user notes
+}
+
+type PreferenceValue = string | number | boolean | null;
+
+interface Config {
+  version: string;                          // Schema version
+  stores: StoreRegistration[];              // Registered stores
+  preferences: Record<string, PreferenceValue>;  // User preferences
+}
+```
+
+---
+
+## Zod Schema (TypeScript)
+
+```typescript
+import { z } from 'zod';
+
+const StoreRegistrationSchema = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  lastAccessed: z.string().datetime(),
+  notes: z.string().optional(),
+});
+
+const PreferenceValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+const ConfigSchema = z.object({
+  version: z.string().regex(/^\d+\.\d+\.\d+$/),
+  stores: z.array(StoreRegistrationSchema),
+  preferences: z.record(PreferenceValueSchema),
+});
+
+export type StoreRegistration = z.infer<typeof StoreRegistrationSchema>;
+export type Config = z.infer<typeof ConfigSchema>;
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| Config file missing | Create with defaults |
+| Config file corrupted (invalid JSON) | Log warning, reset to defaults |
+| Config has unknown fields | Preserve (forward compatibility) |
+| Store path contains special chars | Store as-is; validation only at registration time |
+| Duplicate store path | Reject with error |
+| Missing required fields | Reject with validation error (Pydantic/Zod) |
+
+---
+
+## Migration Strategy
+
+For future schema changes:
+
+1. Check `version` field on load
+2. If version < current, run migration functions
+3. Update version after migration
+4. Write migrated config back to file
+
+```python
+MIGRATIONS = {
+    "1.0.0": lambda config: config,  # No-op for current version
+    # Future: "1.1.0": migrate_1_0_to_1_1,
+}
+```

--- a/specs/003-debrief-config/media/linkedin-planning.md
+++ b/specs/003-debrief-config/media/linkedin-planning.md
@@ -1,0 +1,13 @@
+# LinkedIn Summary: debrief-config Planning
+
+Cross-language configuration is deceptively hard—especially when you need it to work offline.
+
+This week we're designing debrief-config, the shared configuration service for Debrief v4.x. When a maritime analyst registers a STAC catalog in Python, the Electron loader (TypeScript) needs to see it immediately. No servers, no syncing—just a single JSON file that both languages read and write correctly across Linux, macOS, and Windows.
+
+We're using platformdirs (Python) and env-paths (TypeScript) for XDG-compliant paths, with atomic writes and lockfiles protecting concurrent access. Constitution Article I means zero network calls.
+
+Now we're looking for feedback: validate catalogs on every read or just registration? Auto-migrate config schemas or explicit upgrade? File-watch events or polling?
+
+Read the full planning post and share your thoughts: [LINK]
+
+#FutureDebrief #MaritimeAnalysis #OpenSource

--- a/specs/003-debrief-config/media/planning-post.md
+++ b/specs/003-debrief-config/media/planning-post.md
@@ -1,0 +1,36 @@
+---
+layout: future-post
+title: "Planning: debrief-config"
+date: 2026-01-11
+track: "Planning · This Week"
+author: Ian
+reading_time: 2
+tags: [tracer-bullet, config, python, typescript]
+excerpt: "Shared configuration service managing STAC registrations and preferences across Python and TypeScript"
+---
+
+## What We're Building
+
+The debrief-config service provides unified configuration management for Debrief v4.x, handling STAC store registrations and user preferences across both Python and TypeScript consumers. Rather than each application maintaining its own settings, this service ensures that when you register a STAC catalog in the VS Code extension, the Electron loader sees it immediately—and vice versa.
+
+This is foundational infrastructure. Maritime analysts working with sensitive data need predictable, reliable configuration that works offline and respects platform conventions. Whether you're on a Linux workstation, a macOS laptop, or a Windows machine in a disconnected environment, your registered catalogs and preferences follow platform-appropriate paths automatically.
+
+## How It Fits
+
+Config sits at the heart of our tracer bullet sequence. After schemas (done) and IO parsing (underway), applications need somewhere to store references to STAC catalogs containing plot data. The Electron loader and VS Code extension will both consume this service, making it the first piece that truly bridges our Python backend and TypeScript frontends. It validates our "thick services, thin frontends" principle while proving cross-language interoperability works in practice.
+
+## Key Decisions
+
+- **platformdirs for Python, env-paths for TypeScript** — Both are well-maintained libraries that handle XDG Base Directory on Linux, Library/Application Support on macOS, and AppData on Windows
+- **Single JSON config file** — Both languages read and write the same `config.json`, enabling true cross-application state sharing
+- **Atomic writes with lockfile** — Protects against corruption when multiple processes access config simultaneously
+- **Structural validation for STAC catalogs** — We check that registered paths contain valid `catalog.json` with required fields, keeping validation offline-compatible
+- **No network calls** — Per Constitution Article I, the service works entirely offline
+
+## What We'd Love Feedback On
+
+- **Validation depth**: Should we validate STAC catalog structure on every read, or only on registration? Eager validation catches problems early but adds overhead.
+- **Migration strategy**: When config schema evolves, should we auto-migrate old configs or require explicit upgrade commands?
+- **Watch notifications**: Would consumers benefit from file-watch events when another process modifies config, or is polling on-demand sufficient?
+
+→ [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/003-debrief-config/plan.md
+++ b/specs/003-debrief-config/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: debrief-config
+
+**Branch**: `003-debrief-config` | **Date**: 2026-01-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-debrief-config/spec.md`
+
+## Summary
+
+Shared configuration service for Debrief v4.x that manages STAC store registrations and user preferences across Python and TypeScript consumers. Both languages read/write the same JSON config file stored in platform-appropriate XDG locations. This enables the Electron loader to discover stores registered by Python services and vice versa.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (primary), TypeScript 5.x (mirror library)
+**Primary Dependencies**: Pydantic >=2.0.0 (Python), platformdirs (XDG paths), zod (TypeScript validation)
+**Storage**: JSON file at XDG config location (~/.config/debrief/config.json on Linux)
+**Testing**: pytest (Python), vitest (TypeScript), cross-language integration tests
+**Target Platform**: Linux, macOS, Windows (all desktop platforms)
+**Project Type**: Dual-language library (Python service + TypeScript package)
+**Performance Goals**: <10ms config read/write (local file I/O)
+**Constraints**: Offline-capable (Constitution Article I), no network dependencies
+**Scale/Scope**: Single user config, ~10-50 store registrations, ~20 preference keys
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Requirement | Status | Notes |
+|---------|-------------|--------|-------|
+| I.1 Offline by default | All core functionality works without network | PASS | Local file storage only |
+| I.2 No cloud dependencies | Cloud features are optional extensions | PASS | No cloud features |
+| I.3 No silent failures | Operations succeed fully or fail explicitly | PASS | Explicit exceptions for invalid paths, corrupt config |
+| II.1 Single source of truth | LinkML master schemas | DEFER | Config schema simple enough to define directly; consider LinkML for v2 |
+| III.1 Provenance always | Record lineage for transformations | N/A | Config is user settings, not analysis data |
+| III.4 Data stays local | No telemetry without consent | PASS | No external calls |
+| IV.1 Services never touch UI | Return data only | PASS | Pure library, no UI code |
+| IV.3 Zero MCP dependency | Domain logic in pure Python | PASS | MCP wrapper optional, core logic independent |
+| V.3 No vendor lock-in | Avoid proprietary dependencies | PASS | Standard JSON, open-source deps only |
+| VI.2 Services require tests | Unit tests for all service code | PASS | pytest + vitest coverage required |
+| IX.1 Minimal dependencies | Prefer standard library | PASS | platformdirs (Python), filelock (Python), proper-lockfile (TS), zod (TS) - all justified |
+
+### Post-Design Re-check (Phase 1 Complete)
+
+All gates PASS. Design phase confirmed:
+- **platformdirs**: Required for XDG compliance across 3 platforms (Constitution IX.3 - no vendor lock-in)
+- **filelock**: Required for safe concurrent access (Constitution I.3 - no silent failures)
+- **proper-lockfile**: TypeScript equivalent of filelock
+- **zod**: Required for TypeScript runtime validation (mirrors Pydantic)
+
+No blocking issues identified. Ready for implementation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-debrief-config/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (API contracts)
+├── tasks.md             # Phase 2 output (/speckit.tasks)
+└── media/               # Phase 2 media content
+    ├── planning-post.md
+    └── linkedin-planning.md
+```
+
+### Source Code (repository root)
+
+```text
+services/config/
+├── pyproject.toml           # Python package definition
+├── README.md
+├── src/
+│   └── debrief_config/
+│       ├── __init__.py      # Public API exports
+│       ├── core.py          # Domain logic (Config, StoreRegistration)
+│       ├── paths.py         # XDG path resolution
+│       ├── exceptions.py    # Custom exceptions
+│       └── mcp_server.py    # Optional MCP wrapper
+└── tests/
+    ├── conftest.py          # Shared fixtures
+    ├── test_core.py         # Unit tests
+    ├── test_paths.py        # Platform path tests
+    └── test_integration.py  # Round-trip tests
+
+shared/config-ts/
+├── package.json             # TypeScript package definition
+├── tsconfig.json
+├── src/
+│   ├── index.ts             # Public API exports
+│   ├── config.ts            # Config class
+│   ├── paths.ts             # XDG path resolution
+│   └── types.ts             # TypeScript types
+└── tests/
+    ├── config.test.ts       # Unit tests
+    └── integration.test.ts  # Cross-language tests
+```
+
+**Structure Decision**: Dual-language implementation following existing service patterns. Python service in `services/config/` (consistent with `services/io/`, `services/stac/`). TypeScript library in `shared/config-ts/` (for consumption by Electron loader). Both share the same JSON config file format.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| II.1 Deferred LinkML | Config schema is simple (3 entities) | LinkML overhead unjustified for key-value config; can migrate later if schema grows |
+| Dual-language impl | TypeScript needed for Electron loader | Single language would require IPC overhead for every config read |

--- a/specs/003-debrief-config/quickstart.md
+++ b/specs/003-debrief-config/quickstart.md
@@ -1,0 +1,253 @@
+# Quickstart: debrief-config
+
+Get up and running with the debrief-config service in 5 minutes.
+
+---
+
+## Prerequisites
+
+- Python 3.11+ with uv
+- Node.js 20+ with pnpm (for TypeScript)
+- A valid STAC catalog to register (or use debrief-stac to create one)
+
+---
+
+## Installation
+
+### Python
+
+```bash
+# From repository root
+cd services/config
+uv sync
+
+# Or install from workspace
+uv add debrief-config
+```
+
+### TypeScript
+
+```bash
+# From repository root
+cd shared/config-ts
+pnpm install
+
+# Or add to your project
+pnpm add @debrief/config
+```
+
+---
+
+## Quick Example
+
+### Python
+
+```python
+from pathlib import Path
+from debrief_config import register_store, list_stores, get_preference
+
+# Register a STAC catalog
+store = register_store(
+    path=Path.home() / "data" / "exercise-2024",
+    name="Exercise 2024"
+)
+print(f"Registered: {store.name} at {store.path}")
+
+# List all stores
+for s in list_stores():
+    print(f"  - {s.name}")
+
+# Check default store preference
+default = get_preference("defaultStore")
+if default:
+    print(f"Default store: {default}")
+```
+
+### TypeScript
+
+```typescript
+import { registerStore, listStores, getPreference } from '@debrief/config';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+async function main() {
+  // Register a STAC catalog
+  const store = await registerStore(
+    join(homedir(), 'data', 'exercise-2024'),
+    'Exercise 2024'
+  );
+  console.log(`Registered: ${store.name} at ${store.path}`);
+
+  // List all stores
+  const stores = await listStores();
+  for (const s of stores) {
+    console.log(`  - ${s.name}`);
+  }
+
+  // Check default store preference
+  const defaultStore = await getPreference('defaultStore');
+  if (defaultStore) {
+    console.log(`Default store: ${defaultStore}`);
+  }
+}
+
+main();
+```
+
+---
+
+## Config File Location
+
+The config file is stored in a platform-appropriate location:
+
+| Platform | Path |
+|----------|------|
+| Linux | `~/.config/debrief/config.json` |
+| macOS | `~/Library/Application Support/debrief/config.json` |
+| Windows | `%APPDATA%\debrief\config.json` |
+
+You can override the Linux path with `XDG_CONFIG_HOME`:
+
+```bash
+export XDG_CONFIG_HOME=/custom/config
+# Config will be at /custom/config/debrief/config.json
+```
+
+---
+
+## Common Tasks
+
+### Register a Store
+
+```python
+# Python
+from debrief_config import register_store
+
+store = register_store("/path/to/catalog", "My Catalog")
+```
+
+```typescript
+// TypeScript
+const store = await registerStore('/path/to/catalog', 'My Catalog');
+```
+
+### Remove a Store
+
+```python
+# Python
+from debrief_config import remove_store
+
+remove_store("/path/to/catalog")  # Registration removed, files unchanged
+```
+
+```typescript
+// TypeScript
+await removeStore('/path/to/catalog');
+```
+
+### Set User Preferences
+
+```python
+# Python
+from debrief_config import set_preference, get_preference
+
+set_preference("theme", "dark")
+set_preference("defaultStore", "/path/to/catalog")
+
+theme = get_preference("theme", "system")  # Returns "dark"
+```
+
+```typescript
+// TypeScript
+await setPreference('theme', 'dark');
+await setPreference('defaultStore', '/path/to/catalog');
+
+const theme = await getPreference('theme', 'system');  // Returns "dark"
+```
+
+---
+
+## Error Handling
+
+```python
+# Python
+from debrief_config import (
+    register_store,
+    InvalidCatalogError,
+    StoreExistsError,
+    StoreNotFoundError,
+)
+
+try:
+    register_store("/invalid/path", "Test")
+except InvalidCatalogError as e:
+    print(f"Not a valid STAC catalog: {e}")
+except StoreExistsError:
+    print("Store already registered")
+```
+
+```typescript
+// TypeScript
+import {
+  registerStore,
+  InvalidCatalogError,
+  StoreExistsError,
+} from '@debrief/config';
+
+try {
+  await registerStore('/invalid/path', 'Test');
+} catch (e) {
+  if (e instanceof InvalidCatalogError) {
+    console.log(`Not a valid STAC catalog: ${e.message}`);
+  } else if (e instanceof StoreExistsError) {
+    console.log('Store already registered');
+  }
+}
+```
+
+---
+
+## Cross-Language Interop
+
+Both Python and TypeScript read/write the same config file. Changes made from one language are immediately visible to the other:
+
+```bash
+# Terminal 1 (Python)
+python -c "from debrief_config import register_store; register_store('/data/test', 'Test')"
+
+# Terminal 2 (Node.js) - sees the store immediately
+node -e "import('@debrief/config').then(c => c.listStores()).then(console.log)"
+```
+
+---
+
+## Running Tests
+
+### Python
+
+```bash
+cd services/config
+uv run pytest
+```
+
+### TypeScript
+
+```bash
+cd shared/config-ts
+pnpm test
+```
+
+### Cross-Language Integration
+
+```bash
+# From repository root
+./scripts/test-config-integration.sh
+```
+
+---
+
+## Next Steps
+
+- Read the [API documentation](./contracts/python-api.md) for full details
+- See [data-model.md](./data-model.md) for the config schema
+- Explore integration with [debrief-stac](../001-debrief-stac/) for creating catalogs

--- a/specs/003-debrief-config/research.md
+++ b/specs/003-debrief-config/research.md
@@ -1,0 +1,274 @@
+# Research: debrief-config
+
+**Date**: 2026-01-11
+**Spec**: [spec.md](./spec.md)
+
+This document captures research findings and technical decisions for the debrief-config service.
+
+---
+
+## Research Questions
+
+1. XDG path resolution in Python
+2. XDG path resolution in TypeScript
+3. Concurrent file access handling
+4. STAC catalog validation
+
+---
+
+## 1. Python XDG Paths: platformdirs
+
+**Decision**: Use `platformdirs` library
+
+**Rationale**:
+- Well-maintained (latest 4.5.1, Dec 2025), MIT license
+- Follows XDG Base Directory Specification
+- Built-in `ensure_exists` parameter
+- Returns pathlib.Path objects
+
+**Alternatives Considered**:
+- `appdirs` - abandoned, platformdirs is the official successor
+- Manual implementation - unnecessary complexity
+
+**Platform Paths** (for app name "debrief"):
+
+| Platform | Config Path |
+|----------|-------------|
+| Linux | `~/.config/debrief` or `$XDG_CONFIG_HOME/debrief` |
+| macOS | `~/Library/Application Support/debrief` |
+| Windows | `%APPDATA%\debrief` |
+
+**Implementation Pattern**:
+
+```python
+from platformdirs import user_config_path
+
+def get_config_dir() -> Path:
+    return user_config_path(appname="debrief", ensure_exists=True)
+
+def get_config_file() -> Path:
+    return get_config_dir() / "config.json"
+```
+
+---
+
+## 2. TypeScript XDG Paths: env-paths
+
+**Decision**: Use `env-paths` library with custom path alignment
+
+**Rationale**:
+- Most popular (~14.6M weekly downloads)
+- Maintained by sindresorhus (reliable)
+- Ships with TypeScript types
+- ESM-only (aligns with modern TypeScript)
+
+**Critical Finding**: Path mismatch between libraries!
+
+| Platform | platformdirs (Python) | env-paths (TypeScript) |
+|----------|----------------------|------------------------|
+| Linux | `~/.config/debrief` | `~/.config/debrief` |
+| macOS | `~/Library/Application Support/debrief` | `~/Library/Preferences/debrief` |
+| Windows | `%APPDATA%\debrief` | `%APPDATA%\debrief\Config` |
+
+**Resolution**: Override env-paths on macOS and Windows to match Python paths. This ensures both languages use the same config file.
+
+**Implementation Pattern**:
+
+```typescript
+import envPaths from 'env-paths';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function getConfigDir(): string {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    // Match platformdirs: ~/Library/Application Support/debrief
+    return join(homedir(), 'Library', 'Application Support', 'debrief');
+  }
+
+  if (platform === 'win32') {
+    // Match platformdirs: %APPDATA%\debrief (not \Config subfolder)
+    return join(process.env.APPDATA || homedir(), 'debrief');
+  }
+
+  // Linux: env-paths matches platformdirs
+  const paths = envPaths('debrief', { suffix: '' });
+  return paths.config;
+}
+```
+
+---
+
+## 3. Concurrent File Access: Atomic Writes + Lockfile
+
+**Decision**: Use atomic writes for corruption prevention + lockfile for concurrent write protection
+
+**Rationale**:
+- Single-user config, low write frequency → collision probability low
+- But lost updates are confusing for users
+- Atomic writes prevent corruption (partial JSON)
+- Lockfile prevents lost updates when two processes write simultaneously
+
+**Alternatives Considered**:
+- **Single owner via MCP**: Cleanest but requires MCP infrastructure for every config read
+- **OS-level file locking**: Not reliable cross-platform (NFS, Windows network shares)
+- **No protection**: Simple but risks data loss
+
+**Implementation Pattern**:
+
+**Python**:
+```python
+from filelock import FileLock
+import json
+from pathlib import Path
+
+def write_config(path: Path, data: dict) -> None:
+    lock_path = path.with_suffix('.lock')
+    with FileLock(lock_path, timeout=5):
+        # Write to temp file, then atomic rename
+        temp_path = path.with_suffix('.tmp')
+        temp_path.write_text(json.dumps(data, indent=2))
+        temp_path.replace(path)  # Atomic on POSIX
+
+def read_config(path: Path) -> dict:
+    # No lock needed - atomic writes ensure valid JSON
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+```
+
+**TypeScript**:
+```typescript
+import lockfile from 'proper-lockfile';
+import { writeFileSync, readFileSync, renameSync } from 'node:fs';
+
+async function writeConfig(path: string, data: object): Promise<void> {
+  const release = await lockfile.lock(path, {
+    retries: { retries: 3, minTimeout: 100 },
+    stale: 10000 // 10s stale lock detection
+  });
+  try {
+    const tempPath = path + '.tmp';
+    writeFileSync(tempPath, JSON.stringify(data, null, 2));
+    renameSync(tempPath, path);
+  } finally {
+    await release();
+  }
+}
+
+function readConfig(path: string): object {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+```
+
+**Dependencies**:
+- Python: `filelock` (no additional deps for atomic write - use pathlib)
+- TypeScript: `proper-lockfile` (uses mkdir strategy, most reliable cross-platform)
+
+---
+
+## 4. STAC Catalog Validation: Structural Check
+
+**Decision**: Use fast structural check (no external dependencies)
+
+**Rationale**:
+- Constitution Article I requires offline operation
+- pystac requires network for full validation
+- stac-validator requires network for schema fetch
+- Simple structural check is sufficient for registration
+
+**What Makes a Valid STAC Catalog**:
+1. Directory contains `catalog.json`
+2. JSON has `type: "Catalog"`
+3. JSON has required fields: `stac_version`, `id`, `description`, `links`
+
+**Implementation Pattern**:
+
+```python
+import json
+from pathlib import Path
+
+class InvalidCatalogError(Exception):
+    """Raised when path is not a valid STAC catalog."""
+    pass
+
+def validate_stac_catalog(path: Path) -> None:
+    """Validate that path contains a valid STAC catalog.
+
+    Raises:
+        InvalidCatalogError: If validation fails
+    """
+    catalog_json = path / "catalog.json"
+
+    if not catalog_json.exists():
+        raise InvalidCatalogError(f"No catalog.json found at {path}")
+
+    try:
+        data = json.loads(catalog_json.read_text())
+    except json.JSONDecodeError as e:
+        raise InvalidCatalogError(f"Invalid JSON in catalog.json: {e}")
+
+    # Check required fields per STAC spec
+    required = {"type", "stac_version", "id", "description", "links"}
+    missing = required - set(data.keys())
+    if missing:
+        raise InvalidCatalogError(f"Missing required fields: {missing}")
+
+    if data.get("type") != "Catalog":
+        raise InvalidCatalogError(f"Not a Catalog (type={data.get('type')})")
+
+    if not isinstance(data.get("links"), list):
+        raise InvalidCatalogError("links must be an array")
+```
+
+**Note**: This aligns with `debrief-stac` validation patterns (see `services/stac/tests/test_stac_validation.py`).
+
+---
+
+## Dependency Summary
+
+**Python** (`services/config/pyproject.toml`):
+```toml
+dependencies = [
+    "pydantic>=2.0.0",
+    "platformdirs>=4.0.0",
+    "filelock>=3.0.0",
+]
+```
+
+**TypeScript** (`shared/config-ts/package.json`):
+```json
+{
+  "dependencies": {
+    "proper-lockfile": "^4.1.0",
+    "zod": "^3.22.0"
+  }
+}
+```
+
+---
+
+## Open Questions (Resolved)
+
+| Question | Resolution |
+|----------|------------|
+| Path mismatch between platformdirs and env-paths | Override TypeScript paths to match Python |
+| Need for file locking | Yes - atomic writes + lockfile for concurrent protection |
+| STAC validation approach | Structural check only (offline-compatible) |
+| Schema approach | Defer LinkML; use Pydantic + Zod directly |
+
+---
+
+## References
+
+- [platformdirs PyPI](https://pypi.org/project/platformdirs/)
+- [env-paths npm](https://www.npmjs.com/package/env-paths)
+- [filelock](https://pypi.org/project/filelock/)
+- [proper-lockfile](https://www.npmjs.com/package/proper-lockfile)
+- [STAC Catalog Specification](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md)
+- [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/)


### PR DESCRIPTION
Phase 0 research:
- platformdirs for Python XDG paths
- env-paths for TypeScript XDG paths
- atomic writes + lockfile for concurrent access
- structural validation for STAC catalogs

Phase 1 design artifacts:
- data-model.md with Pydantic/Zod schemas
- contracts/python-api.md and typescript-api.md
- quickstart.md with usage examples

Media content:
- planning-post.md for blog announcement
- linkedin-planning.md summary

All Constitution gates pass.