### PR TITLE
feat(backlog): add item 028 - reinstate Playwright E2E testing in CI

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -113,6 +113,7 @@ Description formats:
 | 001 | Infrastructure | Extract shared MCP utilities into mcp-common package | 3 | 2 | 4 | 9 | Medium | proposed |
 | 010 | Tech Debt | Add rollback/cleanup API to debrief-stac for interrupted operations | 3 | 1 | 4 | 8 | Medium | proposed |
 | 027 | Infrastructure | [Add automated screenshot capture for Storybook stories](docs/ideas/027-automated-screenshots.md) | 3 | 4 | 4 | 11 | Medium | approved |
+| 028 | Infrastructure | [Reinstate Playwright E2E testing in CI](docs/ideas/028-reinstate-playwright-ci.md) | 4 | 2 | 5 | 11 | Medium | approved |
 | 012 | Enhancement | Wire loader plot count to debrief-stac list_plots call | 2 | 1 | 5 | 8 | Low | proposed |
 | 027 | Documentation | [Document Storybook VS Code theming setup](docs/ideas/027-storybook-vscode-theming.md) | 2 | 2 | 5 | 9 | Low | approved |
 | 018 | Infrastructure | [Add VS Code multi-root workspace configuration](specs/018-vscode-workspace-config/spec.md) | 3 | 1 | 5 | 9 | Low | shipped |

--- a/docs/ideas/028-reinstate-playwright-ci.md
+++ b/docs/ideas/028-reinstate-playwright-ci.md
@@ -1,0 +1,39 @@
+# Reinstate Playwright E2E Testing in CI Pipeline
+
+## Problem
+
+Playwright E2E tests exist in the codebase but were removed from CI to unblock PR merges. This creates a testing gap where browser-based interactions are not validated automatically.
+
+Current state:
+- E2E tests exist: `shared/components/e2e/ToolMatchHarness.spec.ts` (12+ tests)
+- CI runs `task test` → `pnpm test` → `vitest run` (unit tests only)
+- Separate `test:e2e` script exists but isn't invoked in CI
+- Tests cover Storybook component interactions and screenshot capture
+
+## Proposed Solution
+
+Wire Playwright E2E tests into the CI pipeline:
+
+1. **Add Playwright CI step** to `.github/workflows/ci.yml` or create dedicated workflow
+2. **Install Playwright browsers** in CI environment (`npx playwright install --with-deps`)
+3. **Start Storybook server** before running E2E tests
+4. **Configure CI-appropriate settings** (timeouts, retries, parallelism)
+
+## Success Criteria
+
+- [ ] Playwright E2E tests run on every PR
+- [ ] E2E failures block PR merges
+- [ ] CI completes in reasonable time (< 10 minutes additional)
+- [ ] Screenshot artifacts uploaded on failure for debugging
+
+## Constraints
+
+- Must work on GitHub Actions Ubuntu runners
+- Should not significantly increase CI time
+- Must handle Storybook startup reliably
+
+## Out of Scope
+
+- Adding new E2E tests (existing tests are sufficient for this item)
+- Cross-browser testing (Chromium-only is acceptable initially)
+- Visual regression testing infrastructure


### PR DESCRIPTION
Created backlog item to wire existing Playwright E2E tests into the CI pipeline. Tests exist in shared/components/e2e/ but were previously skipped due to CI issues.

- Added docs/ideas/028-reinstate-playwright-ci.md with requirements
- Added to BACKLOG.md with scores V=4, M=2, A=5 (Total=11)
- Approved: supports CONSTITUTION Article VI (testing requirements)