### PR TITLE
feat(backlog): add time controller UI/UX item (#022)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,6 +88,7 @@ Description formats:
 | ID | Category | Description | V | M | A | Total | Complexity | Status |
 |----|----------|-------------|---|---|---|-------|------------|--------|
 | 021 | Feature | [Add REP file loading to VS Code extension](docs/ideas/021-load-rep-files-stac.md) | 5 | 5 | 4 | 14 | Medium | approved |
+| 022 | Feature | [Design time controller UI/UX for VS Code extension](docs/ideas/022-time-controller.md) | 5 | 5 | 4 | 14 | Medium | approved |
 | 016 | Infrastructure | [Add dynamic component bundling for blog posts](specs/016-dynamic-blog-components/spec.md) | 3 | 5 | 4 | 12 | Medium | specified |
 | ~~014~~ | ~~Feature~~ | ~~[Add styling properties schemas to GeoJSON features](specs/014-geojson-styling-schemas/spec.md)~~ | ~~5~~ | ~~4~~ | ~~5~~ | ~~14~~ | ~~Medium~~ | ~~complete~~ |
 | ~~015~~ | ~~Infrastructure~~ | ~~[Create LinkML schemas for REP annotation item types](specs/015-annotation-item-schemas/spec.md)~~ | ~~5~~ | ~~3~~ | ~~5~~ | ~~13~~ | ~~Medium~~ | ~~complete~~ |

--- a/docs/ideas/022-time-controller.md
+++ b/docs/ideas/022-time-controller.md
@@ -1,0 +1,44 @@
+# Time Controller UI/UX for VS Code Extension
+
+## Problem
+
+Analysts need to visualize track data evolving through time, not just as static positions. Without temporal playback, users can only see the current state of all tracks, missing critical patterns in movement, interactions, and timing.
+
+## Proposed Solution
+
+Build a **time controller** component for the VS Code extension's map view that provides:
+
+### Controls
+1. **Time position scrubber** — Drag to jump to any point in the loaded time range
+2. **Play/Pause button** — Start/stop automatic time progression
+3. **Time acceleration** — Adjust playback speed (1x, 2x, 4x, 8x, etc.)
+
+### Behavior
+- **Global scope** — Controller affects all loaded tracks simultaneously
+- **Map synchronization** — Map displays track positions at the current time
+- **Time display** — Shows current time position in human-readable format
+
+### UI Location
+- Lives in the VS Code activity pane (alongside other Debrief controls)
+- Compact horizontal layout suitable for panel width
+
+## Success Criteria
+
+- [ ] User can scrub through time and see tracks update on map
+- [ ] Play button animates tracks forward through time
+- [ ] Acceleration controls allow faster-than-realtime playback
+- [ ] Time position clearly displayed
+- [ ] Works with all loaded tracks (no per-track controls needed)
+- [ ] Works fully offline (CONSTITUTION requirement)
+
+## Constraints
+
+- Must work within VS Code webview constraints
+- Part of shared-react-components library for reuse
+- No network dependencies (offline-first)
+
+## Out of Scope
+
+- Per-track individual time controls
+- Recording/export of playback as video
+- Time filtering (showing/hiding tracks by time range)


### PR DESCRIPTION
Add backlog item 022 for designing the time controller UI/UX for the VS Code extension. Includes position scrubber, play/pause, and time acceleration controls for animating track visualization.

Scores: V=5, M=5, A=4, Total=14
Status: approved (serves tracer bullet and stakeholder demo themes)

https://claude.ai/code/session_01BBy1vUos8GBRTbLcSM1M6E