### PR TITLE
chore(backlog): score unscored items and reorder by priority

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -77,21 +77,21 @@ Description formats:
 
 | ID | Category | Description | V | M | A | Total | Status |
 |----|----------|-------------|---|---|---|-------|--------|
-| 007 | Enhancement | Implement REP file special comments (NARRATIVE, CIRCLE, etc.) | 4 | 4 | 4 | 12 | proposed |
+| 014 | Feature | [Add styling properties schemas to GeoJSON features](docs/ideas/014-geojson-styling-properties.md) | 5 | 4 | 5 | 14 | approved |
+| 015 | Infrastructure | [Create LinkML schemas for REP annotation item types](docs/ideas/015-annotation-item-schemas.md) (prerequisite for #007) | 5 | 3 | 5 | 13 | approved |
+| 007 | Enhancement | Implement REP file special comments (NARRATIVE, CIRCLE, etc.) (requires #015) | 4 | 4 | 4 | 12 | proposed |
+| 011 | Documentation | Create Jupyter notebook example demonstrating debrief-calc Python API | 4 | 4 | 4 | 12 | proposed |
 | 002 | Feature | Add MCP wrapper for debrief-io service | 4 | 3 | 4 | 11 | proposed |
 | 005 | Tech Debt | Add cross-service end-to-end workflow tests (io -> stac -> calc) | 4 | 2 | 5 | 11 | proposed |
+| 009 | Feature | Implement VS Code map PNG export using leaflet-image integration | 3 | 4 | 3 | 10 | proposed |
 | 008 | Feature | Design and implement extension discovery mechanism for contrib packages | 4 | 3 | 3 | 10 | proposed |
-| 003 | Tech Debt | Extract mapping component to shared/web-components for VS Code, Loader, Jupyter reuse | 4 | 3 | 3 | 10 | proposed |
+| 013 | Bug | [Time Range and Tools panels show empty](https://github.com/debrief/debrief-future/issues/30) | 4 | 2 | 4 | 10 | proposed |
+| 003 | Tech Debt | Extract mapping component to shared/web-components for VS Code, Loader, Jupyter reuse (PARKED - see STRATEGY.md) | 4 | 3 | 3 | 10 | proposed |
 | 004 | Infrastructure | Add contrib folder scaffolding with example extension (requires #008) | 3 | 3 | 4 | 10 | proposed |
 | 001 | Infrastructure | Extract shared MCP utilities into mcp-common package | 3 | 2 | 4 | 9 | proposed |
+| 010 | Tech Debt | Add rollback/cleanup API to debrief-stac for interrupted operations | 3 | 1 | 4 | 8 | proposed |
+| 012 | Enhancement | Wire loader plot count to debrief-stac list_plots call | 2 | 1 | 5 | 8 | proposed |
 | 006 | Enhancement | Add i18n infrastructure to VS Code extension | 2 | 1 | 4 | 7 | proposed |
-| 009 | Feature | Implement VS Code map PNG export using leaflet-image integration | - | - | - | - | proposed |
-| 010 | Tech Debt | Add rollback/cleanup API to debrief-stac for interrupted operations | - | - | - | - | proposed |
-| 011 | Documentation | Create Jupyter notebook example demonstrating debrief-calc Python API | - | - | - | - | proposed |
-| 012 | Enhancement | Wire loader plot count to debrief-stac list_plots call | - | - | - | - | proposed |
-| 013 | Bug | [Time Range and Tools panels show empty](https://github.com/debrief/debrief-future/issues/30) | - | - | - | - | proposed |
-| 014 | Feature | [Add styling properties schemas to GeoJSON features](docs/ideas/014-geojson-styling-properties.md) | 5 | 4 | 5 | 14 | approved |
-| 015 | Infrastructure | [Create LinkML schemas for REP annotation item types](docs/ideas/015-annotation-item-schemas.md) | 5 | 3 | 5 | 13 | approved |
 
 ## Categories
 


### PR DESCRIPTION
- Score 5 previously unscored items (009, 010, 011, 012, 013)
- Reorder all items: approved status first, then by total score
- Add dependency annotations (007 requires 015, 004 requires 008)
- Mark item 003 as PARKED per STRATEGY.md