### PR TITLE
Configure VS Code extension activity visibility

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -87,6 +87,7 @@ Description formats:
 
 | ID | Category | Description | V | M | A | Total | Complexity | Status |
 |----|----------|-------------|---|---|---|-------|------------|--------|
+| 017 | Enhancement | [Configure VS Code extension to hide default activities on load](docs/ideas/017-vscode-hide-activities.md) | 3 | 3 | 4 | 10 | Medium | approved |
 | 014 | Feature | [Add styling properties schemas to GeoJSON features](docs/ideas/014-geojson-styling-properties.md) | 5 | 4 | 5 | 14 | Medium | approved |
 | 015 | Infrastructure | [Create LinkML schemas for REP annotation item types](docs/ideas/015-annotation-item-schemas.md) (prerequisite for #007) | 5 | 3 | 5 | 13 | Medium | approved |
 | 007 | Enhancement | [Implement REP file special comments (NARRATIVE, CIRCLE, etc.)](docs/ideas/007-rep-special-comments.md) (requires #015) | 4 | 4 | 4 | 12 | Medium | approved |

--- a/docs/ideas/017-vscode-hide-activities.md
+++ b/docs/ideas/017-vscode-hide-activities.md
@@ -1,0 +1,32 @@
+# Configure VS Code extension to hide default activities on load
+
+## Problem
+
+When the VS Code extension loads, users see the full VS Code activity bar with many activities (Search, Source Control, Run and Debug, Extensions, Testing, etc.) that aren't relevant for the Debrief maritime analysis workflow. This creates visual clutter and may confuse users focused on track analysis.
+
+## Proposed Solution
+
+Configure the VS Code extension to hide all default activities except:
+1. **Explorer** — Contains the file tree plus the new STAC browser for plot management
+2. **Debrief** — A new custom activity for Debrief-specific functionality (contents TBD in separate item)
+
+The extension should programmatically hide activities on activation, creating a focused analysis environment.
+
+## Success Criteria
+
+- [ ] All default activities except Explorer are hidden when extension activates
+- [ ] A new "Debrief" activity appears in the activity bar
+- [ ] Users can re-enable hidden activities through VS Code settings if needed
+- [ ] Hiding is reversible — not a hard lock on the VS Code experience
+
+## Constraints
+
+- Must work offline (CONSTITUTION requirement)
+- Should use standard VS Code extension APIs for activity bar manipulation
+- Must not break core VS Code functionality — hidden activities should still work if re-enabled
+
+## Out of Scope
+
+- Contents of the "Debrief" activity (separate backlog item)
+- Hiding activities for non-Debrief workspaces (this is Debrief-extension-specific)
+- Customisation UI for choosing which activities to hide


### PR DESCRIPTION
- Hide all activities except Explorer on extension load
- Add new Debrief activity (contents TBD separately)
- Users can restore via settings (not hard locked)

Approved for tracer bullet phase - supports VS Code extension work and demo UX improvements.