### PR TITLE
Add Jekyll-formatted planning posts for blog publishing

### DIFF
--- a/specs/000-schemas/media/2026-01-09-planning-schema-foundation.md
+++ b/specs/000-schemas/media/2026-01-09-planning-schema-foundation.md
@@ -1,0 +1,42 @@
+---
+layout: future-post
+title: "Planning: Schema Foundation"
+date: 2026-01-09
+track: "Planning · This Week"
+author: Ian
+reading_time: 3
+tags: [tracer-bullet, schemas, linkml, pydantic]
+excerpt: "Establishing the schema foundation for Debrief v4.x with LinkML as the single source of truth."
+---
+
+## What We're Building
+
+The Schema Foundation is the bedrock of Debrief v4.x. We're creating a schema-first architecture where LinkML serves as the single source of truth, generating Pydantic models for Python services, JSON Schema for frontend validation, and TypeScript interfaces for type-safe UI development.
+
+This isn't just about defining data structures. It's about guaranteeing that every component of the system speaks the same language. When a Python service validates a TrackFeature and the TypeScript frontend renders it, they're both working from the same schema definition. No drift. No surprises.
+
+## How It Fits
+
+The Schema Foundation is Stage 0 of our tracer bullet approach. Every downstream service depends on these schemas:
+
+- **debrief-stac** (Stage 1) uses them to validate STAC Items and GeoJSON features
+- **debrief-io** (Stage 2) uses them to validate parsed REP files
+- **The VS Code extension** (Stage 6) uses TypeScript interfaces for type-safe rendering
+
+Without validated schemas, we can't guarantee data integrity across the stack. This is why Constitution Article II mandates schema tests gate all merges.
+
+## Key Decisions
+
+- **LinkML as master schema language** — industry-standard, generates to multiple targets, excellent for GeoJSON profiles
+- **Tracer bullet scope** — starting with just TrackFeature and ReferenceLocation; SensorContact, PlotMetadata, and ToolMetadata come in future iterations
+- **Three adherence test strategies** — golden fixtures, round-trip testing (Python to JSON to TypeScript to JSON to Python), and schema comparison
+- **Zero manual edits to generated files** — all customisation via LinkML or generator configuration
+- **Single `make generate` command** — propagates any LinkML change to all derived schemas
+
+## What We'd Love Feedback On
+
+- Are there GeoJSON profile conventions from existing Debrief v3.x that we should capture early?
+- What validation rules have caused pain in the past that we should encode in schemas?
+- Are there entity types beyond the five planned that should be on our radar?
+
+> [Join the discussion on GitHub](https://github.com/debrief/debrief-future/discussions)

--- a/specs/001-debrief-stac/media/2026-01-09-planning-stac-catalog-operations.md
+++ b/specs/001-debrief-stac/media/2026-01-09-planning-stac-catalog-operations.md
@@ -1,0 +1,44 @@
+---
+layout: future-post
+title: "Planning: Local STAC Catalog Operations"
+date: 2026-01-09
+track: "Planning · This Week"
+author: Ian
+reading_time: 3
+tags: [tracer-bullet, stac, storage, python]
+excerpt: "Building local STAC catalog operations for offline-first analysis storage in Debrief v4.x."
+---
+
+## What We're Building
+
+The debrief-stac service is Debrief v4.x's storage backbone. It provides a Python library for creating and managing STAC (SpatioTemporal Asset Catalog) catalogs on local filesystems, storing analysis plots as STAC Items with GeoJSON features and source file assets.
+
+STAC is an open standard for geospatial data. By adopting it, we get a well-defined structure for organising maritime analysis data, interoperability with existing geospatial tools, and a foundation that could eventually connect to cloud STAC APIs if needed (while remaining fully functional offline).
+
+Every plot in Debrief v4.x will be a STAC Item. Every track, sensor contact, and reference location will live in GeoJSON assets. And every original source file will be preserved with provenance metadata.
+
+## How It Fits
+
+This is Stage 1 of the tracer bullet, building directly on the Schema Foundation from Stage 0. The service:
+
+- Depends on **debrief-schemas** for Pydantic validation of all features
+- Is consumed by **debrief-io** (Stage 2) to store parsed features
+- Exposes MCP tools for the **VS Code extension** (Stage 6) to browse and load plots
+
+Constitution Article III requires provenance tracking, so every source file copied into a plot carries metadata about when it was loaded, what tool processed it, and the original file path.
+
+## Key Decisions
+
+- **Local STAC catalogs** — `catalog.json` at root, each plot in its own subdirectory with `item.json` and assets
+- **GeoJSON as the feature container** — FeatureCollection per plot, validated against Stage 0 schemas
+- **BBox auto-calculation** — adding features automatically updates the plot's bounding box
+- **MCP tools as thin wrappers** — core library is pure Python, MCP layer adds no business logic
+- **Provenance in asset metadata** — `debrief:provenance` extension field records source path, timestamp, tool version
+
+## What We'd Love Feedback On
+
+- What metadata about plots is essential for browsing? Title and date seem obvious, but what else?
+- Are there STAC extensions (beyond what we're defining) that would be useful?
+- How should we handle large plots with thousands of features? Separate FeatureCollections per track?
+
+> [Join the discussion on GitHub](https://github.com/debrief/debrief-future/discussions)

--- a/specs/002-debrief-io/media/2026-01-10-planning-rep-file-parsing.md
+++ b/specs/002-debrief-io/media/2026-01-10-planning-rep-file-parsing.md
@@ -1,0 +1,45 @@
+---
+layout: future-post
+title: "Planning: REP File Parsing"
+date: 2026-01-10
+track: "Planning · This Week"
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, parsing, rep-format, python]
+excerpt: "Building an extensible file parser for legacy Debrief formats, starting with REP."
+---
+
+## What We're Building
+
+The debrief-io service transforms legacy file formats into validated GeoJSON features. We're starting with REP files, the primary data format for Debrief v3.x, because parsing them is the critical path for demonstrating the entire architecture.
+
+This isn't just a REP parser. It's an extensible handler registry that will support multiple formats. Register a handler for `.rep`, and the parser automatically routes files to it. Add a new handler for `.gpx` later, and it slots right in.
+
+Every feature that comes out of the parser is validated against our Stage 0 Pydantic models. If a coordinate is out of range or a required field is missing, you'll know exactly which line of the source file caused it.
+
+## How It Fits
+
+Stage 2 of the tracer bullet sits between raw files and storage:
+
+- Uses **debrief-schemas** (Stage 0) to validate all output features
+- Feeds validated features into **debrief-stac** (Stage 1) for storage
+- Exposes MCP tools for the **Electron loader** (Stage 4) to invoke parsing
+
+The Constitution requires pure transformations with no side effects. debrief-io reads files and returns data. It never writes to disk. That's debrief-stac's job.
+
+## Key Decisions
+
+- **REP format first** — it's the primary legacy format and validates our entire pipeline
+- **Handler registry pattern** — `register_handler(".rep", REPHandler)` makes the system extensible
+- **Line numbers in all errors** — Constitution Article I.3 says no silent failures; we go further with precise error locations
+- **Encoding detection** — try UTF-8 first, fall back to Latin-1 for legacy files
+- **Continue after recoverable errors** — collect warnings, return what we can parse, let the caller decide
+- **MCP thin wrappers** — core parsing is pure Python, MCP layer adds no business logic
+
+## What We'd Love Feedback On
+
+- What REP record types are essential for the tracer bullet? We're starting with tracks and reference locations.
+- Are there encoding issues in real-world REP files we should anticipate?
+- What other file formats should be on our roadmap? GPX? KML? Something proprietary?
+
+> [Join the discussion on GitHub](https://github.com/debrief/debrief-future/discussions)


### PR DESCRIPTION
Add ready-to-publish versions of the planning posts with Jekyll date-prefixed filenames. These can be copied directly to debrief.github.io/_posts/:

- specs/000-schemas/media/2026-01-09-planning-schema-foundation.md
- specs/001-debrief-stac/media/2026-01-09-planning-stac-catalog-operations.md
- specs/002-debrief-io/media/2026-01-10-planning-rep-file-parsing.md