### PR TITLE
docs: Add Windows-specific installation instructions for prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,15 @@ flowchart TB
 
 ### Prerequisites
 
-| Tool | Installation |
-|------|--------------|
-| Task | https://taskfile.dev/installation/ (or `brew install go-task`) |
-| uv | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
-| pnpm | `npm install -g pnpm` |
-| Node.js | 18+ |
-| Python | 3.11+ |
+| Tool | macOS / Linux | Windows |
+|------|---------------|---------|
+| Task | `brew install go-task` | `winget install Task.Task` or `choco install go-task` |
+| uv | `curl -LsSf https://astral.sh/uv/install.sh \| sh` | `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 \| iex"` |
+| pnpm | `npm install -g pnpm` | `npm install -g pnpm` |
+| Node.js | 18+ | 18+ |
+| Python | 3.11+ | 3.11+ |
+
+> **Windows note:** After installing tools, restart your terminal for PATH changes to take effect.
 
 ### Quick Start
 


### PR DESCRIPTION
## Summary
Updated the Prerequisites section in README.md to provide platform-specific installation instructions for Windows users, improving the setup experience across different operating systems.

## Key Changes
- Restructured the prerequisites table to include separate columns for macOS/Linux and Windows installation methods
- Added Windows-specific installation commands for:
  - Task: `winget install Task.Task` or `choco install go-task`
  - uv: PowerShell installation script
  - pnpm and Node.js: clarified same command works on both platforms
  - Python: clarified same requirement applies to both platforms
- Added a note about restarting the terminal on Windows after installation to ensure PATH changes take effect

## Implementation Details
The table now clearly distinguishes between platform-specific and cross-platform tools, making it easier for Windows users to follow the setup instructions without confusion. The added Windows note addresses a common issue where newly installed tools aren't available until the terminal is restarted.