### PR TITLE
Mark items #015 and #007 as complete in backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -89,8 +89,8 @@ Description formats:
 |----|----------|-------------|---|---|---|-------|------------|--------|
 | 016 | Infrastructure | [Add dynamic component bundling for blog posts](specs/016-dynamic-blog-components/spec.md) | 3 | 5 | 4 | 12 | Medium | specified |
 | ~~014~~ | ~~Feature~~ | ~~[Add styling properties schemas to GeoJSON features](specs/014-geojson-styling-schemas/spec.md)~~ | ~~5~~ | ~~4~~ | ~~5~~ | ~~14~~ | ~~Medium~~ | ~~complete~~ |
-| 015 | Infrastructure | [Create LinkML schemas for REP annotation item types](docs/ideas/015-annotation-item-schemas.md) (prerequisite for #007) | 5 | 3 | 5 | 13 | Medium | approved |
-| 007 | Enhancement | [Implement REP file special comments (NARRATIVE, CIRCLE, etc.)](specs/007-rep-special-comments/spec.md) (requires #015) | 4 | 4 | 4 | 12 | Medium | specified |
+| ~~015~~ | ~~Infrastructure~~ | ~~[Create LinkML schemas for REP annotation item types](specs/015-annotation-item-schemas/spec.md)~~ | ~~5~~ | ~~3~~ | ~~5~~ | ~~13~~ | ~~Medium~~ | ~~complete~~ |
+| ~~007~~ | ~~Enhancement~~ | ~~[Implement REP file special comments (NARRATIVE, CIRCLE, etc.)](specs/007-rep-special-comments/spec.md)~~ | ~~4~~ | ~~4~~ | ~~4~~ | ~~12~~ | ~~Medium~~ | ~~complete~~ |
 | 011 | Documentation | Create Jupyter notebook example demonstrating debrief-calc Python API | 4 | 4 | 4 | 12 | Low | approved |
 | 002 | Feature | Add MCP wrapper for debrief-io service | 4 | 3 | 4 | 11 | Medium | approved |
 | 005 | Tech Debt | Add cross-service end-to-end workflow tests (io -> stac -> calc) | 4 | 2 | 5 | 11 | Low | approved |


### PR DESCRIPTION
## Summary
Update the project backlog to reflect the completion of two infrastructure and enhancement items that were previously in progress.

## Changes
- Mark item #015 (Create LinkML schemas for REP annotation item types) as complete
  - Updated status from "approved" to "complete"
  - Corrected spec path from `docs/ideas/015-annotation-item-schemas.md` to `specs/015-annotation-item-schemas/spec.md`
  
- Mark item #007 (Implement REP file special comments) as complete
  - Updated status from "specified" to "complete"
  - This item was dependent on #015, which is now also complete

## Notes
Both items are now struck through in the backlog table to indicate completion. The spec path correction for #015 aligns it with the standard specs directory structure used by other items in the backlog.