### PR TITLE
Add QuickSearch component for real-time title filtering

### DIFF
--- a/shared/components/src/FilterBar/FilterBar.css
+++ b/shared/components/src/FilterBar/FilterBar.css
@@ -28,6 +28,67 @@
   font-style: italic;
 }
 
+/* QuickSearch styles */
+.debrief-quick-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--vscode-input-background, #fff);
+  border: 1px solid var(--vscode-input-border, #ccc);
+  border-radius: 3px;
+  padding: 2px 6px;
+  min-width: 160px;
+  max-width: 260px;
+}
+
+.debrief-quick-search:focus-within {
+  border-color: var(--vscode-focusBorder, #0078d4);
+}
+
+.debrief-quick-search__icon {
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+  color: var(--vscode-descriptionForeground, #999);
+}
+
+.debrief-quick-search__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--vscode-input-foreground, #333);
+  font-size: 12px;
+  padding: 2px 0;
+  outline: none;
+  min-width: 0;
+}
+
+.debrief-quick-search__input::placeholder {
+  color: var(--vscode-input-placeholderForeground, #999);
+}
+
+.debrief-quick-search__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #999);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.debrief-quick-search__clear:hover {
+  color: var(--vscode-foreground, #333);
+  background: var(--vscode-list-hoverBackground, rgba(0, 0, 0, 0.04));
+}
+
 .debrief-filter-bar__error {
   background: var(--vscode-inputValidation-errorBackground, #fdd);
   border: 1px solid var(--vscode-inputValidation-errorBorder, #f44);

--- a/shared/components/src/FilterBar/FilterBar.stories.tsx
+++ b/shared/components/src/FilterBar/FilterBar.stories.tsx
@@ -399,6 +399,23 @@ export const VesselTaxonomyBranchSelection: Story = {
   },
 };
 
+export const QuickSearchDemo: Story = {
+  name: 'Quick Search',
+  render: () => (
+    <FilterBarWrapper items={MOCK_ITEMS} taxonomy={MOCK_TAXONOMY} />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Type in the Quick Search box to filter exercises by title in real-time. ' +
+          'Press Enter to "graduate" the search into a title lozenge. ' +
+          'Press Escape to clear. Keyboard shortcuts: "/" or Ctrl+F to focus.',
+      },
+    },
+  },
+};
+
 export const WithSavedFilters: Story = {
   name: 'With Saved Filters',
   render: () => {

--- a/shared/components/src/FilterBar/FilterBar.tsx
+++ b/shared/components/src/FilterBar/FilterBar.tsx
@@ -24,6 +24,7 @@ import { useTaxonomyMatchCounts } from './useTaxonomyMatchCounts';
 import { Lozenge } from './Lozenge';
 import { OrContainer } from './OrContainer';
 import { FilterTypeMenu } from './FilterTypeMenu';
+import { QuickSearch } from './QuickSearch';
 import { ValueEditor } from './ValueEditor';
 import { SaveFilterButton } from './SaveFilterButton';
 import { HistoricFiltersDropdown } from './HistoricFiltersDropdown';
@@ -74,6 +75,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [filteredItems, setFilteredItems] = useState<readonly StacBrowserItem[]>(items);
+  const [quickSearchText, setQuickSearchText] = useState('');
 
   const engine = useMemo(
     () => createFilterEngine({ taxonomy }),
@@ -87,29 +89,49 @@ export const FilterBar: React.FC<FilterBarProps> = ({
 
   const taxonomyCounts = useTaxonomyMatchCounts(filteredItems, taxonomy);
 
+  // Merge quick-search text into lozenge-based expression as an extra title predicate
+  const effectiveExpression: FilterExpression = useMemo(() => {
+    if (!quickSearchText) return expression;
+    return {
+      ...expression,
+      predicates: [
+        ...expression.predicates,
+        { type: 'title' as FilterType, value: quickSearchText },
+      ],
+    };
+  }, [expression, quickSearchText]);
+
   const cql2Json = useMemo(
-    () => engine.toCql2Json(expression),
-    [engine, expression],
+    () => engine.toCql2Json(effectiveExpression),
+    [engine, effectiveExpression],
   );
 
+  // Graduate quick-search into a title lozenge on Enter
+  const handleQuickSearchCommit = useCallback(
+    (text: string) => {
+      addLozenge('title' as FilterType, text);
+      setQuickSearchText('');
+    },
+    [addLozenge],
+  );
 
-  // Filter items whenever expression changes
+  // Filter items whenever effective expression changes
   const prevExpressionRef = useRef<FilterExpression | null>(null);
   useEffect(() => {
     // Skip if expression hasn't changed
-    if (prevExpressionRef.current === expression) return;
-    prevExpressionRef.current = expression;
+    if (prevExpressionRef.current === effectiveExpression) return;
+    prevExpressionRef.current = effectiveExpression;
 
     try {
-      const filtered = engine.filter(items, expression);
+      const filtered = engine.filter(items, effectiveExpression);
       setFilteredItems(filtered);
       onFilteredItems(filtered);
-      onExpressionChange?.(expression);
+      onExpressionChange?.(effectiveExpression);
       setError(null);
     } catch {
       setError(FILTER_ERROR_MESSAGE);
     }
-  }, [expression, items, engine, onFilteredItems, onExpressionChange]);
+  }, [effectiveExpression, items, engine, onFilteredItems, onExpressionChange]);
 
   // DnD sensors
   const sensors = useSensors(
@@ -227,6 +249,11 @@ export const FilterBar: React.FC<FilterBarProps> = ({
         )}
 
         <div className="debrief-filter-bar__items" data-testid="filter-bar-items">
+          <QuickSearch
+            onSearchChange={setQuickSearchText}
+            onCommit={handleQuickSearchCommit}
+          />
+
           {state.items.map((item) => {
             if (item.kind === 'lozenge') {
               return (
@@ -269,7 +296,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
             return null;
           })}
 
-          {isEmpty && (
+          {isEmpty && !quickSearchText && (
             <span className="debrief-filter-bar__hint" data-testid="filter-bar-hint">
               {EMPTY_STATE_HINT}
             </span>

--- a/shared/components/src/FilterBar/QuickSearch.tsx
+++ b/shared/components/src/FilterBar/QuickSearch.tsx
@@ -1,0 +1,147 @@
+/**
+ * QuickSearch — inline search input for fast title filtering.
+ *
+ * Always visible in the FilterBar. Typing filters items by title in real-time
+ * (debounced 200ms). Pressing Enter "graduates" the search text into a title
+ * lozenge. Pressing Escape clears the input without creating a lozenge.
+ *
+ * Keyboard shortcuts: Ctrl+F or "/" focuses the input from anywhere in the
+ * FilterBar's parent container.
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+
+export interface QuickSearchProps {
+  /** Called on every debounced keystroke with the current search text (empty string = cleared). */
+  readonly onSearchChange: (text: string) => void;
+  /** Called when user commits the search (Enter). Parent should create a title lozenge. */
+  readonly onCommit: (text: string) => void;
+  /** Placeholder text */
+  readonly placeholder?: string;
+}
+
+const DEBOUNCE_MS = 200;
+
+export const QuickSearch: React.FC<QuickSearchProps> = ({
+  onSearchChange,
+  onCommit,
+  placeholder = 'Quick search\u2026',
+}) => {
+  const [text, setText] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounced search callback
+  const debouncedSearch = useCallback(
+    (value: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onSearchChange(value);
+      }, DEBOUNCE_MS);
+    },
+    [onSearchChange],
+  );
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setText(value);
+      debouncedSearch(value);
+    },
+    [debouncedSearch],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && text.trim()) {
+        e.preventDefault();
+        // Flush any pending debounce — the commit takes precedence
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        onSearchChange(''); // Clear live filter — lozenge takes over
+        onCommit(text.trim());
+        setText('');
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        setText('');
+        onSearchChange('');
+        inputRef.current?.blur();
+      }
+    },
+    [text, onCommit, onSearchChange],
+  );
+
+  // Global keyboard shortcut: Ctrl+F or "/" focuses the input
+  useEffect(() => {
+    const handleGlobalKey = (e: KeyboardEvent) => {
+      // "/" when no input/textarea is focused
+      if (
+        e.key === '/' &&
+        !isEditableTarget(e.target)
+      ) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        return;
+      }
+      // Ctrl+F (or Cmd+F on Mac)
+      if (e.key === 'f' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleGlobalKey);
+    return () => document.removeEventListener('keydown', handleGlobalKey);
+  }, []);
+
+  return (
+    <div className="debrief-quick-search" data-testid="quick-search">
+      <span className="debrief-quick-search__icon" aria-hidden="true">&#x1F50D;</span>
+      <input
+        ref={inputRef}
+        className="debrief-quick-search__input"
+        type="text"
+        value={text}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        aria-label="Quick search by title"
+        data-testid="quick-search-input"
+      />
+      {text && (
+        <button
+          className="debrief-quick-search__clear"
+          onClick={() => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            setText('');
+            onSearchChange('');
+            inputRef.current?.focus();
+          }}
+          aria-label="Clear search"
+          data-testid="quick-search-clear"
+          title="Clear (Esc)"
+          type="button"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+};
+
+/** Returns true if the event target is an editable element (input, textarea, contenteditable). */
+function isEditableTarget(el: EventTarget | null): boolean {
+  if (!el || !('tagName' in el)) return false;
+  const tag = (el as HTMLElement).tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+  return false;
+}

--- a/shared/components/src/FilterBar/__tests__/QuickSearch.test.tsx
+++ b/shared/components/src/FilterBar/__tests__/QuickSearch.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { QuickSearch } from '../QuickSearch';
+
+describe('QuickSearch', () => {
+  let onSearchChange: ReturnType<typeof vi.fn>;
+  let onCommit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onSearchChange = vi.fn();
+    onCommit = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderQuickSearch() {
+    return render(
+      <QuickSearch onSearchChange={onSearchChange} onCommit={onCommit} />,
+    );
+  }
+
+  it('renders with placeholder text', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'Quick search\u2026');
+  });
+
+  it('renders custom placeholder', () => {
+    render(
+      <QuickSearch
+        onSearchChange={onSearchChange}
+        onCommit={onCommit}
+        placeholder="Find exercise..."
+      />,
+    );
+    expect(screen.getByTestId('quick-search-input')).toHaveAttribute(
+      'placeholder',
+      'Find exercise...',
+    );
+  });
+
+  it('calls onSearchChange after debounce when typing', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: 'alpha' } });
+
+    // Not called immediately
+    expect(onSearchChange).not.toHaveBeenCalled();
+
+    // Called after debounce
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onSearchChange).toHaveBeenCalledWith('alpha');
+  });
+
+  it('debounces rapid keystrokes — only fires once', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    act(() => { vi.advanceTimersByTime(100); });
+
+    fireEvent.change(input, { target: { value: 'al' } });
+    act(() => { vi.advanceTimersByTime(100); });
+
+    fireEvent.change(input, { target: { value: 'alp' } });
+    act(() => { vi.advanceTimersByTime(200); });
+
+    // Only the final value should have been dispatched
+    expect(onSearchChange).toHaveBeenCalledTimes(1);
+    expect(onSearchChange).toHaveBeenCalledWith('alp');
+  });
+
+  it('commits search on Enter and clears input', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: 'bravo' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('bravo');
+    // Clears the live search filter (lozenge takes over)
+    expect(onSearchChange).toHaveBeenCalledWith('');
+    expect(input).toHaveValue('');
+  });
+
+  it('does not commit on Enter when input is empty', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('does not commit on Enter when input is only whitespace', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('clears input and live search on Escape', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: 'charlie' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(input).toHaveValue('');
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('shows clear button when text is present', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    // No clear button initially
+    expect(screen.queryByTestId('quick-search-clear')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'delta' } });
+    expect(screen.getByTestId('quick-search-clear')).toBeInTheDocument();
+  });
+
+  it('clears input when clear button is clicked', () => {
+    renderQuickSearch();
+    const input = screen.getByTestId('quick-search-input');
+
+    fireEvent.change(input, { target: { value: 'echo' } });
+    fireEvent.click(screen.getByTestId('quick-search-clear'));
+
+    expect(input).toHaveValue('');
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  describe('keyboard shortcuts', () => {
+    it('focuses input on "/" key when not in an editable field', () => {
+      renderQuickSearch();
+      const input = screen.getByTestId('quick-search-input');
+
+      // Dispatch on document body (non-editable)
+      fireEvent.keyDown(document, { key: '/' });
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('focuses input on Ctrl+F', () => {
+      renderQuickSearch();
+      const input = screen.getByTestId('quick-search-input');
+
+      fireEvent.keyDown(document, { key: 'f', ctrlKey: true });
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('does not focus on "/" when already in an input', () => {
+      renderQuickSearch();
+
+      // Create a separate input and focus it
+      const other = document.createElement('input');
+      document.body.appendChild(other);
+      other.focus();
+
+      fireEvent.keyDown(other, { key: '/' });
+
+      // Quick search should NOT be focused — the other input should retain focus
+      expect(document.activeElement).toBe(other);
+
+      document.body.removeChild(other);
+    });
+  });
+});

--- a/shared/components/src/FilterBar/index.ts
+++ b/shared/components/src/FilterBar/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { FilterBar } from './FilterBar';
+export { QuickSearch } from './QuickSearch';
 export { useFilterBar } from './useFilterBar';
 export { useDistinctValues } from './useDistinctValues';
 export { taxonomyToCascadingItems } from './taxonomyAdapter';


### PR DESCRIPTION
## Summary
Introduces a new `QuickSearch` component that provides fast, real-time filtering of items by title in the FilterBar. Users can type to filter instantly (debounced), press Enter to "graduate" the search into a title lozenge, or press Escape to clear. Keyboard shortcuts (Ctrl+F or "/") focus the input from anywhere.

## Key Changes
- **New QuickSearch component** (`QuickSearch.tsx`): 
  - Debounced search input (200ms) that calls `onSearchChange` on every keystroke
  - Enter key commits the search text as a title lozenge via `onCommit`
  - Escape key clears the input without creating a lozenge
  - Clear button (×) appears when text is present
  - Global keyboard shortcuts: "/" (when not in an editable field) and Ctrl+F focus the input
  - Proper cleanup of debounce timers on unmount

- **Comprehensive test suite** (`QuickSearch.test.tsx`):
  - Tests debouncing behavior with rapid keystrokes
  - Tests Enter/Escape key handling
  - Tests clear button functionality
  - Tests keyboard shortcuts (/, Ctrl+F) with proper handling of editable fields
  - Tests placeholder customization

- **FilterBar integration**:
  - Merges quick-search text into the filter expression as an additional title predicate
  - Quick-search filters live while typing; Enter graduates it into a persistent lozenge
  - Hides empty state hint when quick-search is active

- **Styling** (`FilterBar.css`):
  - VSCode-themed input styling with focus states
  - Magnifying glass icon and clear button
  - Responsive sizing (160px–260px width)

- **Storybook story**: Added "Quick Search" demo story with usage documentation

## Implementation Details
- Quick-search text is kept separate from the lozenge-based expression and merged at filter time
- The `isEditableTarget()` utility prevents "/" from triggering when already typing in inputs/textareas
- Debounce is properly flushed on Enter to ensure the committed text is the final value
- Component is exported from the FilterBar index for public use

https://claude.ai/code/session_01TUM6W1vBctj29j4HYbdMgk