### PR TITLE
Replace funding language with collaboration focus

### DIFF
--- a/COMMS.md
+++ b/COMMS.md
@@ -118,7 +118,7 @@ Success is:
 - Scientists imagine themselves using Future Debrief
 - Technical leadership sees strategic value
 - Organic conversations happen without prompting
-- When funding discussions come, people already understand the project
+- When collaboration discussions come, people already understand the project
 
 ## What This Strategy Is Not
 

--- a/VISION.md
+++ b/VISION.md
@@ -72,14 +72,14 @@ This proves the components integrate correctly before investing in breadth.
 
 ### Near-term: Existing Stakeholder Engagement (Spring 2026)
 
-Demonstrate the working foundation. Invite stakeholders to fund specific capabilities:
+Demonstrate the working foundation. Invite stakeholders to collaborate on specific capabilities:
 - TMA reconstruction tooling
 - Organisation-specific file handlers
 - Reporting and export features
 
 ### Medium-term: Capability Expansion
 
-Based on user feedback and funding:
+Based on user feedback and collaboration:
 - Additional file format handlers
 - Expanded analysis tool library
 - Remote STAC server support for team collaboration


### PR DESCRIPTION
## Summary
- Update VISION.md and COMMS.md to reflect open development model
- Replace "fund" with "collaborate" for stakeholder engagement
- Remove payment-oriented language now that project is developed in the open

## Changes
- `VISION.md:75` — "invite stakeholders to fund" → "invite stakeholders to collaborate"
- `VISION.md:82` — "based on funding" → "based on collaboration"
- `COMMS.md:121` — "funding discussions" → "collaboration discussions"

## Test plan
- [x] Verify no other funding/payment language remains in strategy docs