### PR TITLE
Add font-family styling to ToolsPanel component

### DIFF
--- a/shared/components/src/ToolsPanel/ToolsPanel.css
+++ b/shared/components/src/ToolsPanel/ToolsPanel.css
@@ -6,6 +6,7 @@
 .debrief-tools-panel {
   display: flex;
   flex-direction: column;
+  font-family: var(--debrief-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
 }
 
 .debrief-tools-panel--empty {


### PR DESCRIPTION
## Summary
Added explicit font-family styling to the `.debrief-tools-panel` component to ensure consistent typography across the application.

## Changes
- Added `font-family` CSS property to `.debrief-tools-panel` class
- Uses CSS custom property `--debrief-font-family` with a sensible fallback stack: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
- This ensures the ToolsPanel respects the application's font theming while maintaining cross-platform compatibility

## Implementation Details
- The fallback font stack prioritizes system fonts for optimal performance and native appearance across macOS, iOS, Windows, and Android platforms
- Using a CSS variable allows for easy customization of the font family globally without modifying component code
- This change ensures the ToolsPanel inherits or respects the application's font configuration rather than relying on browser defaults

https://claude.ai/code/session_01NGLx6SwGkkiP4d6jpfGJKe