### PR TITLE
Add shipped posts for specs 000, 001, and 002

### DIFF
--- a/specs/000-schemas/media/2026-01-11-shipped-schema-foundation.md
+++ b/specs/000-schemas/media/2026-01-11-shipped-schema-foundation.md
@@ -1,0 +1,46 @@
+---
+layout: future-post
+title: "Shipped: Schema Foundation"
+date: 2026-01-11
+track: "Shipped · Stage 0"
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, schemas, linkml, pydantic, shipped]
+excerpt: "The schema foundation is complete. LinkML now generates Pydantic models, JSON Schema, and TypeScript interfaces from a single source of truth."
+---
+
+## What We Built
+
+The Schema Foundation is live. We now have a single LinkML schema that generates validated Pydantic models for Python, JSON Schema for frontend validation, and TypeScript interfaces for type-safe UI development.
+
+This means when a Python service validates a TrackFeature and the TypeScript frontend renders it, they're both working from the same schema definition. No drift. No surprises. No manual synchronisation.
+
+## Key Accomplishments
+
+- **LinkML schemas** for TrackFeature and ReferenceLocation (the tracer bullet scope)
+- **Pydantic models** with full type annotations and validation
+- **JSON Schema** for frontend and API contract validation
+- **TypeScript interfaces** for type-safe frontend development
+- **Golden fixtures** with valid and invalid examples for each entity type
+- **Three adherence test strategies**: golden fixtures, round-trip testing, and schema comparison
+- **Single `make generate` command** that propagates any LinkML change to all targets
+
+## What We Learned
+
+**LinkML is the right choice.** The generator ecosystem is mature, and the ability to target multiple outputs from a single source eliminated the schema drift problem we've seen in other projects.
+
+**Round-trip testing catches subtle bugs.** We found edge cases in timestamp serialisation and coordinate precision that only surfaced when data went Python → JSON → TypeScript → JSON → Python. Those tests are now part of CI.
+
+**Golden fixtures force clarity.** Writing explicit valid/invalid examples for each schema made us think carefully about edge cases upfront rather than discovering them in production.
+
+## What's Next
+
+The Schema Foundation unblocks everything else:
+
+- **debrief-stac** (Stage 1) can now validate STAC Items and GeoJSON features
+- **debrief-io** (Stage 2) can validate parsed REP files against real schemas
+- **Future schemas** (SensorContact, PlotMetadata, ToolMetadata) will follow the same pattern
+
+The tracer bullet continues.
+
+> [View the code on GitHub](https://github.com/debrief/debrief-future)

--- a/specs/000-schemas/media/linkedin-shipped.md
+++ b/specs/000-schemas/media/linkedin-shipped.md
@@ -1,0 +1,11 @@
+The schema foundation for Debrief v4.x is complete.
+
+One LinkML schema now generates Pydantic models, JSON Schema, and TypeScript interfaces. When your Python service validates a track and your TypeScript frontend renders it, they're working from the same definition.
+
+We built three adherence test strategies: golden fixtures, round-trip testing (Python → JSON → TypeScript → JSON → Python), and schema comparison. They've already caught subtle bugs in timestamp serialisation and coordinate precision.
+
+The tracer bullet continues. Storage and parsing can now validate against real schemas.
+
+[Link to full post]
+
+#FutureDebrief #SchemaFirst #OpenSource

--- a/specs/001-debrief-stac/media/2026-01-11-shipped-stac-catalog-operations.md
+++ b/specs/001-debrief-stac/media/2026-01-11-shipped-stac-catalog-operations.md
@@ -1,0 +1,46 @@
+---
+layout: future-post
+title: "Shipped: Local STAC Catalog Operations"
+date: 2026-01-11
+track: "Shipped · Stage 1"
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, stac, storage, python, shipped]
+excerpt: "Local STAC catalog operations are complete. Debrief v4.x can now create catalogs, store plots, and preserve provenance — all offline."
+---
+
+## What We Built
+
+The debrief-stac service is operational. Debrief v4.x can now create local STAC catalogs, store analysis plots as STAC Items, append GeoJSON features, and preserve source files with full provenance tracking.
+
+Every plot is a STAC Item. Every track and reference location lives in validated GeoJSON assets. Every original source file is preserved with metadata recording when it was loaded, what tool processed it, and the original file path.
+
+## Key Accomplishments
+
+- **Create local STAC catalogs** at user-specified paths with valid `catalog.json`
+- **Create plots** (STAC Items) with title, description, temporal extent, and geometry bounds
+- **Add GeoJSON features** to plots with automatic bbox recalculation
+- **Preserve source files** as assets with provenance metadata
+- **List and browse** catalog contents with summary information
+- **MCP tool exposure** for all operations (VS Code extension ready)
+- **Full validation** against Stage 0 Pydantic models for all features
+
+## What We Learned
+
+**STAC is well-suited to this use case.** The STAC specification maps cleanly to Debrief's plot concept. Items hold metadata, assets hold data files, and the catalog structure handles organisation.
+
+**Provenance tracking pays off early.** Even in testing, knowing exactly which source file produced which features helped debug parsing issues. Constitution Article III was right to mandate this.
+
+**Bbox auto-calculation is essential.** Manually tracking geometry bounds would have been error-prone. Calculating bbox on feature addition keeps the STAC Item always consistent with its contents.
+
+## What's Next
+
+With storage in place, the pipeline can flow:
+
+- **debrief-io** (Stage 2) can now store parsed features directly into plots
+- **debrief-config** (Stage 3) can register catalogs for the loader to find
+- **The VS Code extension** (Stage 6) can browse catalogs via MCP tools
+
+The storage backbone is ready. Time to fill it with data.
+
+> [View the code on GitHub](https://github.com/debrief/debrief-future)

--- a/specs/001-debrief-stac/media/linkedin-shipped.md
+++ b/specs/001-debrief-stac/media/linkedin-shipped.md
@@ -1,0 +1,11 @@
+Local STAC catalog operations for Debrief v4.x are live.
+
+Every analysis plot is now a STAC Item. Every track lives in validated GeoJSON. Every source file is preserved with full provenance — when it was loaded, what processed it, where it came from.
+
+STAC turned out to be a natural fit for maritime analysis data. The specification maps cleanly to Debrief's plot concept, and we get interoperability with the broader geospatial ecosystem for free.
+
+The storage backbone is ready. Now we fill it with data.
+
+[Link to full post]
+
+#FutureDebrief #STAC #GeoJSON #OpenSource

--- a/specs/002-debrief-io/media/2026-01-11-shipped-rep-file-parsing.md
+++ b/specs/002-debrief-io/media/2026-01-11-shipped-rep-file-parsing.md
@@ -1,0 +1,46 @@
+---
+layout: future-post
+title: "Shipped: REP File Parsing"
+date: 2026-01-11
+track: "Shipped · Stage 2"
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, parsing, rep-format, python, shipped]
+excerpt: "REP file parsing is complete. Legacy Debrief files now transform into validated GeoJSON with line-level error reporting."
+---
+
+## What We Built
+
+The debrief-io service is operational. REP files — Debrief's primary legacy format — now transform into validated GeoJSON features. Every output feature is checked against our Stage 0 Pydantic models. Every error includes the exact line number that caused it.
+
+This isn't just a parser. It's an extensible handler registry. Add a new format handler, and the system routes files automatically. REP today. GPX tomorrow. The architecture stays the same.
+
+## Key Accomplishments
+
+- **REP format parsing** for tracks and reference locations
+- **Handler registry pattern** for extensible format support
+- **Line-level error reporting** with field names and context
+- **Encoding detection** (UTF-8 first, Latin-1 fallback for legacy files)
+- **Recoverable error handling** (collect warnings, return what we can parse)
+- **MCP tool exposure** for loader app integration
+- **Full validation** against Stage 0 schemas for all output features
+
+## What We Learned
+
+**Line numbers in errors are worth the effort.** When a coordinate is out of range or a timestamp is malformed, knowing it's on line 247 of a 3000-line file saves significant debugging time.
+
+**Encoding detection is essential.** Real-world REP files from older systems use Latin-1, not UTF-8. Silent mojibake would have corrupted data. Detecting and reporting encoding avoids this.
+
+**Pure transformations simplify testing.** Because debrief-io only reads files and returns data (no side effects), tests are deterministic and fast. The same input always produces the same output.
+
+## What's Next
+
+The parsing layer connects raw files to validated storage:
+
+- **Integration with debrief-stac**: parsed features flow directly into STAC plots
+- **Additional format handlers**: GPX, KML, and proprietary formats as needed
+- **Sensor contact parsing**: extending REP support for bearing/range data
+
+The tracer bullet has pierced through schemas, storage, and parsing. The data pipeline is operational.
+
+> [View the code on GitHub](https://github.com/debrief/debrief-future)

--- a/specs/002-debrief-io/media/linkedin-shipped.md
+++ b/specs/002-debrief-io/media/linkedin-shipped.md
@@ -1,0 +1,11 @@
+REP file parsing for Debrief v4.x is operational.
+
+Legacy files now transform into validated GeoJSON with line-level error reporting. When a coordinate is out of range on line 247 of a 3000-line file, you'll know exactly where to look.
+
+The architecture is extensible by design. Register a handler for .rep, and the system routes files automatically. Add .gpx tomorrow, and it slots right in. Pure transformations with no side effects mean tests are deterministic and fast.
+
+The data pipeline is operational. Schemas → Storage → Parsing. The tracer bullet has pierced through.
+
+[Link to full post]
+
+#FutureDebrief #DataParsing #OpenSource


### PR DESCRIPTION
Blog posts and LinkedIn summaries announcing completion of:
- 000-schemas: Schema Foundation with LinkML
- 001-debrief-stac: Local STAC Catalog Operations
- 002-debrief-io: REP File Parsing

Each spec now has:
- 2026-01-11-shipped-*.md (Jekyll blog post)
- linkedin-shipped.md (LinkedIn summary)

Ready to publish to debrief.github.io/_posts/