### PR TITLE
Add STAC catalog overview panel feature to backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -125,6 +125,7 @@ Description formats:
 
 | ID | Category | Description | V | M | A | Total | Complexity | Status |
 |----|----------|-------------|---|---|---|-------|------------|--------|
+| 041 | Feature | [Add STAC catalog overview panel with map and timeline](docs/ideas/041-stac-catalog-overview-panel.md) | 5 | 5 | 3 | 13 | High | approved |
 | 040 | Enhancement | [Reorganize STAC store to per-item folder structure](specs/040-stac-store-organization/spec.md) | 4 | 3 | 4 | 11 | Medium | specified |
 | 039 | Bug | [Wire TimeController to TemporalTrackLayer in VS Code extension](specs/039-wire-timecontroller-temporal-track/spec.md) | 5 | 5 | 4 | 14 | Medium | specified |
 | 028 | Tech Debt | [Add comprehensive unit tests for stacService](specs/028-stacservice-unit-tests/spec.md) | 4 | 2 | 5 | 11 | Low | implementing |

--- a/docs/ideas/041-stac-catalog-overview-panel.md
+++ b/docs/ideas/041-stac-catalog-overview-panel.md
@@ -1,0 +1,45 @@
+# Add STAC catalog overview panel with map and timeline in VS Code
+
+## Problem
+
+Users have no way to get an overview of what's stored in a STAC catalog without opening individual items one at a time. There's no spatial or temporal summary view showing all items in a collection.
+
+## Proposed Solution
+
+Double-clicking a STAC catalog in the VS Code explorer opens an editor panel showing:
+
+1. **Map view** — displays spatial bounds/overview for each item in the collection
+2. **Timeline view** — displays temporal range for each item (reuse existing shared time display component)
+3. **Resizable layout** — horizontal drag bar between map and timeline panels
+4. **Item navigation** — double-clicking an item on the map or timeline opens that asset in the existing plot view (same as opening from the STAC Catalog tree view)
+
+### Prerequisites
+
+- **Temporal metadata in `item.json`** — `start_datetime` and `end_datetime` properties must be written when assets are saved to the STAC store, so the overview panel can read them
+- **Spatial bounds** — similarly updated at save time
+
+### Panel Implementation
+
+- Shown in the VS Code editor pane as a virtual document (in-memory, not file-based)
+- Read-only initially (no delete/edit operations)
+
+## Success Criteria
+
+- Double-clicking a STAC catalog opens the overview panel
+- Map shows spatial extent of all items in the collection
+- Timeline shows temporal range of all items
+- User can resize map/timeline via horizontal drag bar
+- Double-clicking an item opens it in the existing plot view
+- `item.json` files include `start_datetime`/`end_datetime` and spatial `bbox` properties
+
+## Constraints
+
+- Must work offline (local STAC catalog only)
+- Reuse existing shared time display component where possible
+- Panel is read-only (no mutation operations)
+
+## Out of Scope
+
+- Editing or deleting items from the overview panel
+- Remote/cloud STAC catalog support
+- Filtering or search within the overview


### PR DESCRIPTION
## Summary
This PR adds a new feature proposal to the backlog for implementing a STAC catalog overview panel in the VS Code extension. The feature would provide users with a spatial and temporal summary view of all items in a STAC collection without requiring them to open individual items one at a time.

## Changes
- **Added backlog entry #041** — New feature with high complexity, approved status, and total score of 13 points
- **Created feature specification document** — `docs/ideas/041-stac-catalog-overview-panel.md` detailing:
  - Problem statement: lack of overview/summary views for STAC catalogs
  - Proposed solution: double-click catalog to open editor panel with map and timeline views
  - Implementation approach: virtual document in VS Code editor pane
  - Success criteria and constraints
  - Prerequisites for temporal and spatial metadata in `item.json`

## Implementation Details
The feature proposes:
- **Map view** showing spatial bounds for all items in a collection
- **Timeline view** displaying temporal ranges (reusing existing shared time display component)
- **Resizable layout** with horizontal drag bar between panels
- **Item navigation** via double-click to open in existing plot view
- Read-only panel (no mutation operations initially)
- Offline-only support for local STAC catalogs

This is a foundational proposal that will require prerequisite work on temporal/spatial metadata handling before implementation can begin.

https://claude.ai/code/session_01ELCzgYYqhi6deHFcLNj6EP