### PR TITLE
docs: Add specification and planning for sensor schema overhaul (#116)

### DIFF
--- a/specs/116-sensor-schema-overhaul/checklists/requirements.md
+++ b/specs/116-sensor-schema-overhaul/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Sensor Schema Overhaul
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- This is a schema/service feature — no UI Feature Validation section applies.
+- The spec makes informed assumptions where the epic document provides clear guidance (bearing accuracy exclusion, color format, coordinate convention).
+- No [NEEDS CLARIFICATION] markers were needed — the E07 epic document provides comprehensive field definitions, legacy source references, and explicit architectural decisions.

--- a/specs/116-sensor-schema-overhaul/contracts/schema-contract.md
+++ b/specs/116-sensor-schema-overhaul/contracts/schema-contract.md
@@ -1,0 +1,92 @@
+# Schema Contract: Sensor Schema Overhaul (#116)
+
+This feature defines data schemas, not service APIs. The "contract" is the schema itself — the shapes that all producers and consumers of sensor data must conform to.
+
+## Contract: SensorContact Shape
+
+All components producing or consuming SensorContact data MUST conform to the LinkML-generated schema. The canonical shapes are defined in:
+
+- **Source**: `shared/schemas/src/linkml/geojson.yaml` → `SensorContact` class
+- **Python**: `debrief_schemas.SensorContact` (Pydantic model)
+- **TypeScript**: `SensorContact` interface in `@debrief/schemas`
+- **JSON Schema**: `shared/schemas/src/generated/json-schema/SensorContact.json`
+
+### Required Fields
+
+```json
+{
+  "time": "2026-01-09T10:00:00Z",
+  "bearing": 45.0
+}
+```
+
+### Full Shape (all optional fields shown)
+
+```json
+{
+  "time": "2026-01-09T10:00:00Z",
+  "bearing": 45.0,
+  "has_bearing": true,
+  "ambiguous_bearing": 225.0,
+  "has_ambiguous": true,
+  "range": 5000.0,
+  "frequency": 152.3,
+  "has_frequency": true,
+  "label": "C1",
+  "comment": "Initial contact",
+  "color": "#FF0000",
+  "visible": true,
+  "show_label": false,
+  "line_style": "SOLID",
+  "label_location": "LEFT",
+  "put_label_at": "MIDDLE",
+  "origin": [-5.0, 50.0]
+}
+```
+
+## Contract: SensorData Shape
+
+### Required Fields
+
+```json
+{
+  "name": "TOWED_ARRAY",
+  "contacts": []
+}
+```
+
+### Full Shape (all optional fields shown)
+
+```json
+{
+  "name": "TOWED_ARRAY",
+  "base_frequency": 150.0,
+  "offset": 200.0,
+  "array_centre_mode": "PLAIN",
+  "worm_in_hole": false,
+  "color": "#0066CC",
+  "visible": true,
+  "line_thickness": 2,
+  "contacts": [],
+  "measured_positions": [
+    {
+      "time": "2026-01-09T10:00:00Z",
+      "latitude": 50.0,
+      "longitude": -5.0
+    }
+  ]
+}
+```
+
+## Contract: Enum Values
+
+| Enum | Values |
+|------|--------|
+| ArrayCentreModeEnum | PLAIN, WORM, MEASURED |
+| LineStyleEnum | SOLID, DASHED, DOT, DASH_DOT |
+| LabelLocationEnum | LEFT, CENTER, RIGHT |
+| LineLabelPositionEnum | START, MIDDLE, END |
+
+## Backward Compatibility
+
+Existing data with only the pre-overhaul fields (time, bearing, range, frequency, ambiguous_bearing, label, comment for contacts; name, base_frequency, offset, worm_in_hole, contacts for sensors) MUST continue to validate without modification.

--- a/specs/116-sensor-schema-overhaul/data-model.md
+++ b/specs/116-sensor-schema-overhaul/data-model.md
@@ -31,7 +31,7 @@ Single sensor observation at a point in time. Belongs to exactly one SensorData 
 | has_frequency | boolean | no | null | — | Frequency data presence flag |
 | label | string | no | null | — | Display label |
 | comment | string | no | null | — | Operator notes |
-| color | string | no | null | — | Contact color override (CSS hex; null = inherit from sensor) |
+| color | CSSColor | no | null | — | Contact color override (null = inherit from sensor) |
 | visible | boolean | no | true | — | Contact visibility |
 | show_label | boolean | no | false | — | Label visibility |
 | line_style | LineStyleEnum | no | null | SOLID, DASHED, DOT, DASH_DOT | Bearing line style |
@@ -69,7 +69,7 @@ Named sensor instrument attached to a track. Contains configuration, display def
 | offset | float | no | null | — | Array offset from platform reference (metres) |
 | array_centre_mode | ArrayCentreModeEnum | no | null | PLAIN, WORM, MEASURED | How bearing line origin is calculated |
 | worm_in_hole | boolean | no | false | — | Display mode flag |
-| color | string | no | null | — | Default color for all contacts (CSS hex) |
+| color | CSSColor | no | null | — | Default color for all contacts |
 | visible | boolean | no | true | — | Sensor visibility |
 | line_thickness | integer | no | null | — | Bearing line width |
 | contacts | SensorContact[] | yes | — | — | Time-ordered sensor observations |
@@ -93,8 +93,7 @@ Timestamped geographic position of a towed array centre.
 | Field | Type | Required | Default | Constraint | Notes |
 |-------|------|----------|---------|------------|-------|
 | time | datetime | yes | — | ISO8601 | Position timestamp |
-| latitude | float | yes | — | — | Array centre latitude |
-| longitude | float | yes | — | — | Array centre longitude |
+| location | float[2] | yes | — | [lon, lat] | Array centre position (GeoJSON coordinate order) |
 
 ## New Enumerations
 
@@ -119,6 +118,12 @@ Visual style for bearing lines.
 | DOT | Evenly spaced dots |
 | DASH_DOT | Alternating dash and dot |
 
+> **Rendering mapping**: At render time, LineStyleEnum maps to SVG/Leaflet `dash_array` values:
+> SOLID → `null` (no dash), DASHED → `"10, 5"`, DOT → `"2, 5"`, DASH_DOT → `"10, 5, 2, 5"`.
+> This mapping is defined as a code constant in the rendering layer (Phase 3, #118), not in the schema.
+> The existing `LineProperties.dash_array` field in `styling.yaml` is the lower-level representation;
+> `LineStyleEnum` is the semantic label stored in sensor data.
+
 ### LabelLocationEnum
 
 Horizontal alignment of contact labels.
@@ -138,6 +143,16 @@ Position along the bearing line where the label is placed.
 | START | At the origin (sensor location) |
 | MIDDLE | At the midpoint of the bearing line |
 | END | At the far end of the bearing line |
+
+## Boolean Presence Flag Pattern
+
+The `has_bearing`, `has_ambiguous`, and `has_frequency` flags follow a legacy pattern where the boolean controls **display**, not data presence. A contact with `has_bearing=false` and `bearing=045.0` is valid — the bearing value is stored but not displayed. This pattern exists because legacy Debrief stores raw sensor values unconditionally; the flags determine which values are shown to the operator.
+
+**Key implications for developers**:
+- Do NOT treat `has_bearing=false` as "bearing is absent" — the value is still there
+- Rendering code should check the flag before drawing bearing lines
+- Schema validation accepts any `bearing` value regardless of the flag
+- The same pattern applies to `has_ambiguous` and `has_frequency`
 
 ## Entity Relationships
 

--- a/specs/116-sensor-schema-overhaul/data-model.md
+++ b/specs/116-sensor-schema-overhaul/data-model.md
@@ -1,0 +1,167 @@
+# Data Model: Sensor Schema Overhaul (#116)
+
+**Date**: 2026-04-10
+**Feature**: 116-sensor-schema-overhaul
+**Spec**: [spec.md](spec.md) | **Research**: [research.md](research.md)
+
+## Entity Overview
+
+```
+TrackProperties
+ └── sensors: SensorData[]
+      ├── measured_positions: MeasuredArrayPosition[]
+      └── contacts: SensorContact[]
+```
+
+## SensorContact (updated)
+
+Single sensor observation at a point in time. Belongs to exactly one SensorData parent.
+
+### Fields
+
+| Field | Type | Required | Default | Constraint | Notes |
+|-------|------|----------|---------|------------|-------|
+| time | datetime | yes | — | ISO8601 | Observation timestamp |
+| bearing | float | yes | — | 0 ≤ x ≤ 360 | Primary bearing in degrees |
+| has_bearing | boolean | no | true | — | Controls display; data stored regardless |
+| ambiguous_bearing | float | no | null | 0 ≤ x ≤ 360 | Alternative bearing for towed arrays |
+| has_ambiguous | boolean | no | null | — | Ambiguous bearing active flag |
+| range | float | no | null | ≥ 0 | Target distance in metres |
+| frequency | float | no | null | — | Received frequency in Hz |
+| has_frequency | boolean | no | null | — | Frequency data presence flag |
+| label | string | no | null | — | Display label |
+| comment | string | no | null | — | Operator notes |
+| color | string | no | null | — | Contact color override (CSS hex; null = inherit from sensor) |
+| visible | boolean | no | true | — | Contact visibility |
+| show_label | boolean | no | false | — | Label visibility |
+| line_style | LineStyleEnum | no | null | SOLID, DASHED, DOT, DASH_DOT | Bearing line style |
+| label_location | LabelLocationEnum | no | null | LEFT, CENTER, RIGHT | Label horizontal alignment |
+| put_label_at | LineLabelPositionEnum | no | null | START, MIDDLE, END | Label position on bearing line |
+| origin | float[2] | no | null | [lon, lat] | Explicit sensor location override |
+
+### Changes from Current Schema
+
+| Status | Fields |
+|--------|--------|
+| Existing (unchanged) | time, bearing, range, frequency, ambiguous_bearing, label, comment |
+| New data fields | has_bearing, has_ambiguous, has_frequency |
+| New display fields | color, visible, show_label, line_style, label_location, put_label_at |
+| New positioning field | origin |
+
+### Validation Rules
+
+- `bearing` must be between 0 and 360 inclusive (existing)
+- `ambiguous_bearing` must be between 0 and 360 inclusive (existing)
+- `range` must be ≥ 0 (existing)
+- `origin` must be exactly 2 elements when present (follows CircleAnnotation.center pattern)
+- `has_bearing=false` with a bearing value present is valid (flag controls display, not data presence)
+
+## SensorData (updated)
+
+Named sensor instrument attached to a track. Contains configuration, display defaults, and contacts.
+
+### Fields
+
+| Field | Type | Required | Default | Constraint | Notes |
+|-------|------|----------|---------|------------|-------|
+| name | string | yes | — | — | Sensor identifier (e.g., "TOWED_ARRAY") |
+| base_frequency | float | no | null | — | Source transmitted frequency for Doppler (Hz) |
+| offset | float | no | null | — | Array offset from platform reference (metres) |
+| array_centre_mode | ArrayCentreModeEnum | no | null | PLAIN, WORM, MEASURED | How bearing line origin is calculated |
+| worm_in_hole | boolean | no | false | — | Display mode flag |
+| color | string | no | null | — | Default color for all contacts (CSS hex) |
+| visible | boolean | no | true | — | Sensor visibility |
+| line_thickness | integer | no | null | — | Bearing line width |
+| contacts | SensorContact[] | yes | — | — | Time-ordered sensor observations |
+| measured_positions | MeasuredArrayPosition[] | no | null | — | Actual array positions for MEASURED mode |
+
+### Changes from Current Schema
+
+| Status | Fields |
+|--------|--------|
+| Existing (unchanged) | name, base_frequency, offset, worm_in_hole, contacts |
+| New configuration field | array_centre_mode |
+| New display fields | color, visible, line_thickness |
+| New positioning field | measured_positions |
+
+## MeasuredArrayPosition (new)
+
+Timestamped geographic position of a towed array centre.
+
+### Fields
+
+| Field | Type | Required | Default | Constraint | Notes |
+|-------|------|----------|---------|------------|-------|
+| time | datetime | yes | — | ISO8601 | Position timestamp |
+| latitude | float | yes | — | — | Array centre latitude |
+| longitude | float | yes | — | — | Array centre longitude |
+
+## New Enumerations
+
+### ArrayCentreModeEnum
+
+Determines how bearing line origin is calculated relative to the host platform.
+
+| Value | Description |
+|-------|-------------|
+| PLAIN | Simple backtrack along vessel's current heading |
+| WORM | Follow vessel's historical track path backwards |
+| MEASURED | Use actual measured array position data |
+
+### LineStyleEnum
+
+Visual style for bearing lines.
+
+| Value | Description |
+|-------|-------------|
+| SOLID | Continuous line |
+| DASHED | Evenly spaced dashes |
+| DOT | Evenly spaced dots |
+| DASH_DOT | Alternating dash and dot |
+
+### LabelLocationEnum
+
+Horizontal alignment of contact labels.
+
+| Value | Description |
+|-------|-------------|
+| LEFT | Left-aligned text |
+| CENTER | Center-aligned text |
+| RIGHT | Right-aligned text |
+
+### LineLabelPositionEnum
+
+Position along the bearing line where the label is placed.
+
+| Value | Description |
+|-------|-------------|
+| START | At the origin (sensor location) |
+| MIDDLE | At the midpoint of the bearing line |
+| END | At the far end of the bearing line |
+
+## Entity Relationships
+
+```
+TrackFeature
+ └── properties: TrackProperties
+      └── sensors: SensorData[]                    (0..*)
+           ├── contacts: SensorContact[]            (1..*, required)
+           │    ├── line_style → LineStyleEnum
+           │    ├── label_location → LabelLocationEnum
+           │    └── put_label_at → LineLabelPositionEnum
+           ├── measured_positions: MeasuredArrayPosition[]  (0..*)
+           └── array_centre_mode → ArrayCentreModeEnum
+```
+
+## Color Inheritance Pattern
+
+SensorContact color resolution follows legacy behavior:
+1. If `contact.color` is set → use contact color
+2. If `contact.color` is null → inherit from `sensor.color`
+3. If `sensor.color` is also null → use application default
+
+This is a runtime behavior, not a schema constraint. The schema only stores the values; resolution logic belongs to the rendering layer (Phase 3, #118).
+
+## Embedding Location
+
+SensorData remains embedded under `TrackProperties.sensors[]` — no change to the parent structure. The compound track model (#062) established this embedding pattern and it is preserved.

--- a/specs/116-sensor-schema-overhaul/media/linkedin-planning.md
+++ b/specs/116-sensor-schema-overhaul/media/linkedin-planning.md
@@ -1,0 +1,9 @@
+Our sensor schema currently captures 12 fields across SensorContact and SensorData. Legacy Debrief uses 26, plus 4 enumerations and a measured array position class. That gap means display customizations vanish on save, towed array bearing lines originate from the wrong position, and there's no way to distinguish "no bearing data" from "bearing is zero."
+
+This week we're closing that gap — expanding the schema to capture the full legacy sensor data model. Phase 1 of a 7-phase sensor pipeline, and the foundation everything else builds on. All changes are additive, zero breaking changes, 62 fixture files updated.
+
+The interesting design question: should display properties (color, line style, label placement) live in the data schema or in a separate rendering layer? We chose schema-level, matching how legacy persists them. Trade-offs worth discussing.
+
+[Read the full planning post](https://debrief.github.io/blog/planning-sensor-schema-overhaul)
+
+#FutureDebrief #MaritimeAnalysis #OpenSource

--- a/specs/116-sensor-schema-overhaul/media/planning-post.md
+++ b/specs/116-sensor-schema-overhaul/media/planning-post.md
@@ -1,0 +1,46 @@
+---
+layout: future-post
+title: "Planning: Sensor Schema Overhaul"
+date: 2026-04-10
+track: [momentum]
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, schemas, sensor-data]
+excerpt: "Redesigning SensorContact and SensorData schemas to capture the full legacy sensor model — Phase 1 of 7"
+---
+
+## What We're Building
+
+Legacy Debrief has roughly 10,000 lines of Java across 30+ files handling sensor data — towed arrays, bearing lines, frequency measurements, array offset calculations. Our current schema captures a fraction of that: 7 fields on SensorContact and 5 on SensorData. Enough to store a bearing and a timestamp, but not enough to faithfully represent what analysts actually configure and rely on.
+
+This week we're expanding the schema to close that gap. SensorContact goes from 7 fields to 16: display properties (color, visibility, line style, label placement), boolean presence flags (has_bearing, has_ambiguous, has_frequency), and an explicit origin coordinate override for when the sensor location differs from the platform position. SensorData goes from 5 to 10 fields, gaining array centre mode (PLAIN, WORM, MEASURED), display defaults, and a new measured_positions array for recording actual towed array locations.
+
+There are also 4 new enumerations (ArrayCentreModeEnum, LineStyleEnum, LabelLocationEnum, LineLabelPositionEnum) and a new MeasuredArrayPosition class. And because 9 existing sensor tool specifications reference SensorContact and SensorData shapes, we're updating 62 golden fixture JSON files to match.
+
+All new fields are optional. Zero breaking changes. Existing valid fixtures continue to validate without modification.
+
+## How It Fits
+
+This is Phase 1 of a 7-phase Sensor Data Pipeline epic. The schema is the foundation — every subsequent phase depends on it. Phase 2 (REP sensor import) needs these fields to have somewhere to write the parsed data. Phase 3 (sensor rendering on maps) needs the display properties and array centre modes to know how to draw bearing lines. Phase 4 (array offset calculations) needs the measured positions and offset fields.
+
+The existing schema got us through early prototyping, but it was always a placeholder. Without display properties, an analyst's visual customizations vanish on save/reload. Without array centre mode, every bearing line originates from the platform position, which is wrong for towed arrays. Without presence flags, there's no way to distinguish "this contact has no bearing data" from "the bearing is zero degrees."
+
+## Key Decisions
+
+- **Display properties live in the schema, not a separate styling layer.** Legacy Debrief stores color, line style, and label placement alongside the data in the REP file. Customizations persist with the data. We're matching that behavior rather than introducing a separate rendering configuration. The trade-off is a larger schema, but the alternative is a persistence fidelity problem where display settings get lost.
+
+- **Boolean presence flags default to true.** In legacy, sensor data is assumed present unless explicitly flagged otherwise. A contact with has_bearing=false but a bearing value of 045 is valid — the flag controls display, not data presence. The raw value is always stored.
+
+- **SensorContact origin uses a [lon, lat] array**, consistent with the existing pattern in CircleAnnotation and VectorAnnotation. MeasuredArrayPosition currently uses separate latitude/longitude fields — whether to align that with the [lon, lat] convention is an open question (see below).
+
+- **All 4 new enums go in common.yaml** alongside existing project enums, not in a sensor-specific file. They may be reused by other feature types later.
+
+- **Purely additive changes** — every new field is optional, every new enum is referenced only by optional fields. Backward compatibility is preserved by design.
+
+## What We'd Love Feedback On
+
+- **Display properties at the schema level vs. a separate rendering configuration.** We chose schema-level for persistence fidelity — if it's in the REP file, it should be in the schema. But this means the data model carries visual concerns. For a domain where analysts spend significant time customizing displays and expect those customizations to survive save/reload cycles, that feels right. But there's a legitimate argument that rendering concerns should be separated. What's the right boundary?
+
+- **MeasuredArrayPosition coordinate format.** We're using separate latitude/longitude fields here, which is inconsistent with the [lon, lat] array pattern used elsewhere in the schema. The spec calls for separate fields because measured positions are standalone records (not embedded in GeoJSON geometry), but consistency has value. Should we use [lon, lat] arrays for MeasuredArrayPosition too?
+
+-> [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/116-sensor-schema-overhaul/plan.md
+++ b/specs/116-sensor-schema-overhaul/plan.md
@@ -27,7 +27,7 @@ Redesign SensorContact and SensorData in LinkML to fully capture the legacy Debr
 |---------|-------------|--------|-------|
 | I. Defence-Grade Reliability | Offline by default | PASS | Schema definition — no network dependency |
 | II. Schema Integrity | Single source of truth (LinkML) | PASS | All changes in LinkML; Pydantic/JSON Schema/TS are generated |
-| II.2 | Schema tests mandatory | PASS | Golden fixtures + round-trip tests cover all new fields |
+| II.2 | Schema tests mandatory | PASS | Golden fixtures + round-trip tests (Python + TypeScript) + schema comparison + enum exhaustiveness + constraint edge cases |
 | II.3 | Schema versioning for breaking changes | PASS | No breaking changes — all new fields are optional |
 | III. Data Sovereignty | Provenance always | N/A | Schema definition only; no data transformation |
 | IV. Architectural Boundaries | Services never touch UI | PASS | Schema defines data structure; display property storage is not UI logic |
@@ -71,21 +71,28 @@ shared/schemas/
 │   │   └── json-schema/*.json                  # AUTO-GENERATED
 │   └── fixtures/
 │       ├── valid/
-│       │   ├── track-feature-sensors-01.json           # EXISTING (backward compat)
-│       │   ├── track-feature-sensors-02.json           # NEW: all fields
-│       │   ├── track-feature-sensors-measured-01.json  # NEW: MEASURED mode
-│       │   └── track-feature-sensors-minimal-01.json   # NEW: minimal
+│       │   ├── track-feature-sensors-01.json              # EXISTING (backward compat)
+│       │   ├── track-feature-sensors-02.json              # NEW: all fields
+│       │   ├── track-feature-sensors-measured-01.json     # NEW: MEASURED mode
+│       │   ├── track-feature-sensors-minimal-01.json      # NEW: minimal
+│       │   └── track-feature-sensors-boundary-01.json     # NEW: bearing=0/360, empty measured_positions
 │       └── invalid/
-│           ├── track-feature-sensor-no-bearing.json       # EXISTING
-│           ├── track-feature-sensor-invalid-enum.json      # NEW
-│           ├── track-feature-sensor-invalid-origin.json    # NEW
-│           └── track-feature-sensor-bearing-range.json     # NEW
+│           ├── track-feature-sensor-no-bearing.json          # EXISTING
+│           ├── track-feature-sensor-invalid-enum.json         # NEW
+│           ├── track-feature-sensor-invalid-origin.json       # NEW
+│           ├── track-feature-sensor-bearing-range.json        # NEW
+│           ├── track-feature-sensor-bearing-negative.json     # NEW: bearing=-1
+│           ├── track-feature-sensor-bearing-over360.json      # NEW: bearing=361
+│           └── track-feature-sensor-origin-wrong-length.json  # NEW: origin with 1 element
 ├── scripts/
 │   └── generate.py              # NO CHANGE (existing post-processing sufficient)
 └── tests/
     ├── test_golden.py           # NO CHANGE (auto-discovers fixtures)
     ├── test_roundtrip.py        # NO CHANGE (auto-discovers fixtures)
-    └── test_validation.py       # NO CHANGE
+    ├── test_validation.py       # NO CHANGE
+    ├── test_schema_compare.py   # EXTEND: add SensorData, SensorContact, 4 new enums
+    ├── test_sensor_enums.py     # NEW: parametrized enum exhaustiveness test
+    └── test_tool_fixtures.py    # NEW: validate tool fixture JSON against schema
 
 shared/tools/sensor/
 ├── analysis/                    # UPDATE: 38 fixture JSON files
@@ -110,3 +117,37 @@ None — no extension workflow changes. The schema changes are transparent to th
 ## Complexity Tracking
 
 No Constitution violations to justify — all gates pass cleanly.
+
+## Review Decisions
+
+Decisions from `/speckit.review` session (2026-04-10). These amend the original plan.
+
+### Architecture (5A)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | MeasuredArrayPosition uses `location: float[2]` [lon, lat] instead of separate lat/lon | Aligns with GeoJSON coordinate convention used by CircleAnnotation.center and all other coordinate pairs in the codebase |
+| 2 | Add generation verification test for optional `float[2]` coordinate pairs | Catches LinkML/Pydantic drift on tuple-shaped optional fields (MeasuredArrayPosition.location, SensorContact.origin) |
+| 3 | Full rewrite of 62 tool fixtures to embedded SensorData pattern | Avoids schema-fixture divergence; higher upfront effort but prevents accumulating technical debt |
+
+### Design Quality (5B)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 4 | Use `CSSColor` type (not plain `string`) for sensor color fields | Consistent with every other color field in the schema; adds regex validation via existing custom type |
+| 5 | LineStyleEnum is the canonical semantic label; a code constant maps to `dash_array` at render time | Single representation in data model; rendering layer owns the translation. Fix importers to produce enum values |
+| 6 | Document boolean presence flag pattern (has_bearing etc.) prominently in data-model.md | Prevents future developer confusion about "required field with a boolean that says it's not really there" |
+| 7 | Add pytest parametrized test validating tool fixture JSON against schema | Ensures correctness of 62-file rewrite; existing test infrastructure has no coverage for tool fixtures |
+
+### Test Coverage (5C)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 8 | Add TypeScript round-trip test (JSON → TS → JSON) | Required by CLAUDE.md test strategy; catches Pydantic↔TypeScript type drift |
+| 9 | Extend test_schema_compare.py for SensorData, SensorContact, 4 new enums | Required by CLAUDE.md; catches LinkML↔Pydantic JSON Schema drift |
+| 10 | Add parametrized enum exhaustiveness test for all 4 new enums | Catches enum definition mismatches; ensures every valid value passes validation |
+| 11 | Add 4+ boundary fixtures for constraint edge cases | Covers bearing=0/360 (valid), bearing=-1/361 (invalid), empty measured_positions (valid), origin cardinality (invalid) |
+
+### Performance (5D)
+
+No issues. Schema-only feature; data volumes well within memory budgets at realistic scales (1000 contacts ≈ 455 KB).

--- a/specs/116-sensor-schema-overhaul/plan.md
+++ b/specs/116-sensor-schema-overhaul/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Sensor Schema Overhaul
+
+**Branch**: `116-sensor-schema-overhaul` | **Date**: 2026-04-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/116-sensor-schema-overhaul/spec.md`
+
+## Summary
+
+Redesign SensorContact and SensorData in LinkML to fully capture the legacy Debrief sensor data model. Add 4 new enums, 9 new SensorContact fields (boolean presence flags, display properties, origin coordinate pair), 4 new SensorData fields (array centre mode, display properties, measured positions), and a new MeasuredArrayPosition class. Update the schema generation pipeline output, create comprehensive golden fixtures, and update all 9 sensor tool spec fixtures (62 JSON files).
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (schema generation, tests), TypeScript 5.x (generated types, consumer components)
+**Primary Dependencies**: LinkML >= 1.7.0 (schema source), Pydantic v2 (Python validation), gen-pydantic / gen-json-schema / gen-typescript (code generators)
+**Storage**: Local filesystem — STAC Items with GeoJSON payloads containing embedded sensor data
+**Testing**: pytest (schema validation, round-trip, golden fixtures), vitest (TypeScript consumer tests)
+**Target Platform**: Cross-platform (offline-first desktop analysis tool)
+**Project Type**: Monorepo — schema definitions generate code consumed by multiple packages
+**Performance Goals**: N/A — schema definition, no runtime performance concern
+**Constraints**: Offline-capable (Constitution Art. I), schema tests mandatory (Constitution Art. II), all derived schemas auto-generated from LinkML (Constitution Art. II.1)
+**Scale/Scope**: 3 schema files modified, ~62 tool fixture files updated, 6+ golden fixtures created
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Requirement | Status | Notes |
+|---------|-------------|--------|-------|
+| I. Defence-Grade Reliability | Offline by default | PASS | Schema definition — no network dependency |
+| II. Schema Integrity | Single source of truth (LinkML) | PASS | All changes in LinkML; Pydantic/JSON Schema/TS are generated |
+| II.2 | Schema tests mandatory | PASS | Golden fixtures + round-trip tests cover all new fields |
+| II.3 | Schema versioning for breaking changes | PASS | No breaking changes — all new fields are optional |
+| III. Data Sovereignty | Provenance always | N/A | Schema definition only; no data transformation |
+| IV. Architectural Boundaries | Services never touch UI | PASS | Schema defines data structure; display property storage is not UI logic |
+| VI. Testing | Schema tests gate merges | PASS | Existing test infrastructure auto-discovers new fixtures |
+| VI.2 | Services require unit tests | PASS | Schema tests serve as unit tests for the data model |
+| VII. Test-Driven AI | Tests before implementation | PASS | Golden fixtures define expected behavior before schema changes |
+| VIII. Documentation | Specs before code | PASS | This plan and spec.md precede implementation |
+| IX. Dependencies | Minimal, vetted dependencies | PASS | No new dependencies — uses existing LinkML/Pydantic toolchain |
+| XIV. Pre-Release Freedom | Breaking changes permitted | PASS | But not needed — all changes are additive |
+| XV. Strict Type Safety | Explicit types everywhere | PASS | LinkML generates fully typed models; no Any/any in output |
+
+**Gate result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/116-sensor-schema-overhaul/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Technical decisions and rationale
+├── data-model.md        # Entity definitions and relationships
+├── quickstart.md        # Developer onboarding guide
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Task breakdown (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+shared/schemas/
+├── src/
+│   ├── linkml/
+│   │   ├── common.yaml          # ADD: 4 new enums
+│   │   └── geojson.yaml         # MODIFY: SensorContact, SensorData, ADD: MeasuredArrayPosition
+│   ├── generated/
+│   │   ├── python/debrief_schemas/__init__.py  # AUTO-GENERATED
+│   │   ├── typescript/types.ts                 # AUTO-GENERATED
+│   │   └── json-schema/*.json                  # AUTO-GENERATED
+│   └── fixtures/
+│       ├── valid/
+│       │   ├── track-feature-sensors-01.json           # EXISTING (backward compat)
+│       │   ├── track-feature-sensors-02.json           # NEW: all fields
+│       │   ├── track-feature-sensors-measured-01.json  # NEW: MEASURED mode
+│       │   └── track-feature-sensors-minimal-01.json   # NEW: minimal
+│       └── invalid/
+│           ├── track-feature-sensor-no-bearing.json       # EXISTING
+│           ├── track-feature-sensor-invalid-enum.json      # NEW
+│           ├── track-feature-sensor-invalid-origin.json    # NEW
+│           └── track-feature-sensor-bearing-range.json     # NEW
+├── scripts/
+│   └── generate.py              # NO CHANGE (existing post-processing sufficient)
+└── tests/
+    ├── test_golden.py           # NO CHANGE (auto-discovers fixtures)
+    ├── test_roundtrip.py        # NO CHANGE (auto-discovers fixtures)
+    └── test_validation.py       # NO CHANGE
+
+shared/tools/sensor/
+├── analysis/                    # UPDATE: 38 fixture JSON files
+├── calibration/                 # UPDATE: 18 fixture JSON files
+└── detection/                   # UPDATE: 2 fixture JSON files (buffer-zone-generator)
+```
+
+**Structure Decision**: Schema-only feature — all changes are in `shared/schemas/` (LinkML definitions, generated code, fixtures) and `shared/tools/sensor/` (tool spec fixtures). No new directories or packages needed.
+
+## Media Components
+
+None — backend/infrastructure feature. This is a schema definition change with no visual components.
+
+## Storybook E2E Testing
+
+None — no interactive UI components. Schema changes are validated through golden fixtures and round-trip tests.
+
+## VS Code Webview E2E Testing
+
+None — no extension workflow changes. The schema changes are transparent to the VS Code extension until Phase 3 (rendering).
+
+## Complexity Tracking
+
+No Constitution violations to justify — all gates pass cleanly.

--- a/specs/116-sensor-schema-overhaul/quickstart.md
+++ b/specs/116-sensor-schema-overhaul/quickstart.md
@@ -1,0 +1,131 @@
+# Quickstart: Sensor Schema Overhaul (#116)
+
+**Date**: 2026-04-10
+**Feature**: 116-sensor-schema-overhaul
+
+## What This Feature Does
+
+Redesigns the SensorContact and SensorData schemas in LinkML to fully capture the legacy Debrief sensor data model. Adds display properties (color, visibility, line style, label placement), array centre modes (PLAIN, WORM, MEASURED), measured array positions, and boolean presence flags. Updates all 9 sensor tool spec fixtures to match.
+
+## Key Files to Modify
+
+### Schema (source of truth)
+
+| File | Change |
+|------|--------|
+| `shared/schemas/src/linkml/common.yaml` | Add 4 new enums: ArrayCentreModeEnum, LineStyleEnum, LabelLocationEnum, LineLabelPositionEnum |
+| `shared/schemas/src/linkml/geojson.yaml` | Expand SensorContact (9 new fields), SensorData (4 new fields), add MeasuredArrayPosition class |
+
+### Generated (auto-generated, do not hand-edit)
+
+| File | How to Regenerate |
+|------|-------------------|
+| `shared/schemas/src/generated/python/debrief_schemas/__init__.py` | `cd shared/schemas && uv run python scripts/generate.py` |
+| `shared/schemas/src/generated/typescript/types.ts` | Same command |
+| `shared/schemas/src/generated/json-schema/*.json` | Same command |
+
+### Fixtures
+
+| File | Change |
+|------|--------|
+| `shared/schemas/src/fixtures/valid/track-feature-sensors-01.json` | Verify still validates (backward compat) |
+| `shared/schemas/src/fixtures/valid/track-feature-sensors-02.json` | NEW — comprehensive fixture with all new fields |
+| `shared/schemas/src/fixtures/valid/track-feature-sensors-measured-01.json` | NEW — MEASURED mode with measured_positions |
+| `shared/schemas/src/fixtures/valid/track-feature-sensors-minimal-01.json` | NEW — minimal required fields only |
+| `shared/schemas/src/fixtures/invalid/track-feature-sensor-invalid-enum.json` | NEW — invalid enum value |
+| `shared/schemas/src/fixtures/invalid/track-feature-sensor-invalid-origin.json` | NEW — origin with wrong cardinality |
+| `shared/schemas/src/fixtures/invalid/track-feature-sensor-bearing-range.json` | NEW — bearing out of range |
+| `shared/tools/sensor/**/*.json` | Update 62 tool fixture files to include new fields where relevant |
+
+### Tests
+
+| File | Change |
+|------|--------|
+| `shared/schemas/tests/test_golden.py` | No change needed — auto-discovers fixtures |
+| `shared/schemas/tests/test_roundtrip.py` | No change needed — auto-discovers fixtures |
+
+## Development Workflow
+
+```bash
+# 1. Edit LinkML schemas
+#    - Add enums to common.yaml
+#    - Add fields/classes to geojson.yaml
+
+# 2. Regenerate all derived schemas
+cd shared/schemas && uv run python scripts/generate.py
+
+# 3. Create golden fixtures
+#    - Add valid fixtures to fixtures/valid/
+#    - Add invalid fixtures to fixtures/invalid/
+
+# 4. Run schema tests
+uv run pytest shared/schemas/tests/
+
+# 5. Update tool spec fixtures
+#    - Edit JSON files under shared/tools/sensor/
+
+# 6. Run full verification
+task verify
+```
+
+## Patterns to Follow
+
+### Adding an enum (in common.yaml)
+
+```yaml
+enums:
+  LineStyleEnum:
+    description: Visual style for bearing lines
+    permissible_values:
+      SOLID:
+        description: Continuous line
+      DASHED:
+        description: Evenly spaced dashes
+```
+
+### Adding an optional field to SensorContact (in geojson.yaml)
+
+```yaml
+  SensorContact:
+    attributes:
+      # ... existing fields ...
+      color:
+        description: Contact color override (CSS hex string, null inherits from sensor)
+      visible:
+        description: Contact visibility
+        range: boolean
+```
+
+### Adding a coordinate pair field
+
+```yaml
+      origin:
+        description: Explicit sensor location as [longitude, latitude]
+        range: float
+        multivalued: true
+        minimum_cardinality: 2
+        maximum_cardinality: 2
+```
+
+### Adding a nested class array (measured_positions)
+
+```yaml
+  SensorData:
+    attributes:
+      measured_positions:
+        description: Actual array positions for MEASURED mode
+        range: MeasuredArrayPosition
+        multivalued: true
+        inlined_as_list: true
+```
+
+## Verification Checklist
+
+- [ ] `uv run pytest shared/schemas/tests/` passes
+- [ ] Existing `track-feature-sensors-01.json` still validates
+- [ ] New valid fixtures validate
+- [ ] New invalid fixtures fail validation with expected errors
+- [ ] Round-trip test passes for comprehensive fixture
+- [ ] Generated Pydantic model has all new fields
+- [ ] Generated TypeScript interface has all new fields
+- [ ] `task verify` passes (full CI equivalent)

--- a/specs/116-sensor-schema-overhaul/research.md
+++ b/specs/116-sensor-schema-overhaul/research.md
@@ -1,0 +1,123 @@
+# Research: Sensor Schema Overhaul (#116)
+
+**Date**: 2026-04-10
+**Feature**: 116-sensor-schema-overhaul
+**Spec**: [spec.md](spec.md)
+
+## R1: LinkML Enum Definition Pattern
+
+**Decision**: Use `permissible_values` syntax in `common.yaml`, consistent with existing enums.
+
+**Rationale**: The project already defines 10+ enums in `shared/schemas/src/linkml/common.yaml` (FeatureKindEnum, TrackTypeEnum, PointShapeEnum, etc.) using the standard LinkML `permissible_values` pattern. Following this pattern ensures:
+- Consistent generation across Pydantic, JSON Schema, and TypeScript
+- No post-processing required in `generate.py`
+- Automatic integration with fixture validation tests
+
+**Alternatives considered**:
+- Defining enums inline in `geojson.yaml` — rejected because all existing enums live in `common.yaml`
+- Using string constraints instead of enums — rejected because enums provide compile-time safety and better error messages
+
+**Syntax**:
+```yaml
+enums:
+  ArrayCentreModeEnum:
+    description: Array centre calculation mode
+    permissible_values:
+      PLAIN:
+        description: Simple backtrack along vessel heading
+      WORM:
+        description: Follow vessel track path backwards
+      MEASURED:
+        description: Use actual measured array positions
+```
+
+## R2: Coordinate Pair Pattern for SensorContact.origin
+
+**Decision**: Use `range: float, multivalued: true, minimum_cardinality: 2, maximum_cardinality: 2` pattern.
+
+**Rationale**: This is the established pattern used by CircleAnnotation.center and VectorAnnotation.origin in `annotations.yaml` (lines 89-95, 260-267). It generates:
+- **Pydantic**: `list[float]` with validation for exactly 2 elements
+- **JSON Schema**: Array with `minItems: 2, maxItems: 2`
+- **TypeScript**: `number[]`
+- **Fixtures**: `[-5.0, 50.0]` format (longitude, latitude)
+
+No post-processing in `generate.py` is needed — the existing post-processor only handles GeoJSON geometry coordinates (nested arrays), not simple coordinate pairs.
+
+**Alternatives considered**:
+- Separate `origin_lon` / `origin_lat` float fields — rejected because it breaks the [lon, lat] convention used everywhere else and complicates serialization
+- A named `Position` class with lat/lon attributes — rejected because the existing codebase uses array notation for all coordinates, and introducing a different pattern creates inconsistency
+
+## R3: New Field Impact on Schema Generation Pipeline
+
+**Decision**: All new fields are safe for the existing pipeline with no post-processing changes required.
+
+**Rationale**: Analysis of `shared/schemas/scripts/generate.py` shows post-processing handles only:
+1. GeoJSON geometry coordinates (nested array depth changes) — not applicable
+2. Nullable array items (`position_style_overrides`) — not applicable
+3. Optional list fields with min_length constraints — only applicable if we add required multivalued fields
+4. `dict[str, Any]` → `dict[str, object]` in boilerplate — not applicable
+
+New fields fall into safe categories:
+- Optional booleans (`has_bearing`, `visible`, `show_label`) → no issues
+- Optional enums (`line_style`, `array_centre_mode`) → no issues
+- Optional floats/integers (`line_thickness`) → no issues
+- Optional coordinate pair (`origin`) → follows existing pattern
+- Optional multivalued class range (`measured_positions`) → uses `inlined_as_list: true` like `contacts`
+
+## R4: Round-Trip Test Integration Strategy
+
+**Decision**: Add new fixtures to `shared/schemas/src/fixtures/valid/` and they will be automatically discovered by existing test infrastructure.
+
+**Rationale**: The test infrastructure in `test_roundtrip.py` uses:
+- `ROUNDTRIP_ENTITY_MAP` to map fixture filename prefixes to Pydantic model classes
+- Automatic discovery of all files in `fixtures/valid/` directory
+- `track-feature-*` prefix maps to `TrackFeature` model
+
+Adding `track-feature-sensors-02.json` (with all new fields) will be auto-discovered. The existing `track-feature-sensors-01.json` must continue to validate (backward compatibility). Invalid fixtures in `fixtures/invalid/` are auto-discovered by `test_golden.py`.
+
+## R5: Tool Spec Fixture Structure
+
+**Decision**: Update tool fixtures conservatively — add new fields only where they affect tool behavior, keep existing structure intact.
+
+**Rationale**: Research reveals the tool fixtures use a standalone `SENSOR` feature kind with either `cuts` or `contacts` arrays, which is a tool-specific input contract separate from the core schema's embedded `SensorData`. The 62 fixture files across 3 categories use varying field subsets:
+
+| Pattern | Tools Using It | Current Fields |
+|---------|---------------|----------------|
+| TRACK-only | doppler-curve, inflection-point-detector, generate-sensor-range-plot | positions with course/speed |
+| SENSOR with `cuts` | ambiguity-resolver, resolve-ambiguity | time, bearing, ambiguous_bearing, origin |
+| SENSOR with `contacts` | merge-contacts, generate-new-sensor-contact, delete-ambiguous-bearings, insert-sensor-arc | id, time, bearing, frequency |
+
+Update strategy:
+- TRACK-only fixtures: Add `sensors[]` array where the tool consumes sensor data from the parent track
+- SENSOR fixtures: Add `has_bearing`, `visible` where tool behavior depends on display flags
+- All outputs: Ensure returned contacts include new optional fields where the tool sets them
+
+**Alternatives considered**:
+- Full rewrite of all fixtures to match embedded SensorData pattern — rejected because tools define their own input contracts and the standalone SENSOR feature is a valid tool input pattern
+- No fixture updates — rejected because outdated fixtures give tool implementers the wrong schema contract
+
+## R6: Downstream Consumer Impact Assessment
+
+**Decision**: All changes are additive (new optional fields only) — zero breaking changes to existing consumers.
+
+**Rationale**: Analysis of downstream consumers:
+
+| Consumer | File | Impact |
+|----------|------|--------|
+| FeatureList.flattenFeatures | `shared/components/src/FeatureList/flattenFeatures.ts` | No impact — accesses `name`, `contacts`, `bearing`, `time` only |
+| FeatureList.stories | `shared/components/src/FeatureList/FeatureList.stories.tsx` | No impact — test fixtures use subset of fields |
+| DSF handler | `services/io/src/debrief_io/handlers/dsf.py` | No impact — constructs dicts with current fields |
+| DPF handler | `services/io/src/debrief_io/handlers/dpf.py` | No impact — constructs dicts with bearing from track |
+| Import catalog | `services/io/src/debrief_io/import_catalog.py` | No impact — merge logic uses `name` and `contacts` keys |
+
+All new fields are optional with sensible defaults, so existing code continues to work unchanged. TypeScript consumers will see new optional properties in their interface but won't need to handle them until Phase 3 (rendering).
+
+## R7: Enum Placement Decision
+
+**Decision**: Place new enums in `common.yaml` alongside existing enums.
+
+**Rationale**: All project enums live in `common.yaml` (lines 23-252). The new enums (ArrayCentreModeEnum, LineStyleEnum, LabelLocationEnum, LineLabelPositionEnum) are not sensor-specific — LineStyleEnum and LabelLocationEnum could apply to other annotation types in the future. Centralizing them maintains the single-enum-file convention.
+
+**Alternatives considered**:
+- Defining enums in `geojson.yaml` next to SensorContact — rejected because it breaks the convention and creates a second enum location
+- Creating a new `sensor.yaml` schema file — rejected because the sensor entities are part of the GeoJSON feature model, not a separate concern

--- a/specs/116-sensor-schema-overhaul/spec.md
+++ b/specs/116-sensor-schema-overhaul/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Sensor Schema Overhaul
+
+**Feature Branch**: `116-sensor-schema-overhaul`
+**Created**: 2026-04-10
+**Status**: Draft
+**Input**: User description: "Full SensorContact/SensorData redesign with display properties, array offset modes, measured positions; update 9 tool spec fixtures"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Full-fidelity sensor data round-trips through the system (Priority: P1)
+
+A developer loads a track fixture containing a towed array sensor with contacts that include bearings, ambiguous bearings, frequencies, ranges, display properties (color, visibility, line style, label placement), and an explicit sensor origin override. The data is validated by the Python schema layer, serialized to JSON, deserialized by the TypeScript schema layer, re-serialized back to JSON, and re-loaded into Python. Every field value is identical after the full round trip.
+
+**Why this priority**: This is the foundational capability. If the schema cannot faithfully represent and round-trip all legacy sensor data fields, every downstream phase (import, rendering, analysis, TMA) is blocked. The schema is the single source of truth for the entire sensor pipeline.
+
+**Independent Test**: Can be fully tested by creating a fixture file with all SensorContact and SensorData fields populated, running it through the Python-JSON-TypeScript-JSON-Python round-trip pipeline, and asserting field-level equality at each stage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a JSON fixture with a track containing a sensor with all optional fields populated (color, line_style, label_location, put_label_at, visible, show_label, origin), **When** the fixture is validated by the Python schema layer, **Then** all fields are correctly parsed with proper types and constraints.
+2. **Given** a valid Python SensorData model, **When** serialized to JSON and deserialized in TypeScript, **Then** all fields (including nested contacts and measured_positions) are present with correct values.
+3. **Given** a TypeScript SensorData object, **When** serialized to JSON and re-loaded in Python, **Then** field values match the original model exactly.
+4. **Given** a fixture with only required fields (time, bearing for contacts; name, contacts for sensors), **When** validated, **Then** optional fields default correctly (visible=true, has_bearing=true, show_label=false) and absent fields are null/undefined.
+
+---
+
+### User Story 2 - Display properties persist with sensor data across save/load cycles (Priority: P1)
+
+An analyst customizes sensor display settings: sets the sensor color to red, changes bearing line style to dashed, places labels at the end of bearing lines aligned right, and hides specific contacts. After saving the plot and reopening it later, all display customizations are preserved exactly as configured.
+
+**Why this priority**: Display properties are a critical gap in the current schema. Without them, any visual customization is lost on save/reload, which is a fundamental usability failure for analysts who spend significant time configuring displays. This directly enables Phase 3 (rendering).
+
+**Independent Test**: Can be fully tested by setting display properties on sensor data, saving to a STAC Item, loading the STAC Item back, and verifying all display properties match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SensorData object with color="#FF0000", visible=true, line_thickness=3, **When** persisted as a STAC Item and reloaded, **Then** all SensorData-level display properties are preserved.
+2. **Given** a SensorContact with color="#00FF00" (override), line_style=DASHED, label_location=RIGHT, put_label_at=END, visible=false, show_label=true, **When** persisted and reloaded, **Then** all contact-level display properties are preserved.
+3. **Given** a SensorContact with no color set (null), **When** the system needs to determine its color, **Then** the contact inherits color from its parent SensorData (color inheritance pattern from legacy).
+
+---
+
+### User Story 3 - Array centre modes are captured in the schema (Priority: P1)
+
+A developer configures a towed array sensor with array_centre_mode set to MEASURED and provides a time-series of measured array positions. The schema validates the measured_positions array, enforces required fields (time, latitude, longitude), and round-trips the full configuration. A second sensor with array_centre_mode=WORM and no measured_positions also validates correctly.
+
+**Why this priority**: Array centre modes directly affect where bearing lines originate. The schema must capture the mode and any associated data (measured positions) so that Phase 4 (array offset calculations) can compute correct origins. Without this, bearing line rendering in Phase 3 would always use the platform position, which is incorrect for towed arrays.
+
+**Independent Test**: Can be fully tested by creating fixtures with each array_centre_mode (PLAIN, WORM, MEASURED), validating them, and verifying that measured_positions is accepted for all modes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SensorData with array_centre_mode=MEASURED and three measured_positions entries, **When** validated, **Then** the model accepts it and all positions are parsed with correct time, latitude, and longitude.
+2. **Given** a SensorData with array_centre_mode=PLAIN and no measured_positions, **When** validated, **Then** the model accepts it (measured_positions not required for PLAIN/WORM).
+3. **Given** a SensorData with array_centre_mode=MEASURED but no measured_positions, **When** validated, **Then** the model still accepts it (measured positions may be provided later; fallback to PLAIN is a runtime behavior, not a schema constraint).
+
+---
+
+### User Story 4 - Tool spec fixtures updated to match new schema (Priority: P2)
+
+A developer running the existing 9 sensor tool spec golden example tests sees all tests pass after the schema overhaul. The tool input/output fixtures reference the expanded SensorContact and SensorData shapes (with display properties, boolean presence flags, and array centre mode) so that downstream tool implementations will produce schema-compliant outputs.
+
+**Why this priority**: The 9 sensor tool specs define the contract for future tool implementations. If their fixtures still reference the old (incomplete) schema, tool authors will build against the wrong contract, creating rework when the schema is eventually updated. Updating fixtures now ensures a single, consistent schema contract.
+
+**Independent Test**: Can be fully tested by running the fixture validation suite against all sensor tool golden examples and verifying zero validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated SensorContact schema with new fields, **When** each of the 9 sensor tool spec input/output fixtures is validated, **Then** all fixtures pass schema validation.
+2. **Given** a tool spec fixture that previously used only bearing and range, **When** updated, **Then** it includes relevant new fields (has_bearing, visible, etc.) where they affect the tool's behavior, and omits them where they do not.
+3. **Given** all 9 tool spec fixtures are updated, **When** the golden example test suite runs, **Then** zero validation errors occur.
+
+---
+
+### User Story 5 - Golden fixtures validate schema correctness for new fields and enums (Priority: P2)
+
+A developer adds an invalid enum value to the schema. The invalid golden fixture catches the regression by failing validation. Conversely, the valid golden fixtures confirm that all legitimate combinations of new fields (enums, booleans, nested measured positions) are accepted.
+
+**Why this priority**: Golden fixtures are the project's primary safety net for schema changes (per Constitution Art. II). Without comprehensive valid/invalid fixtures for the new fields, regressions in later phases may go undetected until they cause runtime failures.
+
+**Independent Test**: Can be fully tested by running the fixture validation suite against all golden fixtures in the fixtures directory and verifying that valid fixtures pass and invalid fixtures fail with the expected errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid fixture with all new enum values (ArrayCentreModeEnum, LineStyleEnum, LabelLocationEnum, LineLabelPositionEnum), **When** validated, **Then** it passes.
+2. **Given** an invalid fixture with an out-of-range enum value (e.g., array_centre_mode="INVALID"), **When** validated, **Then** it fails with a clear validation error.
+3. **Given** an invalid fixture where bearing is outside 0-360, **When** validated, **Then** it fails (existing constraint preserved).
+4. **Given** a valid fixture with a minimal SensorContact (only time and bearing), **When** validated, **Then** it passes with all optional fields absent.
+
+---
+
+### Edge Cases
+
+- What happens when a SensorContact has has_bearing=false but a bearing value is present? The schema accepts this — the flag controls display behavior, not data presence (legacy stores the raw value regardless).
+- How does the system handle a bearing of exactly 0 or exactly 360? Both are valid (0 and 360 represent the same direction; legacy accepts both).
+- What happens when measured_positions is an empty array? The schema accepts this (array may be populated later).
+- What happens when origin is provided as [lon, lat] on a SensorContact that also has a parent sensor with array offset? The explicit origin takes precedence (matching legacy `_absoluteOrigin` behavior); this is a runtime decision, not a schema constraint.
+- How are contacts ordered when times are identical? The schema accepts duplicate timestamps (ordering is by insertion order; legacy allowed same-time contacts from different operators).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST define a SensorContact schema with required fields: time (datetime, ISO8601) and bearing (float, 0-360 degrees)
+- **FR-002**: System MUST define optional SensorContact data fields: has_bearing (boolean, default true), ambiguous_bearing (float, 0-360), has_ambiguous (boolean), range (float, metres, >=0), frequency (float, Hz), has_frequency (boolean), label (string), comment (string)
+- **FR-003**: System MUST define SensorContact display properties: color (string, nullable for inheritance), visible (boolean, default true), show_label (boolean, default false), line_style (enum: SOLID, DASHED, DOT, DASH_DOT), label_location (enum: LEFT, CENTER, RIGHT), put_label_at (enum: START, MIDDLE, END)
+- **FR-004**: System MUST define an optional SensorContact origin field as a coordinate pair [longitude, latitude] that overrides the calculated sensor position
+- **FR-005**: System MUST define a SensorData schema with required fields: name (string) and contacts (array of SensorContact)
+- **FR-006**: System MUST define optional SensorData fields: base_frequency (float, Hz), offset (float, metres), array_centre_mode (enum: PLAIN, WORM, MEASURED), worm_in_hole (boolean, default false), color (string), visible (boolean, default true), line_thickness (integer)
+- **FR-007**: System MUST define an optional SensorData measured_positions field as an array of MeasuredArrayPosition records
+- **FR-008**: System MUST define a MeasuredArrayPosition schema with required fields: time (datetime), latitude (float), longitude (float)
+- **FR-009**: System MUST define four new enumerations: ArrayCentreModeEnum (PLAIN, WORM, MEASURED), LineStyleEnum (SOLID, DASHED, DOT, DASH_DOT), LabelLocationEnum (LEFT, CENTER, RIGHT), LineLabelPositionEnum (START, MIDDLE, END)
+- **FR-010**: System MUST generate validated models, portable schema definitions, and typed interfaces from the updated master schema definitions
+- **FR-011**: System MUST provide golden fixtures (valid and invalid) that exercise all new fields, enums, and edge cases
+- **FR-012**: System MUST pass round-trip tests: Python to JSON to TypeScript to JSON to Python with zero data loss for all sensor fields
+- **FR-013**: System MUST update all 9 existing sensor tool spec fixtures to reference the new SensorContact and SensorData shapes
+- **FR-014**: System MUST preserve backward compatibility for existing valid fixtures (fixtures with only the previously-defined fields must continue to validate)
+
+### Key Entities
+
+- **SensorContact**: A single sensor observation at a point in time, capturing bearing, optional range/frequency, ambiguity data, operator notes, and per-contact display properties. Belongs to exactly one SensorData parent.
+- **SensorData**: A named sensor instrument (e.g., "TOWED_ARRAY") attached to a track, containing configuration (offset, array centre mode, base frequency), default display properties, and an ordered collection of SensorContacts.
+- **MeasuredArrayPosition**: A timestamped geographic position recording the actual location of a towed array centre, used by the MEASURED array centre mode for interpolation.
+- **ArrayCentreModeEnum**: Determines how the bearing line origin is calculated relative to the host platform: PLAIN (simple backtrack), WORM (follow track path), MEASURED (use actual position data).
+- **LineStyleEnum**: Visual style for bearing lines: SOLID, DASHED, DOT, DASH_DOT.
+- **LabelLocationEnum**: Horizontal alignment of contact labels: LEFT, CENTER, RIGHT.
+- **LineLabelPositionEnum**: Position along the bearing line where the label is placed: START (origin), MIDDLE, END (far end).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All fields from the legacy SensorContactWrapper (16 fields) and SensorWrapper (10 fields) are represented in the new schema, plus MeasuredArrayPosition (3 fields)
+- **SC-002**: Round-trip tests pass with 100% field preservation across Python-JSON-TypeScript-JSON-Python for a comprehensive fixture exercising all fields
+- **SC-003**: At least 3 valid and 3 invalid golden fixtures are created covering new fields, enums, and edge cases
+- **SC-004**: All 9 sensor tool spec fixture files (across analysis, calibration, and detection categories) pass schema validation after updates
+- **SC-005**: Generated types are produced without manual intervention from the updated master schema definitions
+- **SC-006**: Existing valid sensor fixtures continue to validate without modification (backward compatibility)
+- **SC-007**: Schema adherence test suite completes with zero failures after the overhaul
+
+## Assumptions
+
+- The compound track model (#062) is complete and SensorData continues to be embedded under `track.properties.sensors[]` — no change to the embedding location.
+- Bearing accuracy and frequency accuracy fields are intentionally excluded per the E07 epic decision (legacy parsed but never stored these).
+- Color values use CSS hex string format (e.g., "#FF0000") consistent with the existing style system in the codebase.
+- The `has_bearing`, `has_ambiguous`, and `has_frequency` boolean presence flags default to true when absent, matching legacy behavior where data is assumed present unless explicitly marked otherwise.
+- REP export is out of scope — the schema is designed for import and internal representation only.
+- The origin coordinate pair on SensorContact follows the GeoJSON convention of [longitude, latitude].
+- Schema-per-phase for TMA is a separate concern (Phase 6) — this overhaul does not define TMA schemas.
+
+## Dependencies
+
+- **#062 (complete)**: Compound track model with embedded sensors — provides the TrackProperties structure that SensorData embeds into.
+
+## Out of Scope
+
+- REP sensor format parsing (Phase 2, #117)
+- Sensor rendering on map (Phase 3, #118)
+- Array offset calculation logic (Phase 4, #119) — only the schema fields are defined here
+- TMA schemas (Phase 6, #121)
+- Bearing/frequency accuracy fields (deferred per epic decision)
+- Multi-static sonar, active sonar two-way propagation
+- Sensor arc coverage shapes (DynamicTrackCoverage — addressed in #117 and #118)

--- a/specs/116-sensor-schema-overhaul/tasks.md
+++ b/specs/116-sensor-schema-overhaul/tasks.md
@@ -20,9 +20,9 @@
 
 | Artifact | Description | Captured When |
 |----------|-------------|---------------|
-| test-summary.md | pytest results for schema tests (golden fixtures, round-trip, validation) | After all tests pass |
+| test-summary.md | pytest results for schema tests (golden fixtures, round-trip, validation, schema comparison, enum exhaustiveness) | After all tests pass |
 | usage-example.md | Python code creating SensorData with all new fields, serializing to JSON | After schema generation works |
-| round-trip-evidence.md | Full Python -> JSON -> TypeScript -> JSON -> Python proof for comprehensive sensor fixture | After round-trip tests pass |
+| round-trip-evidence.md | Full Python -> JSON -> TypeScript -> JSON -> Python proof for comprehensive sensor fixture (both Python and TypeScript legs) | After round-trip tests pass |
 
 ### Media Content
 
@@ -80,6 +80,10 @@
 - [ ] T015 [P] Verify generated TypeScript interfaces have all new fields `shared/schemas/src/generated/typescript/types.ts`
 - [ ] T016 [P] Verify generated JSON Schema has all new fields `shared/schemas/src/generated/json-schema/`
 
+### Generation Verification (Review Decision #2)
+
+- [ ] T058 [test] Verify generated code handles optional float[2] coordinate pairs correctly (MeasuredArrayPosition.location, SensorContact.origin) `shared/schemas/tests/test_schema_compare.py`
+
 **Checkpoint**: Schema expanded and all generated code reflects new fields. Fixture and test work can now begin.
 
 ---
@@ -103,7 +107,11 @@
 - [ ] T022 [US1] Verify optional fields default correctly in Pydantic model (visible=true, has_bearing=true, show_label=false)
 - [ ] T023 [US1] Verify TypeScript interface accepts both comprehensive and minimal fixtures
 
-**Checkpoint**: Round-trip fidelity proven for all sensor fields. Backward compatibility confirmed.
+### TypeScript Round-Trip (Review Decision #8)
+
+- [ ] T059 [test] [US1] Add vitest TypeScript round-trip test: JSON → TS deserialize → TS serialize → JSON for sensor fixtures `shared/schemas/tests/ts/test_sensor_roundtrip.test.ts`
+
+**Checkpoint**: Round-trip fidelity proven for all sensor fields in both Python and TypeScript. Backward compatibility confirmed.
 
 ---
 
@@ -143,7 +151,7 @@
 
 - [ ] T031 [US3] Verify PLAIN mode with no measured_positions validates correctly (covered by comprehensive fixture T017)
 - [ ] T032 [US3] Verify MEASURED mode with empty measured_positions array validates correctly
-- [ ] T033 [US3] Verify MeasuredArrayPosition fields (time, latitude, longitude) are all required and typed correctly
+- [ ] T033 [US3] Verify MeasuredArrayPosition fields (time, location as float[2] [lon, lat]) are all required and typed correctly
 
 **Checkpoint**: All three array centre modes validate. MEASURED mode with position time-series round-trips correctly.
 
@@ -168,7 +176,11 @@
 - [ ] T042 [P] [US4] Update resolve-ambiguity fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/calibration/resolve-ambiguity.*.json`
 - [ ] T043 [US4] Validate all updated tool fixtures pass schema validation
 
-**Checkpoint**: All 62 tool fixture files updated and validated against new schema.
+### Tool Fixture Schema Validation Test (Review Decision #7)
+
+- [ ] T060 [test] [US4] Add pytest parametrized test validating all tool fixture JSON files against SensorData/SensorContact Pydantic models `shared/schemas/tests/test_tool_fixtures.py`
+
+**Checkpoint**: All 62 tool fixture files updated and validated against new schema. Automated test prevents future fixture drift.
 
 ---
 
@@ -184,12 +196,27 @@
 - [ ] T045 [P][test] [US5] Create invalid fixture: origin with wrong cardinality (3 elements) `shared/schemas/src/fixtures/invalid/track-feature-sensor-invalid-origin.json`
 - [ ] T046 [P][test] [US5] Create invalid fixture: bearing outside 0-360 range `shared/schemas/src/fixtures/invalid/track-feature-sensor-bearing-range.json`
 
+### Constraint Edge-Case Fixtures (Review Decision #11)
+
+- [ ] T063 [test] [US5] Create valid boundary fixture: bearing=0 and bearing=360, empty measured_positions array `shared/schemas/src/fixtures/valid/track-feature-sensors-boundary-01.json`
+- [ ] T064 [P][test] [US5] Create invalid fixture: bearing=-1 `shared/schemas/src/fixtures/invalid/track-feature-sensor-bearing-negative.json`
+- [ ] T065 [P][test] [US5] Create invalid fixture: bearing=361 `shared/schemas/src/fixtures/invalid/track-feature-sensor-bearing-over360.json`
+- [ ] T066 [P][test] [US5] Create invalid fixture: origin with 1 element `shared/schemas/src/fixtures/invalid/track-feature-sensor-origin-wrong-length.json`
+
+### Schema Comparison Extension (Review Decision #9)
+
+- [ ] T061 [test] [US5] Extend test_schema_compare.py to cover SensorData, SensorContact, and 4 new enums `shared/schemas/tests/test_schema_compare.py`
+
+### Enum Exhaustiveness Test (Review Decision #10)
+
+- [ ] T062 [test] [US5] Add parametrized test validating every value of ArrayCentreModeEnum, LineStyleEnum, LabelLocationEnum, LineLabelPositionEnum `shared/schemas/tests/test_sensor_enums.py`
+
 ### Implementation for User Story 5
 
-- [ ] T047 [US5] Run golden fixture validation: all invalid fixtures fail with clear error messages `shared/schemas/tests/test_golden.py`
+- [ ] T047 [US5] Run golden fixture validation: all invalid fixtures (including new boundary cases) fail with clear error messages `shared/schemas/tests/test_golden.py`
 - [ ] T048 [US5] Verify existing invalid fixture (track-feature-sensor-no-bearing.json) still fails correctly `shared/schemas/src/fixtures/invalid/track-feature-sensor-no-bearing.json`
 
-**Checkpoint**: Schema safety net is comprehensive. Invalid data is caught with useful error messages. Existing invalid fixtures still work.
+**Checkpoint**: Schema safety net is comprehensive. Invalid data is caught with useful error messages. Existing invalid fixtures still work. All enum values validated. Schema comparison covers sensor entities.
 
 ---
 
@@ -250,9 +277,9 @@
 
 - Phase 1: T001-T004 (enum additions) can all run in parallel
 - Phase 2: T007-T009 (SensorContact display props) can all run in parallel; T010-T012 (SensorData fields) in parallel
-- Phase 3: T017-T018 (valid fixture creation) in parallel
-- Phase 6: T035-T042 (tool fixture updates) can ALL run in parallel (different files)
-- Phase 7: T044-T046 (invalid fixture creation) can all run in parallel
+- Phase 3: T017-T018 (valid fixture creation) in parallel; T059 (TS round-trip) after fixtures exist
+- Phase 6: T035-T042 (tool fixture updates) can ALL run in parallel (different files); T060 after all fixtures updated
+- Phase 7: T044-T046, T063-T066 (fixture creation) can all run in parallel; T061-T062 (test additions) in parallel
 
 ---
 
@@ -288,7 +315,8 @@ Task: T042 "Update resolve-ambiguity fixtures"
 
 - **Schema generation failure**: Run `generate.py` early (T013) to catch LinkML issues before creating fixtures
 - **Backward compatibility**: Verify existing fixture (T021) immediately after generation
-- **Tool fixture drift**: Validate all tool fixtures (T043) as a batch after updates
+- **Tool fixture drift**: Validate all tool fixtures (T043, T060) as a batch after updates
+- **Type drift**: TypeScript round-trip (T059) and schema comparison (T061) catch cross-language divergence early
 
 ---
 

--- a/specs/116-sensor-schema-overhaul/tasks.md
+++ b/specs/116-sensor-schema-overhaul/tasks.md
@@ -1,0 +1,304 @@
+# Tasks: Sensor Schema Overhaul
+
+**Input**: Design documents from `/specs/116-sensor-schema-overhaul/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: This feature requires schema tests (golden fixtures, round-trip tests) per Constitution Art. II and VI. Test tasks are included.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+---
+
+## Evidence Requirements
+
+> **Purpose**: Capture artifacts that demonstrate the feature works as expected. These are used in PR descriptions, documentation, and future blog posts.
+
+**Evidence Directory**: `specs/116-sensor-schema-overhaul/evidence/`
+**Media Directory**: `specs/116-sensor-schema-overhaul/media/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| test-summary.md | pytest results for schema tests (golden fixtures, round-trip, validation) | After all tests pass |
+| usage-example.md | Python code creating SensorData with all new fields, serializing to JSON | After schema generation works |
+| round-trip-evidence.md | Full Python -> JSON -> TypeScript -> JSON -> Python proof for comprehensive sensor fixture | After round-trip tests pass |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| media/planning-post.md | Blog post announcing the feature | During /speckit.plan (done) |
+| media/linkedin-planning.md | LinkedIn summary for planning | During /speckit.plan (done) |
+| media/shipped-post.md | Blog post celebrating completion | During Polish phase |
+| media/linkedin-shipped.md | LinkedIn summary for shipped | During Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in debrief-future with evidence | Final task in Polish phase |
+| Blog PR | PR in debrief.github.io with post | Triggered by /speckit.pr |
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add new enumerations and the MeasuredArrayPosition class that all user stories depend on.
+
+- [ ] T001 Add ArrayCentreModeEnum to LinkML enums `shared/schemas/src/linkml/common.yaml`
+- [ ] T002 [P] Add LineStyleEnum to LinkML enums `shared/schemas/src/linkml/common.yaml`
+- [ ] T003 [P] Add LabelLocationEnum to LinkML enums `shared/schemas/src/linkml/common.yaml`
+- [ ] T004 [P] Add LineLabelPositionEnum to LinkML enums `shared/schemas/src/linkml/common.yaml`
+- [ ] T005 Add MeasuredArrayPosition class to LinkML schema `shared/schemas/src/linkml/geojson.yaml`
+
+---
+
+## Phase 2: Foundation — Schema Expansion (Blocking Prerequisites)
+
+**Purpose**: Expand SensorContact and SensorData with all new fields. MUST be complete before any user story can be tested.
+
+**CRITICAL**: No fixture or test work can begin until this phase is complete.
+
+### SensorContact Schema Expansion
+
+- [ ] T006 Add boolean presence flags (has_bearing, has_ambiguous, has_frequency) to SensorContact `shared/schemas/src/linkml/geojson.yaml`
+- [ ] T007 [P] Add display properties (color, visible, show_label) to SensorContact `shared/schemas/src/linkml/geojson.yaml`
+- [ ] T008 [P] Add enum-typed display properties (line_style, label_location, put_label_at) to SensorContact `shared/schemas/src/linkml/geojson.yaml`
+- [ ] T009 [P] Add origin coordinate pair field to SensorContact `shared/schemas/src/linkml/geojson.yaml`
+
+### SensorData Schema Expansion
+
+- [ ] T010 Add array_centre_mode enum field to SensorData `shared/schemas/src/linkml/geojson.yaml`
+- [ ] T011 [P] Add display properties (color, visible, line_thickness) to SensorData `shared/schemas/src/linkml/geojson.yaml`
+- [ ] T012 [P] Add measured_positions array field to SensorData `shared/schemas/src/linkml/geojson.yaml`
+
+### Schema Generation
+
+- [ ] T013 Run schema generation pipeline and verify output `shared/schemas/scripts/generate.py`
+- [ ] T014 Verify generated Pydantic models have all new fields `shared/schemas/src/generated/python/debrief_schemas/__init__.py`
+- [ ] T015 [P] Verify generated TypeScript interfaces have all new fields `shared/schemas/src/generated/typescript/types.ts`
+- [ ] T016 [P] Verify generated JSON Schema has all new fields `shared/schemas/src/generated/json-schema/`
+
+**Checkpoint**: Schema expanded and all generated code reflects new fields. Fixture and test work can now begin.
+
+---
+
+## Phase 3: User Story 1 — Full-fidelity sensor data round-trips (Priority: P1)
+
+**Goal**: Verify that all sensor fields (including new display properties, presence flags, origin, measured positions) survive Python-JSON-TypeScript-JSON-Python round trips with zero data loss.
+
+**Independent Test**: Create a comprehensive fixture with all fields populated, run it through the round-trip pipeline, and assert field-level equality at each stage.
+
+### Tests for User Story 1
+
+- [ ] T017 [test] [US1] Create comprehensive valid fixture with ALL new SensorContact and SensorData fields `shared/schemas/src/fixtures/valid/track-feature-sensors-02.json`
+- [ ] T018 [P][test] [US1] Create minimal valid fixture with only required fields (time, bearing, name, contacts) `shared/schemas/src/fixtures/valid/track-feature-sensors-minimal-01.json`
+- [ ] T019 [US1] Run golden fixture validation tests to confirm both fixtures pass `shared/schemas/tests/test_golden.py`
+- [ ] T020 [US1] Run round-trip tests to confirm comprehensive fixture survives Python-JSON-Python cycle `shared/schemas/tests/test_roundtrip.py`
+- [ ] T021 [US1] Verify existing track-feature-sensors-01.json still validates (backward compatibility) `shared/schemas/src/fixtures/valid/track-feature-sensors-01.json`
+
+### Implementation for User Story 1
+
+- [ ] T022 [US1] Verify optional fields default correctly in Pydantic model (visible=true, has_bearing=true, show_label=false)
+- [ ] T023 [US1] Verify TypeScript interface accepts both comprehensive and minimal fixtures
+
+**Checkpoint**: Round-trip fidelity proven for all sensor fields. Backward compatibility confirmed.
+
+---
+
+## Phase 4: User Story 2 — Display properties persist across save/load (Priority: P1)
+
+**Goal**: Verify that display properties (color, line_style, label_location, put_label_at, visible, show_label, line_thickness) persist when sensor data is saved to a STAC Item and reloaded.
+
+**Independent Test**: Set display properties on SensorData and SensorContact, serialize to JSON, deserialize back, and verify all display values match.
+
+### Tests for User Story 2
+
+- [ ] T024 [test] [US2] Verify comprehensive fixture (T017) includes display properties at both SensorData and SensorContact levels `shared/schemas/src/fixtures/valid/track-feature-sensors-02.json`
+- [ ] T025 [test] [US2] Verify contact with null color serializes correctly (inheritance case) — covered by minimal fixture
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Verify Pydantic serialization preserves color, line_style, label_location, put_label_at, visible, show_label for SensorContact
+- [ ] T027 [US2] Verify Pydantic serialization preserves color, visible, line_thickness for SensorData
+
+**Checkpoint**: Display properties round-trip correctly. Color inheritance (null contact color → inherit from sensor) is schema-compatible.
+
+---
+
+## Phase 5: User Story 3 — Array centre modes captured in schema (Priority: P1)
+
+**Goal**: Verify that array_centre_mode (PLAIN, WORM, MEASURED) and measured_positions are correctly captured, validated, and round-tripped.
+
+**Independent Test**: Create fixtures with each array_centre_mode value, validate them, and verify MEASURED mode with measured_positions round-trips correctly.
+
+### Tests for User Story 3
+
+- [ ] T028 [test] [US3] Create valid fixture with MEASURED mode and measured_positions array `shared/schemas/src/fixtures/valid/track-feature-sensors-measured-01.json`
+- [ ] T029 [test] [US3] Run golden fixture validation for measured positions fixture `shared/schemas/tests/test_golden.py`
+- [ ] T030 [test] [US3] Run round-trip test for measured positions fixture `shared/schemas/tests/test_roundtrip.py`
+
+### Implementation for User Story 3
+
+- [ ] T031 [US3] Verify PLAIN mode with no measured_positions validates correctly (covered by comprehensive fixture T017)
+- [ ] T032 [US3] Verify MEASURED mode with empty measured_positions array validates correctly
+- [ ] T033 [US3] Verify MeasuredArrayPosition fields (time, latitude, longitude) are all required and typed correctly
+
+**Checkpoint**: All three array centre modes validate. MEASURED mode with position time-series round-trips correctly.
+
+---
+
+## Phase 6: User Story 4 — Tool spec fixtures updated (Priority: P2)
+
+**Goal**: Update all 9 sensor tool spec golden example fixtures to reference the new SensorContact and SensorData shapes, ensuring tool implementers build against the correct schema contract.
+
+**Independent Test**: Run fixture validation suite against all sensor tool golden examples and verify zero validation errors.
+
+### Implementation for User Story 4
+
+- [ ] T034 [US4] Update doppler-curve fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/analysis/doppler-curve.*.json`
+- [ ] T035 [P] [US4] Update generate-new-sensor-contact fixtures (basic input/output) `shared/tools/sensor/analysis/generate-new-sensor-contact.*.json`
+- [ ] T036 [P] [US4] Update generate-sensor-range-plot fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/analysis/generate-sensor-range-plot.*.json`
+- [ ] T037 [P] [US4] Update inflection-point-detector fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/analysis/inflection-point-detector.*.json`
+- [ ] T038 [P] [US4] Update insert-sensor-arc fixtures (basic, complex, edge input/output) `shared/tools/sensor/analysis/insert-sensor-arc.*.json`
+- [ ] T039 [P] [US4] Update merge-contacts fixtures (basic, complex, edge input/output) `shared/tools/sensor/analysis/merge-contacts.*.json`
+- [ ] T040 [P] [US4] Update ambiguity-resolver fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/calibration/ambiguity-resolver.*.json`
+- [ ] T041 [P] [US4] Update delete-ambiguous-bearings fixtures (basic, complex, edge input/output) `shared/tools/sensor/calibration/delete-ambiguous-bearings.*.json`
+- [ ] T042 [P] [US4] Update resolve-ambiguity fixtures (basic, complex, edge-1, edge-2 input/output) `shared/tools/sensor/calibration/resolve-ambiguity.*.json`
+- [ ] T043 [US4] Validate all updated tool fixtures pass schema validation
+
+**Checkpoint**: All 62 tool fixture files updated and validated against new schema.
+
+---
+
+## Phase 7: User Story 5 — Golden fixtures validate schema correctness (Priority: P2)
+
+**Goal**: Create invalid golden fixtures that catch schema regressions for new fields and enums. Verify that the validation safety net is comprehensive.
+
+**Independent Test**: Run fixture validation suite against all golden fixtures. Valid fixtures pass, invalid fixtures fail with expected errors.
+
+### Tests for User Story 5
+
+- [ ] T044 [test] [US5] Create invalid fixture: out-of-range enum value (array_centre_mode="INVALID") `shared/schemas/src/fixtures/invalid/track-feature-sensor-invalid-enum.json`
+- [ ] T045 [P][test] [US5] Create invalid fixture: origin with wrong cardinality (3 elements) `shared/schemas/src/fixtures/invalid/track-feature-sensor-invalid-origin.json`
+- [ ] T046 [P][test] [US5] Create invalid fixture: bearing outside 0-360 range `shared/schemas/src/fixtures/invalid/track-feature-sensor-bearing-range.json`
+
+### Implementation for User Story 5
+
+- [ ] T047 [US5] Run golden fixture validation: all invalid fixtures fail with clear error messages `shared/schemas/tests/test_golden.py`
+- [ ] T048 [US5] Verify existing invalid fixture (track-feature-sensor-no-bearing.json) still fails correctly `shared/schemas/src/fixtures/invalid/track-feature-sensor-no-bearing.json`
+
+**Checkpoint**: Schema safety net is comprehensive. Invalid data is caught with useful error messages. Existing invalid fixtures still work.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, evidence collection, media content, and PR creation.
+
+### Verification
+
+- [ ] T049 Run full schema test suite: `uv run pytest shared/schemas/tests/`
+- [ ] T050 Run full CI verification: `task verify`
+- [ ] T051 Verify quickstart.md checklist items all pass `specs/116-sensor-schema-overhaul/quickstart.md`
+
+### Evidence Collection
+
+- [ ] T052 Capture test results using template (.specify/templates/evidence/test-summary-template.md) `specs/116-sensor-schema-overhaul/evidence/test-summary.md`
+- [ ] T053 Create usage demonstration `specs/116-sensor-schema-overhaul/evidence/usage-example.md`
+- [ ] T054 [P] Capture round-trip proof (Python -> JSON -> TypeScript -> JSON -> Python) `specs/116-sensor-schema-overhaul/evidence/round-trip-evidence.md`
+
+### Media Content
+
+- [ ] T055 Create shipped blog post `specs/116-sensor-schema-overhaul/media/shipped-post.md`
+- [ ] T056 [P] Create LinkedIn shipped summary `specs/116-sensor-schema-overhaul/media/linkedin-shipped.md`
+
+### PR Creation
+
+- [ ] T057 Create PR and publish blog: run /speckit.pr
+
+**Task T057 must run last. It depends on all evidence and media tasks being complete.**
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundation (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **US1-US3 (Phases 3-5)**: All depend on Foundation phase. US1-US3 are all P1 priority and can run in parallel but have a natural sequencing (US1 creates the comprehensive fixture that US2 and US3 rely on for verification)
+- **US4-US5 (Phases 6-7)**: Depend on Foundation. US4 (tool fixtures) and US5 (invalid fixtures) can run in parallel with each other and with US1-US3
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 2 only. Creates the comprehensive valid fixture used by other stories.
+- **User Story 2 (P1)**: Depends on Phase 2. Verifies display properties in fixtures created by US1 — can run after US1 or in parallel if using its own fixture sections.
+- **User Story 3 (P1)**: Depends on Phase 2. Creates its own MEASURED mode fixture — can run in parallel with US1 and US2.
+- **User Story 4 (P2)**: Depends on Phase 2. Independent of US1-US3 — modifies tool fixtures, not schema fixtures.
+- **User Story 5 (P2)**: Depends on Phase 2. Independent of US1-US4 — creates invalid fixtures only.
+
+### Within Each User Story
+
+- Test fixtures created before validation tests run
+- Schema generation (Phase 2) must complete before any fixture validation
+- Fixtures with [P] can be created in parallel
+
+### Parallel Opportunities
+
+- Phase 1: T001-T004 (enum additions) can all run in parallel
+- Phase 2: T007-T009 (SensorContact display props) can all run in parallel; T010-T012 (SensorData fields) in parallel
+- Phase 3: T017-T018 (valid fixture creation) in parallel
+- Phase 6: T035-T042 (tool fixture updates) can ALL run in parallel (different files)
+- Phase 7: T044-T046 (invalid fixture creation) can all run in parallel
+
+---
+
+## Parallel Example: Phase 6 (Tool Fixture Updates)
+
+```bash
+# All tool fixture updates can run simultaneously (different files):
+Task: T035 "Update generate-new-sensor-contact fixtures"
+Task: T036 "Update generate-sensor-range-plot fixtures"
+Task: T037 "Update inflection-point-detector fixtures"
+Task: T038 "Update insert-sensor-arc fixtures"
+Task: T039 "Update merge-contacts fixtures"
+Task: T040 "Update ambiguity-resolver fixtures"
+Task: T041 "Update delete-ambiguous-bearings fixtures"
+Task: T042 "Update resolve-ambiguity fixtures"
+```
+
+---
+
+## Implementation Strategy
+
+### Incremental Delivery
+
+1. Complete Setup + Foundation (Phases 1-2) → Schema expanded, generated code ready
+2. Add US1 fixtures (Phase 3) → Round-trip fidelity proven
+3. Add US2 verification (Phase 4) → Display property persistence confirmed
+4. Add US3 fixtures (Phase 5) → Array centre modes validated
+5. Update tool fixtures (Phase 6) → All tool contracts aligned
+6. Add invalid fixtures (Phase 7) → Safety net complete
+7. Polish + Evidence + PR (Phase 8) → Feature shipped
+
+### Key Risk Mitigations
+
+- **Schema generation failure**: Run `generate.py` early (T013) to catch LinkML issues before creating fixtures
+- **Backward compatibility**: Verify existing fixture (T021) immediately after generation
+- **Tool fixture drift**: Validate all tool fixtures (T043) as a batch after updates
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [US*] label maps task to specific user story for traceability
+- [test] label identifies fixture/test creation tasks
+- All schema changes go through LinkML → generated code pipeline (never hand-edit generated files)
+- Commit after each phase or logical group
+- The comprehensive fixture (T017) is the cornerstone — it exercises all new fields and is reused by multiple test categories
+- Evidence is required — capture artifacts that prove the feature works
+- Run `/speckit.pr` after all tasks complete to create PR with evidence


### PR DESCRIPTION
## Summary

This PR adds comprehensive specification and planning documentation for the Sensor Schema Overhaul feature (#116). These are specification-phase deliverables that define the requirements, design, and implementation roadmap for expanding the SensorContact and SensorData schemas to capture the full legacy Debrief sensor data model.

## Key Changes

- **spec.md**: Feature specification with 5 user stories (P1/P2 priorities), acceptance scenarios, and testing requirements
- **plan.md**: Implementation plan with technical context, Constitution compliance checklist, project structure, and phase breakdown
- **data-model.md**: Entity definitions for SensorContact, SensorData, and MeasuredArrayPosition with field tables, validation rules, and relationships
- **research.md**: Technical decision rationale for LinkML enum patterns, coordinate pair representation, schema generation pipeline impact, and tool fixture strategy
- **quickstart.md**: Developer onboarding guide with key files, workflow steps, and verification checklist
- **tasks.md**: Detailed task breakdown organized by 7 implementation phases and 5 user stories, with evidence requirements and test specifications
- **contracts/schema-contract.md**: Data shape contracts for SensorContact and SensorData with required/full field examples and enum values
- **checklists/requirements.md**: Specification quality validation checklist
- **media/planning-post.md**: Blog post announcing the feature
- **media/linkedin-planning.md**: LinkedIn summary for planning phase

## Notable Details

- All new schema fields are optional — zero breaking changes to existing data
- Specification includes mandatory schema tests (golden fixtures, round-trip validation, enum exhaustiveness)
- Task breakdown enables independent implementation and testing of 5 user stories across 7 phases
- Evidence artifacts defined for PR descriptions and future documentation
- Constitution compliance verified (Articles I, II, III, IV, VI, VII, VIII, IX, XIV, XV)

https://claude.ai/code/session_01YLYMTixjtBJ75TLfzKKuqQ