### PR TITLE
Add interview capture to backlog agents

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -102,6 +102,7 @@ Description formats:
 | 010 | Tech Debt | Add rollback/cleanup API to debrief-stac for interrupted operations | 3 | 1 | 4 | 8 | Medium | proposed |
 | 012 | Enhancement | Wire loader plot count to debrief-stac list_plots call | 2 | 1 | 5 | 8 | Low | proposed |
 | 018 | Infrastructure | [Add VS Code multi-root workspace configuration](docs/ideas/018-vscode-workspace-config.md) | 3 | 1 | 5 | 9 | Low | approved |
+| 019 | Enhancement | [Add 'needs-interview' status to backlog workflow](docs/ideas/019-backlog-interview-capture.md) | 3 | 3 | 5 | 11 | Medium | proposed |
 
 ## Categories
 

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -91,6 +91,7 @@ Items that don't fit current strategy but may return later:
 | Shared Web Components library (BACKLOG #003) | No VS Code extension exists yet to extract from | VS Code extension development begins (tracer bullet step 6) |
 | VS Code map PNG export (BACKLOG #009) | Nice demo but not tracer bullet critical | After core workflow validated |
 | i18n infrastructure (BACKLOG #006) | Premature for NATO pilot | NATO pilot planning begins |
+| Backlog interview capture workflow (BACKLOG #019) | Workflow tooling, doesn't serve tracer bullet themes | After tracer bullet complete, during process refinement |
 
 ## Rejected Items Log
 

--- a/docs/ideas/019-backlog-interview-capture.md
+++ b/docs/ideas/019-backlog-interview-capture.md
@@ -1,0 +1,40 @@
+# Add 'needs-interview' status to backlog workflow
+
+## Problem
+
+When managing the backlog, some ideas are captured at a high level but lack enough detail for implementation. Currently, all ideas must either go through the full interview process immediately or be captured with incomplete information. There's no way to:
+- Defer detailed requirements gathering to a later time
+- Track which items need interviews
+- Batch interview work when the user has dedicated time
+
+## Proposed Solution
+
+Add an "interview deferred" workflow to the backlog system:
+
+1. **New status**: Add `needs-interview` to BACKLOG.md workflow statuses
+2. **Agent updates**: Modify backlog agents (opportunity-scout, ideas-guy, backlog-prioritizer) to recognize and set `needs-interview` status
+3. **New /interview command**: Create a skill that:
+   - Lists all items with `needs-interview` status
+   - Allows selection and processing of deferred items
+   - Conducts the full interview
+   - Updates item with complete detail and refined scores
+
+## Success Criteria
+
+- [ ] BACKLOG.md documents `needs-interview` status in workflow section
+- [ ] Agents can mark items as `needs-interview` when detail is insufficient
+- [ ] `/interview` command lists and processes deferred items
+- [ ] Preliminary scores given at capture, updated after interview
+- [ ] Items transition from `needs-interview` → `proposed` after interview completes
+
+## Constraints
+
+- Must work offline (CONSTITUTION requirement)
+- Should integrate with existing /idea workflow
+- Preliminary scoring should use same V/M/A dimensions
+
+## Out of Scope
+
+- Automated interview scheduling
+- Notifications/reminders for pending interviews
+- Changes to speckit workflow (starts after item is fully defined)


### PR DESCRIPTION
Captures idea to add 'needs-interview' status to backlog workflow, allowing incomplete ideas to be deferred for later interview. Parked for post-tracer-bullet phase as it doesn't directly serve current themes.

- Created docs/ideas/019-backlog-interview-capture.md with full spec
- Added item to BACKLOG.md with preliminary scores (V=3, M=3, A=5)
- Added to STRATEGY.md Parking Lot