### PR TITLE
Auto-focus Debrief activity pane when opening plots

### DIFF
--- a/apps/vscode/src/commands/openPlot.ts
+++ b/apps/vscode/src/commands/openPlot.ts
@@ -520,6 +520,10 @@ export function createOpenPlotCommand(
       storeId,
       itemPath
     );
+
+    // Switch sidebar to Debrief activity pane so the analyst has
+    // tools, layers, and time controls ready immediately.
+    void vscode.commands.executeCommand('debrief.activityPanel.focus');
   };
 }
 


### PR DESCRIPTION
## Summary
When a plot is opened, the sidebar now automatically switches to the Debrief activity pane to provide immediate access to relevant tools, layers, and time controls.

## Changes
- Added command to focus the Debrief activity panel after a plot is opened
- This ensures analysts have quick access to essential controls without manual navigation

## Implementation Details
- The `debrief.activityPanel.focus` command is executed asynchronously (using `void`) after the plot is successfully opened
- Includes a clarifying comment explaining the UX benefit of this automatic focus behavior

https://claude.ai/code/session_01N7gobwHGgk1AnZi65VqADA