### PR TITLE
docs: plan and spec Feature 047 (Unified Activity Panel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ Institutional knowledge lives in `docs/project_notes/` for consistency across se
 - Local filesystem STAC catalogs (read-write) (043-load-rep-new-plot)
 - TypeScript 5.x (VS Code extension) + VS Code extension API, existing `stacService`, existing `ioService`, Node.js `fs/promises`, `crypto.randomUUID()` (043-load-rep-new-plot)
 - Markdown (documentation only — no code implementation) + N/A (reads existing source files for reference content) (032-storybook-vscode-theming)
+- TypeScript 5.x (VS Code extension + shared components), React 18+ + vscrui ^0.1.0, @debrief/components (shared), @debrief/session-state (Zustand), VS Code extension API (host only) (047-unified-activity-panel)
+- N/A (in-memory session state only) (047-unified-activity-panel)
 
 ## Recent Changes
 - 039-wire-timecontroller-temporal-track: Added TypeScript 5.x (VS Code extension webview) + Leaflet (vanilla JS), VS Code webview API, `@debrief/session-state` (Zustand store)

--- a/docs/posts/2026-02-03-planning-unified-activity-panel-linkedin.md
+++ b/docs/posts/2026-02-03-planning-unified-activity-panel-linkedin.md
@@ -1,0 +1,9 @@
+Three VS Code sidebar panels, each with its own title bar and message channel, when one panel with collapsible sections would do. That is the kind of overhead that quietly steals screen real estate from the data analysts actually care about.
+
+This week we are planning Feature 047 for Future Debrief: consolidating the Time Controller, Tools, and Layers panels into a single unified activity panel. The interesting constraint is that the sub-components need to work outside VS Code too -- they are shared React components that will eventually compose into Electron and Jupyter layouts as well.
+
+Using vscrui's Pane component for the accordion sections gives us native VS Code styling without building custom collapse logic. Each section gets its own React ErrorBoundary, so a failure in one does not take down the others. The result is 45% less panel chrome and a single message-passing channel instead of three.
+
+Full write-up with architecture decisions and open questions: [link]
+
+#FutureDebrief #MaritimeAnalysis #VSCode

--- a/docs/posts/2026-02-03-planning-unified-activity-panel.md
+++ b/docs/posts/2026-02-03-planning-unified-activity-panel.md
@@ -1,0 +1,50 @@
+---
+layout: future-post
+title: "Planning: Unified Debrief Activity Panel"
+date: 2026-02-03
+track: [momentum]
+author: Ian
+reading_time: 3
+tags: [tracer-bullet, vscode-extension, shared-components, ui-architecture]
+excerpt: "Consolidating three sidebar panels into one unified webview with collapsible sections"
+---
+
+## What We're Building
+
+Right now the Debrief sidebar in VS Code has three separate panels -- Time Controller, Tools, and Layers -- each with its own title bar, collapse affordance, and webview lifecycle. It works, but it wastes roughly 60 pixels of vertical space per extra panel header, and it means three independent message-passing channels between the extension host and the webviews. That is overhead we do not need.
+
+Feature 047 replaces all three with a single webview containing collapsible sections. One `WebviewViewProvider`, one message channel, one React tree. The three capabilities remain distinct inside the panel -- they just share a container.
+
+## How It Fits
+
+This is a layout and architecture change, not a feature change. The Time Controller, Tools list, and Layers list keep their existing behaviour. What changes is where they live.
+
+The important part is that the sub-components are being built as shared React components in `shared/components/`. That means they are not coupled to VS Code. When the Electron loader or Jupyter frontend arrives, the same `TimeController`, `ToolsList`, and `FeatureList` components can be composed into whatever layout those frontends need. The VS Code activity panel is just the first consumer.
+
+This follows the "thick services, thin frontends" principle. The panel does not contain domain logic -- it renders state from the session store and dispatches actions back through the message protocol.
+
+## Key Decisions
+
+- **vscrui Pane component for collapsible sections.** This gives us native VS Code accordion styling without building our own. The Pane component handles expand/collapse, header rendering, and keyboard navigation.
+
+- **Converting Tools and Layers from native tree views to React.** The existing Tools panel uses VS Code's built-in TreeView API. Moving to React means we lose native tree rendering, but gain composability and cross-frontend reuse. The Layers section already has React components (`FeatureList` and `LayersToolbar` from #045) so that conversion is straightforward.
+
+- **React ErrorBoundary per section.** If the Tools list throws, the Time Controller and Layers keep working. Each section gets its own error boundary so a failure in one does not blank the entire panel.
+
+- **Session-scoped collapse state.** Which sections are expanded persists within a VS Code session using the webview state API. We are not persisting this to disk -- if you restart VS Code, sections reset to their defaults (all expanded). That feels like the right trade-off: low complexity, no config file clutter.
+
+- **No new dependencies.** The panel uses vscrui (#031, already integrated), React (already in the project), and the session-state store. Nothing new to install.
+
+## The Numbers
+
+Three panels currently consume about 132px of chrome (title bars, padding, borders). A single panel with collapsible sections drops that to roughly 72px -- a 45% reduction. On a 1080p display with a typical sidebar width, that reclaims enough space for two or three additional visible track entries in the Layers list. Not dramatic, but meaningful when you are working with exercises that have a dozen or more participants.
+
+## What We'd Love Feedback On
+
+- **Default section order.** We are planning Time Controller at the top, then Tools, then Layers. The logic is that time controls are used most frequently during playback, and layers are more of a "set and forget" concern. Does that match how analysts actually work, or would a different order be more natural?
+
+- **Should collapse state persist across sessions?** We are leaning toward session-only persistence (resets on restart). But if analysts consistently collapse the same sections, maybe persisting to `workspaceState` is worth the small extra complexity.
+
+- **Tool discoverability.** Moving tools from a native tree view to a React list means we control the rendering entirely. Are there affordances beyond a simple list that would help scientists find the right analysis tool -- grouping by category, recently-used, or something else?
+
+-> [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/047-unified-activity-panel/contracts/components.ts
+++ b/specs/047-unified-activity-panel/contracts/components.ts
@@ -1,0 +1,98 @@
+/**
+ * Component prop contracts for the Unified Activity Panel.
+ *
+ * These interfaces define the public API of each shared component.
+ * Components in shared/components/ accept these props and have
+ * zero dependency on VS Code APIs.
+ */
+
+import type { ToolItemContract, FeatureItemContract } from './messages';
+
+// ─── ActivityPanel ───────────────────────────────────────────────────────────
+
+export interface ActivityPanelProps {
+  /** Initial collapse state for each section */
+  initialCollapsed?: {
+    timeController?: boolean;
+    tools?: boolean;
+    layers?: boolean;
+  };
+  /** Called when a section is collapsed or expanded */
+  onSectionToggle?: (sectionId: string, collapsed: boolean) => void;
+  /** Time Controller props */
+  timeController: TimeControllerSectionProps;
+  /** Tools section props */
+  tools: ToolsListProps;
+  /** Layers section props */
+  layers: LayersSectionProps;
+}
+
+// ─── CollapsibleSection ──────────────────────────────────────────────────────
+
+export interface CollapsibleSectionProps {
+  /** Unique section identifier */
+  id: string;
+  /** Display title */
+  title: string;
+  /** Codicon icon name */
+  icon?: string;
+  /** Whether section is collapsed */
+  collapsed: boolean;
+  /** Called when header is clicked */
+  onToggle: (collapsed: boolean) => void;
+  /** Section content */
+  children: React.ReactNode;
+}
+
+// ─── ToolsList ───────────────────────────────────────────────────────────────
+
+export interface ToolsListProps {
+  /** Available tools with match status */
+  tools: ToolItemContract[];
+  /** Whether any features are selected */
+  hasSelection: boolean;
+  /** Summary of current selection for display */
+  selectionSummary: string;
+  /** Whether to show inactive tools */
+  showInactive?: boolean;
+  /** Called when user clicks an active tool */
+  onExecute: (toolId: string) => void;
+}
+
+// ─── TimeControllerSectionProps ──────────────────────────────────────────────
+
+/** Props passed to TimeController within the unified panel (existing component API) */
+export interface TimeControllerSectionProps {
+  /** Start of time extent (epoch ms) */
+  timeStart: number;
+  /** End of time extent (epoch ms) */
+  timeEnd: number;
+  /** Current time position (epoch ms) */
+  currentTime: number;
+  /** Playback speed multiplier */
+  speed: number;
+  /** Display mode */
+  displayMode: 'full' | 'trail';
+  /** Whether playback is active */
+  isPlaying: boolean;
+  /** Called when user changes time */
+  onTimeChange: (time: number) => void;
+  /** Called when playback state changes */
+  onPlaybackChange: (state: 'playing' | 'paused') => void;
+  /** Called when display mode changes */
+  onDisplayModeChange: (mode: 'full' | 'trail') => void;
+}
+
+// ─── LayersSectionProps ──────────────────────────────────────────────────────
+
+/** Props for the layers section (wraps FeatureList + LayersToolbar) */
+export interface LayersSectionProps {
+  /** Features to display */
+  features: FeatureItemContract[];
+  /** Currently selected feature IDs */
+  selectedIds: string[];
+  /** Called when visibility is toggled */
+  onToggleVisibility: (featureId: string, visible: boolean) => void;
+  /** Called when selection changes */
+  onSelectionChange: (selectedIds: string[]) => void;
+}

--- a/specs/047-unified-activity-panel/contracts/messages.ts
+++ b/specs/047-unified-activity-panel/contracts/messages.ts
@@ -1,0 +1,148 @@
+/**
+ * Message contracts for the Unified Activity Panel webview.
+ *
+ * Messages flow between the VS Code extension host (activityPanelView.ts)
+ * and the webview (activityPanel.tsx) via postMessage.
+ */
+
+// ─── Webview → Extension Host ────────────────────────────────────────────────
+
+/** Webview signals it is ready to receive messages */
+export interface WebviewReadyMessage {
+  type: 'webviewReady';
+}
+
+// Time Controller messages (existing, carried forward)
+export interface TimeChangeMessage {
+  type: 'timeChange';
+  time: number;
+}
+
+export interface PlaybackStateChangeMessage {
+  type: 'playbackStateChange';
+  state: 'playing' | 'paused';
+}
+
+export interface DisplayModeChangeMessage {
+  type: 'displayModeChange';
+  mode: 'full' | 'trail';
+}
+
+// Tools messages
+export interface ExecuteToolMessage {
+  type: 'executeTool';
+  toolId: string;
+}
+
+// Layers messages
+export interface ToggleVisibilityMessage {
+  type: 'toggleVisibility';
+  featureId: string;
+  visible: boolean;
+}
+
+export interface LayerSelectionChangeMessage {
+  type: 'layerSelectionChange';
+  selectedIds: string[];
+}
+
+// Panel state messages
+export interface SectionCollapseMessage {
+  type: 'sectionCollapse';
+  sectionId: 'timeController' | 'tools' | 'layers';
+  collapsed: boolean;
+}
+
+export type WebviewToHostMessage =
+  | WebviewReadyMessage
+  | TimeChangeMessage
+  | PlaybackStateChangeMessage
+  | DisplayModeChangeMessage
+  | ExecuteToolMessage
+  | ToggleVisibilityMessage
+  | LayerSelectionChangeMessage
+  | SectionCollapseMessage;
+
+// ─── Extension Host → Webview ────────────────────────────────────────────────
+
+// Time Controller updates
+export interface UpdateTimeExtentMessage {
+  type: 'updateTimeExtent';
+  start: number;
+  end: number;
+}
+
+export interface SetCurrentTimeMessage {
+  type: 'setCurrentTime';
+  time: number;
+}
+
+export interface SetTimeUIStateMessage {
+  type: 'setTimeUIState';
+  speed: number;
+  displayMode: 'full' | 'trail';
+  isPlaying: boolean;
+}
+
+// Tools updates
+export interface UpdateToolMatchesMessage {
+  type: 'updateToolMatches';
+  tools: ToolItemContract[];
+  hasSelection: boolean;
+  selectionSummary: string;
+}
+
+export interface ToolItemContract {
+  id: string;
+  name: string;
+  description: string;
+  active: boolean;
+  explanation: string;
+  icon: string;
+}
+
+export interface ToolExecutionResultMessage {
+  type: 'toolExecutionResult';
+  toolId: string;
+  success: boolean;
+  error?: string;
+}
+
+// Layers updates
+export interface UpdateFeaturesMessage {
+  type: 'updateFeatures';
+  features: FeatureItemContract[];
+}
+
+export interface FeatureItemContract {
+  id: string;
+  name: string;
+  kind: string;
+  visible: boolean;
+  selected: boolean;
+}
+
+export interface UpdateLayerSelectionMessage {
+  type: 'updateLayerSelection';
+  selectedIds: string[];
+}
+
+// Panel state restore
+export interface RestoreCollapseStateMessage {
+  type: 'restoreCollapseState';
+  collapsedSections: {
+    timeController: boolean;
+    tools: boolean;
+    layers: boolean;
+  };
+}
+
+export type HostToWebviewMessage =
+  | UpdateTimeExtentMessage
+  | SetCurrentTimeMessage
+  | SetTimeUIStateMessage
+  | UpdateToolMatchesMessage
+  | ToolExecutionResultMessage
+  | UpdateFeaturesMessage
+  | UpdateLayerSelectionMessage
+  | RestoreCollapseStateMessage;

--- a/specs/047-unified-activity-panel/data-model.md
+++ b/specs/047-unified-activity-panel/data-model.md
@@ -1,0 +1,75 @@
+# Data Model: Unified Debrief Activity Panel
+
+**Feature**: 047-unified-activity-panel
+**Date**: 2026-02-01
+
+## Entities
+
+### ActivityPanelState
+
+Session-scoped UI state for the unified panel, persisted via VS Code webview state API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| collapsedSections | `CollapsedSections` | all false | Which sections are collapsed |
+
+### CollapsedSections
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| timeController | boolean | false | Time Controller section collapsed |
+| tools | boolean | false | Tools section collapsed |
+| layers | boolean | false | Layers section collapsed |
+
+### ToolItem
+
+Presentational data for a single tool in the ToolsList component. Derived from existing `MatchResult` in `ToolMatchAdapter`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Tool identifier |
+| name | string | Display name |
+| description | string | Tool description |
+| active | boolean | Whether tool is applicable to current selection |
+| explanation | string | Why tool is active/inactive |
+| icon | string | Codicon icon name |
+
+### SectionConfig
+
+Configuration for each collapsible section in the ActivityPanel.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | `'timeController' \| 'tools' \| 'layers'` | Section identifier |
+| title | string | Display title (externalisable for i18n) |
+| icon | string | Codicon icon for section header |
+| component | ReactNode | The sub-component to render |
+
+## State Transitions
+
+```
+Panel Opens → Load persisted state → Render sections (collapsed/expanded per state)
+                                          ↓
+User clicks section header → Toggle collapsed state → Persist → Re-render
+                                          ↓
+Sub-component error → ErrorBoundary catches → Show fallback in that section only
+                                          ↓
+Panel closes → State already persisted → No action needed
+```
+
+## Relationships
+
+- `ActivityPanel` contains exactly 3 `CollapsibleSection` instances
+- Each `CollapsibleSection` wraps exactly 1 sub-component (TimeController, ToolsList, or FeatureList+LayersToolbar)
+- `ActivityPanelState` is 1:1 with the panel instance
+- `ToolItem[]` is provided to `ToolsList` via props (data flows from extension host via messages)
+
+## Validation Rules
+
+- `collapsedSections` must have exactly 3 keys matching known section IDs
+- `ToolItem.id` must be non-empty string
+- At least one section must be expandable (UI does not prevent collapsing all, but all-collapsed is a valid state per spec edge cases)
+
+## No New Schemas
+
+This feature does not introduce new persistent data schemas. All data flows through existing session state (`@debrief/session-state`) and existing service interfaces (`ToolMatchAdapter`, `SessionManager`). The data model above describes in-memory UI state only.

--- a/specs/047-unified-activity-panel/media/linkedin-planning.md
+++ b/specs/047-unified-activity-panel/media/linkedin-planning.md
@@ -1,0 +1,9 @@
+Three VS Code sidebar panels, each with its own title bar and message channel, when one panel with collapsible sections would do. That is the kind of overhead that quietly steals screen real estate from the data analysts actually care about.
+
+This week we are planning Feature 047 for Future Debrief: consolidating the Time Controller, Tools, and Layers panels into a single unified activity panel. The interesting constraint is that the sub-components need to work outside VS Code too -- they are shared React components that will eventually compose into Electron and Jupyter layouts as well.
+
+Using vscrui's Pane component for the accordion sections gives us native VS Code styling without building custom collapse logic. Each section gets its own React ErrorBoundary, so a failure in one does not take down the others. The result is 45% less panel chrome and a single message-passing channel instead of three.
+
+Full write-up with architecture decisions and open questions: [link]
+
+#FutureDebrief #MaritimeAnalysis #VSCode

--- a/specs/047-unified-activity-panel/media/planning-post.md
+++ b/specs/047-unified-activity-panel/media/planning-post.md
@@ -1,0 +1,50 @@
+---
+layout: future-post
+title: "Planning: Unified Debrief Activity Panel"
+date: 2026-02-03
+track: [momentum]
+author: Ian
+reading_time: 3
+tags: [tracer-bullet, vscode-extension, shared-components, ui-architecture]
+excerpt: "Consolidating three sidebar panels into one unified webview with collapsible sections"
+---
+
+## What We're Building
+
+Right now the Debrief sidebar in VS Code has three separate panels -- Time Controller, Tools, and Layers -- each with its own title bar, collapse affordance, and webview lifecycle. It works, but it wastes roughly 60 pixels of vertical space per extra panel header, and it means three independent message-passing channels between the extension host and the webviews. That is overhead we do not need.
+
+Feature 047 replaces all three with a single webview containing collapsible sections. One `WebviewViewProvider`, one message channel, one React tree. The three capabilities remain distinct inside the panel -- they just share a container.
+
+## How It Fits
+
+This is a layout and architecture change, not a feature change. The Time Controller, Tools list, and Layers list keep their existing behaviour. What changes is where they live.
+
+The important part is that the sub-components are being built as shared React components in `shared/components/`. That means they are not coupled to VS Code. When the Electron loader or Jupyter frontend arrives, the same `TimeController`, `ToolsList`, and `FeatureList` components can be composed into whatever layout those frontends need. The VS Code activity panel is just the first consumer.
+
+This follows the "thick services, thin frontends" principle. The panel does not contain domain logic -- it renders state from the session store and dispatches actions back through the message protocol.
+
+## Key Decisions
+
+- **vscrui Pane component for collapsible sections.** This gives us native VS Code accordion styling without building our own. The Pane component handles expand/collapse, header rendering, and keyboard navigation.
+
+- **Converting Tools and Layers from native tree views to React.** The existing Tools panel uses VS Code's built-in TreeView API. Moving to React means we lose native tree rendering, but gain composability and cross-frontend reuse. The Layers section already has React components (`FeatureList` and `LayersToolbar` from #045) so that conversion is straightforward.
+
+- **React ErrorBoundary per section.** If the Tools list throws, the Time Controller and Layers keep working. Each section gets its own error boundary so a failure in one does not blank the entire panel.
+
+- **Session-scoped collapse state.** Which sections are expanded persists within a VS Code session using the webview state API. We are not persisting this to disk -- if you restart VS Code, sections reset to their defaults (all expanded). That feels like the right trade-off: low complexity, no config file clutter.
+
+- **No new dependencies.** The panel uses vscrui (#031, already integrated), React (already in the project), and the session-state store. Nothing new to install.
+
+## The Numbers
+
+Three panels currently consume about 132px of chrome (title bars, padding, borders). A single panel with collapsible sections drops that to roughly 72px -- a 45% reduction. On a 1080p display with a typical sidebar width, that reclaims enough space for two or three additional visible track entries in the Layers list. Not dramatic, but meaningful when you are working with exercises that have a dozen or more participants.
+
+## What We'd Love Feedback On
+
+- **Default section order.** We are planning Time Controller at the top, then Tools, then Layers. The logic is that time controls are used most frequently during playback, and layers are more of a "set and forget" concern. Does that match how analysts actually work, or would a different order be more natural?
+
+- **Should collapse state persist across sessions?** We are leaning toward session-only persistence (resets on restart). But if analysts consistently collapse the same sections, maybe persisting to `workspaceState` is worth the small extra complexity.
+
+- **Tool discoverability.** Moving tools from a native tree view to a React list means we control the rendering entirely. Are there affordances beyond a simple list that would help scientists find the right analysis tool -- grouping by category, recently-used, or something else?
+
+-> [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/047-unified-activity-panel/plan.md
+++ b/specs/047-unified-activity-panel/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: Unified Debrief Activity Panel
+
+**Branch**: `047-unified-activity-panel` | **Date**: 2026-02-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/047-unified-activity-panel/spec.md`
+
+## Summary
+
+Consolidate the three separate activity sidebar panels (Time Controller webview, Tools tree view, Layers tree view) into a single unified webview panel. Each sub-component will be a shared React component in `@debrief/components`, composed into one `ActivityPanel` container with collapsible sections. The Tools and Layers panels must be converted from native VS Code TreeDataProviders to React components — the Tools panel will be built as a new shared component, while Layers will leverage the existing `FeatureList` + `LayersToolbar` components. All components use `vscrui` for native VS Code styling.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (VS Code extension + shared components), React 18+
+**Primary Dependencies**: vscrui ^0.1.0, @debrief/components (shared), @debrief/session-state (Zustand), VS Code extension API (host only)
+**Storage**: N/A (in-memory session state only)
+**Testing**: Vitest (shared components), Storybook (visual), VS Code extension integration tests
+**Target Platform**: VS Code extension webview (sidebar), with standalone renderability for Electron/Jupyter
+**Project Type**: Web (shared component library + VS Code extension integration)
+**Performance Goals**: 60 fps scrolling, <100ms section collapse/expand transitions, 20% less vertical space than current 3-panel layout
+**Constraints**: Offline-capable (Constitution Art. I), no VS Code API dependencies in shared components (Constitution Art. IV), vscrui for all UI elements (spec #031)
+**Scale/Scope**: 3 sub-components (TimeController, ToolsList, LayersPanel) + 1 container (ActivityPanel), ~5 new/modified files in shared/components, ~3 new/modified files in apps/vscode
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Requirement | Status | Notes |
+|---------|-------------|--------|-------|
+| I. Defence-Grade Reliability | Offline by default | ✅ PASS | All components render locally, no network calls |
+| I.3 | No silent failures | ✅ PASS | FR-006 requires error isolation per section |
+| II. Schema Integrity | Schema-driven data | ✅ PASS | No new data schemas — consumes existing session state |
+| III. Data Sovereignty | Provenance always | N/A | UI-only feature, no data transformation |
+| IV. Architectural Boundaries | Services never touch UI | ✅ PASS | Sub-components are pure React, VS Code integration is a thin wrapper |
+| IV.2 | Frontends never persist | ✅ PASS | Collapse state is session-scoped only (FR-007) |
+| V. Extensibility | Fail-safe loading | ✅ PASS | FR-006: error in one sub-component doesn't crash others |
+| VI. Testing | Services require unit tests | ✅ PASS | Component tests via Vitest + Storybook stories |
+| VII. Test-Driven AI | Tests before implementation | ✅ PASS | Acceptance scenarios defined in spec |
+| VIII. Documentation | Specs before code | ✅ PASS | This plan + spec.md |
+| IX. Dependencies | Minimal dependencies | ✅ PASS | Uses existing vscrui + React, no new deps |
+| XI. Internationalisation | I18N from the start | ⚠️ NOTE | Section header strings must be externalisable |
+| XII. Community Engagement | Public by default | ✅ PASS | Planning post included in media phase |
+
+**Gate Result**: PASS — no violations. I18N note tracked as implementation detail.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/047-unified-activity-panel/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+shared/components/src/
+├── ActivityPanel/
+│   ├── ActivityPanel.tsx        # Unified container with collapsible sections
+│   ├── ActivityPanel.test.tsx   # Component tests
+│   ├── CollapsibleSection.tsx   # Reusable collapsible section wrapper
+│   └── index.ts
+├── ToolsList/
+│   ├── ToolsList.tsx            # New: React version of tools tree
+│   ├── ToolsList.test.tsx
+│   └── index.ts
+├── TimeController/              # Existing — no changes expected
+├── FeatureList/                 # Existing — used as Layers sub-component
+├── LayersToolbar/               # Existing — used with FeatureList
+└── index.ts                     # Updated exports
+
+apps/vscode/src/
+├── views/
+│   ├── activityPanelView.ts     # New: WebviewViewProvider for unified panel
+│   └── timeRangeView.ts         # Deprecated (replaced by unified panel)
+├── providers/
+│   ├── toolsTreeProvider.ts     # Deprecated (replaced by ToolsList component)
+│   └── layersTreeProvider.ts    # Deprecated (replaced by FeatureList)
+├── webview/web/
+│   └── activityPanel.tsx        # New: React entry point for unified webview
+└── package.json                 # Updated: single view replaces three
+```
+
+**Structure Decision**: Shared components in `shared/components/src/` with VS Code integration in `apps/vscode/src/views/`. The ActivityPanel container lives in shared/components so it can be reused across frontends.
+
+## Media Components
+
+| Component | Story Source | Bundle Name | Purpose |
+|-----------|--------------|-------------|---------|
+| ActivityPanel | `shared/components/src/ActivityPanel/ActivityPanel.stories.tsx` | `activity-panel.js` | Demonstrates unified 3-section panel with collapse |
+| ToolsList | `shared/components/src/ToolsList/ToolsList.stories.tsx` | `tools-list.js` | Shows context-sensitive tool display |
+
+**Inclusion Criteria Applied**:
+- [x] New visual component
+- [x] Significant visual change
+- [x] Interactive demo adds narrative value
+
+**Bundleability Verified**:
+- [ ] Stories exist in Storybook (will be created)
+- [x] Components render standalone (no app context required)
+- [x] Reasonable bundle size expected (< 500KB)
+
+**Storybook Link**: `https://debrief.github.io/debrief-future/storybook/?path=/story/activitypanel--default`
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/047-unified-activity-panel/quickstart.md
+++ b/specs/047-unified-activity-panel/quickstart.md
@@ -1,0 +1,94 @@
+# Quickstart: Unified Debrief Activity Panel
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm installed
+- VS Code 1.85+ (for extension testing)
+- Dependencies: `pnpm install` from repo root
+
+## Development Order
+
+### 1. CollapsibleSection component
+
+Create `shared/components/src/ActivityPanel/CollapsibleSection.tsx`:
+- Uses vscrui `Pane` for header styling
+- Manages expand/collapse with CSS transitions
+- Props: `id`, `title`, `icon`, `collapsed`, `onToggle`, `children`
+- Add Storybook story demonstrating collapse behavior
+
+### 2. ToolsList component
+
+Create `shared/components/src/ToolsList/ToolsList.tsx`:
+- Renders `ToolItemContract[]` as clickable rows
+- Active tools: clickable with execute action
+- Inactive tools: greyed out with explanation tooltip
+- Empty states: "Select features to see tools" / "No tools available"
+- Uses vscrui `Button`, `Icon`, `Label` components
+- Add Storybook story with mock tool data
+
+### 3. ActivityPanel container
+
+Create `shared/components/src/ActivityPanel/ActivityPanel.tsx`:
+- Composes 3 `CollapsibleSection` instances
+- Wraps each sub-component in React `ErrorBoundary`
+- Manages collapse state, calls `onSectionToggle` callback
+- Section order: Time Controller, Tools, Layers (fixed)
+- Add Storybook story showing all sections
+
+### 4. Webview entry point
+
+Create `apps/vscode/src/webview/web/activityPanel.tsx`:
+- Acquires VS Code API
+- Translates messages to/from component props
+- Persists collapse state via `getState()`/`setState()`
+- Renders `ActivityPanel` into `#root`
+
+### 5. WebviewViewProvider
+
+Create `apps/vscode/src/views/activityPanelView.ts`:
+- Implements `WebviewViewProvider` for `debrief.activity`
+- Subscribes to `SessionManager` for time, selection, features
+- Subscribes to `ToolMatchAdapter` for tool matches
+- Posts messages to webview on state changes
+- Handles incoming messages (execute tool, toggle visibility, etc.)
+- Queues messages until webview ready
+
+### 6. Extension manifest update
+
+Update `apps/vscode/package.json`:
+- Replace `debrief.timeRange`, `debrief.tools`, `debrief.layers` views with single `debrief.activity` webview view
+- Update `extension.ts` to register `ActivityPanelView` instead of the three separate providers
+
+### 7. esbuild config update
+
+Update `apps/vscode/esbuild.config.js`:
+- Add/replace entry point for `activityPanel.tsx`
+- Output to `dist/webview/activityPanel.js`
+
+## Running
+
+```bash
+# Shared components dev (Storybook)
+cd shared/components
+pnpm storybook
+
+# Build extension
+cd apps/vscode
+pnpm build
+
+# Test in VS Code
+# Press F5 to launch Extension Development Host
+```
+
+## Testing Checklist
+
+- [ ] All 3 sections render in single panel
+- [ ] Each section collapses/expands independently
+- [ ] Collapse state persists across panel close/reopen
+- [ ] Time Controller responds to session time changes
+- [ ] Tools update when selection changes
+- [ ] Layers show features with visibility toggles
+- [ ] Error in one section doesn't crash others
+- [ ] Panel uses less vertical space than 3 separate panels
+- [ ] Components render in Storybook without VS Code

--- a/specs/047-unified-activity-panel/research.md
+++ b/specs/047-unified-activity-panel/research.md
@@ -1,0 +1,123 @@
+# Research: Unified Debrief Activity Panel
+
+**Feature**: 047-unified-activity-panel
+**Date**: 2026-02-01
+
+## Research Questions & Findings
+
+### RQ-1: How to implement collapsible sections?
+
+**Decision**: Use vscrui `Pane` component for collapsible section headers.
+
+**Rationale**: The vscrui library already provides a `Pane` layout component with `title` and `actions` props. This gives native VS Code styling out of the box and avoids adding new dependencies. A thin `CollapsibleSection` wrapper will manage expand/collapse state and CSS transitions.
+
+**Alternatives Considered**:
+- Custom HTML details/summary element — rejected: doesn't match VS Code styling
+- VS Code tree view with collapsible nodes — rejected: loses webview flexibility
+- Custom accordion component — rejected: unnecessary when vscrui Pane exists
+
+### RQ-2: How to convert Tools panel from TreeDataProvider to React?
+
+**Decision**: Build a new `ToolsList` shared React component that renders tool match results as a flat list with vscrui components.
+
+**Rationale**: The existing `ToolsTreeProvider` uses `ToolMatchAdapter` to get `MatchResult[]` (active/inactive tools with explanations). A React component can consume the same data shape via props, rendering each tool as a clickable row with icon, label, and status. The adapter logic stays in the VS Code extension host; the React component is purely presentational.
+
+**Alternatives Considered**:
+- Embed native tree view inside webview — rejected: not possible, tree views are VS Code-native only
+- Keep Tools as a separate native panel — rejected: defeats the unified panel goal
+- Use FeatureList component for tools — rejected: tools have different interaction model (execute vs select)
+
+### RQ-3: How to handle Layers panel in the unified view?
+
+**Decision**: Compose existing `FeatureList` + `LayersToolbar` components as the Layers section.
+
+**Rationale**: These components already exist as shared React components with vscrui styling (spec #045). The `FeatureList` provides virtualized feature listing with multi-select, and `LayersToolbar` provides filter/run/associated-files functionality. Together they replace the `LayersTreeProvider` fully.
+
+**Alternatives Considered**:
+- Build new layers component from scratch — rejected: duplicates existing work
+- Wrap tree view in webview — rejected: not technically possible
+
+### RQ-4: What message passing pattern to use for the unified panel?
+
+**Decision**: Single `WebviewViewProvider` with a unified message protocol extending the existing pattern from `timeRangeView.ts`.
+
+**Rationale**: The existing pattern uses typed message unions, a ready-signal handshake, and a pending message queue. The unified panel will extend this with additional message types for tools (execute, refresh) and layers (toggle visibility, selection change). Each sub-component receives only its relevant messages.
+
+**Message Types**:
+- Existing: `timeChange`, `playbackStateChange`, `displayModeChange`, `updateTimeExtent`, `setCurrentTime`, `setUIState`, `webviewReady`
+- New for tools: `updateToolMatches`, `executeTool`, `toolExecutionResult`
+- New for layers: `updateFeatures`, `toggleVisibility`, `selectionChange`, `updateSelection`
+- New for panel: `setSectionCollapsed`, `restoreCollapseState`
+
+**Alternatives Considered**:
+- Separate message channels per sub-component — rejected: adds complexity with no benefit in a single webview
+- State management in webview only — rejected: tools and layers data originates from extension host services
+
+### RQ-5: How to register the unified panel in VS Code?
+
+**Decision**: Replace the three existing view registrations (`debrief.timeRange`, `debrief.tools`, `debrief.layers`) with a single `debrief.activity` webview view in `package.json`.
+
+**Rationale**: VS Code's `contributes.views` allows webview views in activity bar containers. The existing `debrief` container already hosts the three views. Replacing them with one view simplifies the manifest and eliminates the multi-panel overhead that causes wasted vertical space.
+
+**Migration**: The three old view IDs will be removed from `package.json`. The new `activityPanelView.ts` WebviewViewProvider replaces all three providers.
+
+### RQ-6: How to persist collapse state within a session?
+
+**Decision**: Use VS Code's `webview.getState()`/`setState()` API (same pattern as TimeController).
+
+**Rationale**: The existing TimeController already persists UI state (current time, speed, display mode) via the VS Code webview state API. This state survives webview reloads but not editor restarts — exactly matching the FR-007 session-scoped requirement.
+
+**State Shape**:
+```typescript
+interface ActivityPanelState {
+  collapsedSections: {
+    timeController: boolean;
+    tools: boolean;
+    layers: boolean;
+  };
+}
+```
+
+### RQ-7: How to achieve 20% vertical space reduction (SC-002)?
+
+**Decision**: Eliminate per-panel chrome (title bars, padding, margins) by using a single webview with compact section headers.
+
+**Rationale**: Each VS Code panel has ~28px of title bar + 8px padding top/bottom = ~44px overhead. Three panels = ~132px wasted. A single webview with ~24px section headers × 3 = ~72px, saving ~60px (~45% overhead reduction). Additional savings come from shared padding and removing inter-panel gaps.
+
+**Measurement Plan**: Screenshot comparison of current 3-panel vs unified panel with identical content, measured in pixels.
+
+### RQ-8: Error isolation strategy (FR-006)?
+
+**Decision**: React Error Boundaries around each sub-component section.
+
+**Rationale**: React's ErrorBoundary pattern catches rendering errors in child components and displays a fallback UI. Each of the three sections will be wrapped in its own ErrorBoundary, so a crash in ToolsList doesn't affect TimeController or FeatureList.
+
+**Implementation**:
+```tsx
+<CollapsibleSection title="Time Controller">
+  <ErrorBoundary fallback={<SectionError name="Time Controller" />}>
+    <TimeController {...timeProps} />
+  </ErrorBoundary>
+</CollapsibleSection>
+```
+
+### RQ-9: esbuild configuration for unified panel?
+
+**Decision**: Add a new entry point `activityPanel.tsx` to the existing esbuild webview config.
+
+**Rationale**: The current config builds `map.ts` as an IIFE bundle. The `timeController.tsx` entry point follows the same pattern. The unified panel will replace the time controller entry point with a broader `activityPanel.tsx` that imports all three sub-components.
+
+**Config Change**: Replace `src/webview/web/timeController.tsx` entry with `src/webview/web/activityPanel.tsx`, outputting to `dist/webview/activityPanel.js`.
+
+## Technology Decisions Summary
+
+| Decision | Choice | Key Reason |
+|----------|--------|------------|
+| Collapsible sections | vscrui Pane | Native styling, no new deps |
+| Tools component | New ToolsList (React) | TreeDataProvider can't live in webview |
+| Layers component | Existing FeatureList + LayersToolbar | Already built and tested |
+| Message protocol | Extended typed union pattern | Proven in TimeController |
+| VS Code registration | Single `debrief.activity` view | Replaces 3 views, saves chrome |
+| State persistence | `getState()`/`setState()` | Session-scoped, existing pattern |
+| Error isolation | React ErrorBoundary per section | Standard React pattern |
+| Build | esbuild IIFE bundle | Existing pipeline |


### PR DESCRIPTION
## Summary

This PR adds comprehensive planning and specification documentation for Feature 047: consolidating the three separate VS Code sidebar panels (Time Controller, Tools, Layers) into a single unified activity panel with collapsible sections.

## Changes

- **CLAUDE.md**: Added tech stack entry for Feature 047 (TypeScript 5.x, React 18+, vscrui, Zustand session state)
- **Planning post** (`docs/posts/2026-02-03-planning-unified-activity-panel.md`): Public-facing announcement explaining the motivation (45% reduction in panel chrome), key architectural decisions, and open questions for community feedback
- **LinkedIn post** (`docs/posts/2026-02-03-planning-unified-activity-panel-linkedin.md`): Social media version of planning announcement
- **Implementation plan** (`specs/047-unified-activity-panel/plan.md`): Detailed roadmap including Constitution check (all articles pass), project structure, development order, and complexity tracking
- **Research document** (`specs/047-unified-activity-panel/research.md`): Answers to 9 key research questions covering collapsible section implementation (vscrui Pane), Tools panel conversion to React, Layers component reuse, message protocol design, VS Code registration, state persistence, and error isolation strategy
- **Data model** (`specs/047-unified-activity-panel/data-model.md`): Entity definitions for ActivityPanelState, ToolItem, SectionConfig, with state transition diagrams and validation rules
- **Quickstart guide** (`specs/047-unified-activity-panel/quickstart.md`): Step-by-step development order for implementing the 7 components (CollapsibleSection, ToolsList, ActivityPanel container, webview entry point, WebviewViewProvider, manifest update, esbuild config)
- **Component contracts** (`specs/047-unified-activity-panel/contracts/components.ts`): TypeScript interfaces defining the public API of ActivityPanel, CollapsibleSection, ToolsList, TimeControllerSection, and LayersSection props
- **Message contracts** (`specs/047-unified-activity-panel/contracts/messages.ts`): Typed message unions for bidirectional communication between extension host and webview (webview→host and host→webview)

## Key Design Decisions

1. **Single unified webview** replaces three separate panels, reducing chrome overhead by ~45% (132px → 72px)
2. **vscrui Pane component** for collapsible section headers (native VS Code styling, no custom accordion logic)
3. **New ToolsList React component** to replace native TreeDataProvider (enables cross-frontend reuse)
4. **Reuse existing FeatureList + LayersToolbar** for Layers section (already built in #045)
5. **React ErrorBoundary per section** for error isolation (failure in one section doesn't crash others)
6. **Session-scoped collapse state** via VS Code webview state API (resets on restart, no disk persistence)
7. **No new dependencies** — uses existing vscrui, React, and @debrief/session-state

## Architecture Highlights

- Shared components in `shared/components/src/` (ActivityPanel, CollapsibleSection, ToolsList) for cross-frontend reuse
- Thin VS Code integration layer in `apps/vscode/src/views/activityPanelView.ts` (WebviewViewProvider)
- Single message protocol extending existing TimeController pattern
- All Constitution articles pass (offline-capable, no VS Code API in shared components, schema-driven data, error isolation)

## Notes for Reviewers

- This is **planning and specification only** — no implementation code yet
- All documents follow the established spec structure (research → data model → quickstart → plan)
- Planning post is ready for publication to announce the feature to the community
- Implementation can proceed directly from the quickstart guide's development order

https://claude.ai/code/session_013bHpCLfMdYmoM2cqWLSjXn