### PR TITLE
Add backlog item 030: temporal UI state alignment spec

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -107,6 +107,7 @@ Description formats:
 | 005 | Tech Debt | Add cross-service end-to-end workflow tests (io -> stac -> calc) | 4 | 2 | 5 | 11 | Low | approved |
 | 028 | Tech Debt | [Add comprehensive unit tests for stacService](https://github.com/debrief/debrief-future/issues/98) | 4 | 2 | 5 | 11 | Low | proposed |
 | 029 | Tech Debt | [Integrate session-state service into VS Code extension](specs/029-session-state-vscode/spec.md) (multi-document support) | 5 | 3 | 4 | 12 | High | tasked |
+| 030 | Tech Debt | [Add replay mode and time acceleration to temporal state schema](docs/ideas/030-temporal-ui-state.md) (requires #029) | 4 | 2 | 4 | 10 | Medium | approved |
 | 013 | Bug | [Time Range and Tools panels show empty](https://github.com/debrief/debrief-future/issues/30) | 5 | 2 | 4 | 11 | Low | approved |
 | 008 | Feature | Design and implement extension discovery mechanism for contrib packages | 4 | 3 | 3 | 10 | High | approved |
 | 019 | Enhancement | [Add 'needs-interview' status to backlog workflow](docs/ideas/019-backlog-interview-capture.md) | 3 | 3 | 5 | 11 | Medium | proposed |

--- a/docs/ideas/030-temporal-ui-state.md
+++ b/docs/ideas/030-temporal-ui-state.md
@@ -1,0 +1,50 @@
+# Add replay mode and time acceleration to temporal state schema
+
+## Problem
+
+The Time Controller UI has properties that aren't represented in the centralized session state's `temporal` block:
+- **Replay mode toggle** - UI has this but no schema property exists
+- **Time acceleration** - Schema allows 0.1-100.0 continuous but UI shows discrete [1,2,4,8]
+
+Additionally, there are 5 critical inconsistencies between UI and session state:
+1. Display mode enum mismatch (`'normal'|'snailTrail'` vs `'full'|'trail'`)
+2. Playback state enum mismatch (3 states vs 2 states - missing 'stopped')
+3. Playback rate model mismatch (continuous vs discrete)
+4. Playback state persistence violation (should be ephemeral)
+5. WebView maintains separate local state instead of using centralized store
+
+## Proposed Solution
+
+1. Add `replayMode: boolean` to the temporal schema
+2. Align enum values between session state and UI components
+3. Decide on canonical playback rate model (recommend: continuous in schema, UI adapts)
+4. Ensure WebView reads from/writes to centralized session state
+5. Update shared component types to match session state schema
+
+## Success Criteria
+
+- [ ] `replayMode` property exists in temporal schema and is persisted
+- [ ] Display mode enum is consistent (`'normal'|'snailTrail'` everywhere)
+- [ ] Playback state enum is consistent (3 states: stopped/playing/paused)
+- [ ] Time Controller UI reads temporal state from session store
+- [ ] Time Controller UI writes temporal changes back to session store
+- [ ] Ephemeral properties (playbackState) reset correctly on load
+
+## Constraints
+
+- Depends on #029 (session-state VS Code integration) being complete
+- Must work offline (CONSTITUTION requirement)
+- Schema changes should follow schema-first principle (LinkML → derived types)
+
+## Out of Scope
+
+- Adding new UI controls (just aligning existing ones with state)
+- Changing the visual design of the Time Controller
+- Real-time streaming mode (parked item)
+
+## Related
+
+- Spec: `specs/025-time-controller/spec.md`
+- Spec: `specs/029-session-state-vscode/spec.md`
+- Session state types: `services/session-state/src/types/temporal.ts`
+- UI types: `shared/components/src/TimeController/types.ts`


### PR DESCRIPTION
## Summary

This PR adds a new backlog item (030) documenting the need to align the Time Controller UI with the centralized session state schema, and creates a detailed specification for resolving inconsistencies between UI and state management.

## Changes

- **BACKLOG.md**: Added item 030 (Tech Debt) to track temporal state schema alignment work
  - Estimated effort: 4-2-4 (10 total points)
  - Priority: Medium
  - Status: Approved
  - Dependency: Requires #029 (session-state VS Code integration)

- **docs/ideas/030-temporal-ui-state.md**: New specification document outlining:
  - **Problem**: Five critical inconsistencies between UI and session state:
    1. Missing `replayMode` property in schema
    2. Display mode enum mismatch (`'normal'|'snailTrail'` vs `'full'|'trail'`)
    3. Playback state enum mismatch (3 states vs 2 states)
    4. Playback rate model mismatch (continuous vs discrete)
    5. WebView maintaining separate local state instead of using centralized store
  
  - **Proposed Solution**: Add missing schema properties, align enums, ensure centralized state usage
  
  - **Success Criteria**: Six measurable outcomes including schema persistence, enum consistency, and proper state synchronization
  
  - **Constraints**: Offline-first requirement, schema-first principle (LinkML → derived types)

## Implementation Notes

This is a planning/specification PR that establishes the scope and requirements for future work on temporal state management. The actual implementation will be tracked as a separate task once #029 is complete.

https://claude.ai/code/session_01BypBezTSSNwaVt7PiN26da