### PR TITLE
chore(backlog): add item 026 - annotation shape renderers

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -111,6 +111,7 @@ Description formats:
 | 005 | Tech Debt | Add cross-service end-to-end workflow tests (io -> stac -> calc) | 4 | 2 | 5 | 11 | Low | approved |
 | 008 | Feature | Design and implement extension discovery mechanism for contrib packages | 4 | 3 | 3 | 10 | High | approved |
 | 013 | Bug | [Time Range and Tools panels show empty](https://github.com/debrief/debrief-future/issues/30) | 4 | 2 | 4 | 10 | Low | approved |
+| 026 | Feature | [Add annotation shape renderers to VS Code extension](https://github.com/debrief/debrief-future/issues/86) (requires #021) | 5 | 5 | 4 | 14 | Medium | approved |
 | 019 | Enhancement | [Add 'needs-interview' status to backlog workflow](docs/ideas/019-backlog-interview-capture.md) | 3 | 3 | 5 | 11 | Medium | proposed |
 | 020 | Infrastructure | [Add ELLIPSE and POLYGON annotation schemas](https://github.com/debrief/debrief-future/issues/56) | 3 | 2 | 5 | 10 | Low | proposed |
 | 004 | Infrastructure | Add contrib folder scaffolding with example extension (requires #008) | 3 | 3 | 4 | 10 | Low | proposed |


### PR DESCRIPTION
## Summary

- Adds backlog item 026: Add annotation shape renderers to VS Code extension
- Links to GitHub issue #86 with full requirements
- Scored V5/M5/A4 = 14 (high priority)
- Status: approved

## Context

Captured via `/idea` workflow with interview:
- Scope: All 6 annotation types (Circle, Rectangle, Line, Text, Vector, Narrative)
- Full styling support from schema properties
- Full selection integration with SelectionManager
- Separate renderer classes per type

## Test plan

- [x] BACKLOG.md has valid markdown table format
- [x] Item links to GitHub issue #86
- [x] Scores populated and totaled correctly