### PR TITLE
spec(181): LinkML per-platform override fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Only updated when a feature introduces a technology not already listed here.
 - TypeScript 5.x (VS Code extension + shared components, host + webview), Python 3.11 (no changes required — debrief-calc already returns the right shapes) + VS Code Extension API ^1.85.0, React 18.x, `@debrief/components` (`ChartPanelWrapper`, `TableRenderer`, `ChartRenderer`, `PanelContext`), `@debrief/utils` (`buildCsvContent`, `generateCsvFilename`, `sanitizeFilename`, NEW `parseCsvToTableDataset` and NEW `synthesizeTableDataset`), `@debrief/session-state` (`LogService` — extended with `recordFileSaved`), existing `apps/vscode/src/services/stacService.ts` (178-vscode-tabular-results)
 - Python 3.11, TypeScript 5.x + no new dependencies (both languages read JSON natively) (180-platform-registry)
 - Static JSON file at `shared/data/platform-registry.json` (180-platform-registry)
+- Python 3.11 (schema generation, tests), TypeScript 5.x (generated types, type checking) + LinkML >= 1.7.0 (schema source), Pydantic v2 (generated Python models), gen-pydantic/gen-typescript/gen-json-schema (code generators) (181-linkml-platform-overrides)
 
 ## Before Pushing
 
@@ -211,6 +212,6 @@ cd apps/web-shell && node run-playwright.mjs && cd ../..
 Note: `vitest` does not catch TypeScript type errors — only `tsc` (run during typecheck) does. The `pnpm build` step also runs `tsc`, but typecheck is the explicit CI gate.
 
 ## Recent Changes
+- 181-linkml-platform-overrides: Added Python 3.11 (schema generation, tests), TypeScript 5.x (generated types, type checking) + LinkML >= 1.7.0 (schema source), Pydantic v2 (generated Python models), gen-pydantic/gen-typescript/gen-json-schema (code generators)
 - 180-platform-registry: Added Python 3.11, TypeScript 5.x + no new dependencies (both languages read JSON natively)
 - 178-vscode-tabular-results: Added TypeScript 5.x (VS Code extension + shared components, host + webview), Python 3.11 (no changes required — debrief-calc already returns the right shapes) + VS Code Extension API ^1.85.0, React 18.x, `@debrief/components` (`ChartPanelWrapper`, `TableRenderer`, `ChartRenderer`, `PanelContext`), `@debrief/utils` (`buildCsvContent`, `generateCsvFilename`, `sanitizeFilename`, NEW `parseCsvToTableDataset` and NEW `synthesizeTableDataset`), `@debrief/session-state` (`LogService` — extended with `recordFileSaved`), existing `apps/vscode/src/services/stacService.ts`
-- 175-review-feedback: Added Python 3.11 (service, schema), TypeScript 5.x (frontend components, VS Code extension) + Pydantic v2 (models), LinkML >= 1.7.0 (schema), `ulid` (ID generation), React 18.x (UI), `@tanstack/react-virtual` (list virtualisation)

--- a/specs/181-linkml-platform-overrides/checklists/requirements.md
+++ b/specs/181-linkml-platform-overrides/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: LinkML Per-Platform Override Fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-13  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. No [NEEDS CLARIFICATION] markers were needed -- the epic document (E10) provides comprehensive design context with specific field names, types, constraints, and the resolution model.
+- UI Feature Validation section skipped -- this is a schema/infrastructure feature with no user-facing interface.
+- The spec intentionally avoids naming specific technologies (LinkML, Pydantic, TypeScript) in functional requirements, using generic terms like "schema", "generated models", and "generated types" instead. Technology names appear only in the header metadata and assumptions section where they provide necessary project context.
+- Specs without UI sections should skip the UI Feature Validation checklist entirely.

--- a/specs/181-linkml-platform-overrides/checklists/requirements.md
+++ b/specs/181-linkml-platform-overrides/checklists/requirements.md
@@ -35,3 +35,4 @@
 - UI Feature Validation section skipped -- this is a schema/infrastructure feature with no user-facing interface.
 - The spec intentionally avoids naming specific technologies (LinkML, Pydantic, TypeScript) in functional requirements, using generic terms like "schema", "generated models", and "generated types" instead. Technology names appear only in the header metadata and assumptions section where they provide necessary project context.
 - Specs without UI sections should skip the UI Feature Validation checklist entirely.
+- **Scope expanded (2026-04-13)**: Per user direction, flat aggregate fields (`vessel_classes`, `nationalities`, `track_names`) are being removed (not preserved). All consumer code and fixtures are migrated atomically. Constitution Article XIV (Pre-Release Freedom) permits this breaking change.

--- a/specs/181-linkml-platform-overrides/data-model.md
+++ b/specs/181-linkml-platform-overrides/data-model.md
@@ -40,28 +40,36 @@ Represents fully-resolved metadata for a single platform within a STAC item. Pro
 
 ### Modified: StacExtensionProperties (stac-extension.yaml)
 
-**New field**:
+**Added**:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `platforms` | PlatformRecord[] | No | Fully-resolved per-platform metadata array. Each entry represents one platform in the plot with merged registry + override data. |
 
-**Existing fields preserved** (backward compatibility):
-- `vessel_classes` -- flat list of taxonomy paths
-- `tags` -- plot-level tags
-- `feature_tags` -- union of feature-level tags
-- `track_names` -- flat list of track names
-- `nationalities` -- flat list of nationality codes
+**Removed** (replaced by `platforms`):
+
+| Field | Reason |
+|-------|--------|
+| `vessel_classes` | Flat list of taxonomy paths -- now `platforms[].vessel_class` |
+| `nationalities` | Flat list of country codes -- now `platforms[].nationality` |
+| `track_names` | Flat list of track names -- now `platforms[].name` |
+
+**Retained** (not platform-related):
+- `tags` -- plot-level tags (independent of platforms)
+- `feature_tags` -- union of feature-level tags (independent of platforms)
 
 ### Modified: StacItemSummary (stac-extension.yaml)
 
-**New field**:
+**Added**:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `platforms` | PlatformRecord[] | No | Same structure as StacExtensionProperties.platforms. Carried on the summary for filtering. |
 
-**Existing fields preserved**: All 15 current fields unchanged.
+**Removed** (same three fields as StacExtensionProperties):
+- `vessel_classes`, `nationalities`, `track_names`
+
+**Retained**: `id`, `title`, `datetime`, `item_path`, `catalog_id`, `store_id`, `bbox`, `start_datetime`, `end_datetime`, `tags`, `feature_tags`, `platforms`.
 
 ## Enum Changes
 

--- a/specs/181-linkml-platform-overrides/data-model.md
+++ b/specs/181-linkml-platform-overrides/data-model.md
@@ -1,0 +1,110 @@
+# Data Model: LinkML Per-Platform Override Fields
+
+**Feature**: 181-linkml-platform-overrides  
+**Date**: 2026-04-13
+
+## Entity Changes
+
+### Modified: TrackProperties (geojson.yaml)
+
+TrackProperties gains six optional override fields. These are **analyst-set overrides** -- they are only populated when the analyst explicitly provides values that differ from the platform registry. When absent, downstream consumers resolve the values from the registry at runtime.
+
+**New fields** (all optional, appended after existing fields):
+
+| Field | Type | Constraint | Description |
+|-------|------|-----------|-------------|
+| `display_name` | string | None | Human-readable name (e.g., "HMS Nelson"). Overrides registry `name`. |
+| `nationality` | string | `^[A-Z]{2}$` | ISO 3166-1 alpha-2 country code. Overrides registry `nationality`. |
+| `vessel_class` | string | `^[a-z0-9-]+(/[a-z0-9-]+){0,3}$` | Full taxonomy path (e.g., "surface/warship/frigate/type23"). Overrides registry-derived path. |
+| `vessel_type` | string | `^[a-z0-9-]+$` | Leaf of class path (e.g., "type23"). Overrides registry-derived type. |
+| `vessel_role` | string | `^[a-z0-9-]+$` | Parent of leaf (e.g., "frigate"). Overrides registry-derived role. |
+| `domain` | VesselDomainEnum | surface, subsurface, unknown | First segment of class path. Overrides registry-derived domain. |
+
+**Existing fields unchanged**: `kind`, `platform_id`, `platform_name`, `track_type`, `start_time`, `end_time`, `positions`, `style`, `default_position_style`, `symbol_interval`, `label_interval`, `position_style_overrides`, `segments`, `sensors`, `tuas` (inherited: `tags`, `provenance`).
+
+### New: PlatformRecord (stac-extension.yaml)
+
+Represents fully-resolved metadata for a single platform within a STAC item. Produced by the save-time resolution handler (#183) by merging registry lookups with analyst-set overrides.
+
+| Field | Type | Required | Constraint | Description |
+|-------|------|----------|-----------|-------------|
+| `id` | string | Yes | None | Platform identifier (e.g., "NELSON"). Matches `platform_id` on TrackProperties. |
+| `name` | string | No | None | Human-readable name (e.g., "HMS Nelson"). |
+| `nationality` | string | No | `^[A-Z]{2}$` | ISO 3166-1 alpha-2 country code. |
+| `vessel_class` | string | No | `^[a-z0-9-]+(/[a-z0-9-]+){0,3}$` | Full taxonomy path. |
+| `vessel_type` | string | No | `^[a-z0-9-]+$` | Leaf of class path. |
+| `vessel_role` | string | No | `^[a-z0-9-]+$` | Parent of leaf. |
+| `domain` | VesselDomainEnum | No | surface, subsurface, unknown | Vessel domain classification. |
+
+**Sparsity rule**: Only `id` is required. A record with only `id` is valid -- this represents an unregistered platform with no registry data and no analyst overrides.
+
+### Modified: StacExtensionProperties (stac-extension.yaml)
+
+**New field**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `platforms` | PlatformRecord[] | No | Fully-resolved per-platform metadata array. Each entry represents one platform in the plot with merged registry + override data. |
+
+**Existing fields preserved** (backward compatibility):
+- `vessel_classes` -- flat list of taxonomy paths
+- `tags` -- plot-level tags
+- `feature_tags` -- union of feature-level tags
+- `track_names` -- flat list of track names
+- `nationalities` -- flat list of nationality codes
+
+### Modified: StacItemSummary (stac-extension.yaml)
+
+**New field**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `platforms` | PlatformRecord[] | No | Same structure as StacExtensionProperties.platforms. Carried on the summary for filtering. |
+
+**Existing fields preserved**: All 15 current fields unchanged.
+
+## Enum Changes
+
+### Moved: VesselDomainEnum (common.yaml <-- stac-extension.yaml)
+
+Relocated from `stac-extension.yaml` to `common.yaml` to enable cross-module use. Definition unchanged.
+
+| Value | Description |
+|-------|-------------|
+| `surface` | Surface vessels (warships, auxiliaries, merchant) |
+| `subsurface` | Subsurface vessels (submarines) |
+| `unknown` | Vessel domain not determined or not applicable |
+
+## Relationships
+
+```
+TrackProperties (geojson.yaml)
+  ├── platform_id: string (required, existing -- key for registry lookup)
+  ├── display_name: string (optional, NEW -- override)
+  ├── nationality: string (optional, NEW -- override)
+  ├── vessel_class: string (optional, NEW -- override)
+  ├── vessel_type: string (optional, NEW -- override)
+  ├── vessel_role: string (optional, NEW -- override)
+  └── domain: VesselDomainEnum (optional, NEW -- override)
+
+PlatformRecord (stac-extension.yaml)
+  ├── id: string (required -- matches platform_id)
+  ├── name: string (optional)
+  ├── nationality: string (optional)
+  ├── vessel_class: string (optional)
+  ├── vessel_type: string (optional)
+  ├── vessel_role: string (optional)
+  └── domain: VesselDomainEnum (optional)
+
+StacExtensionProperties.platforms → PlatformRecord[]
+StacItemSummary.platforms → PlatformRecord[]
+```
+
+## Validation Rules
+
+1. `nationality` pattern `^[A-Z]{2}$` enforces ISO 3166-1 alpha-2 format (exactly 2 uppercase letters).
+2. `vessel_class` pattern `^[a-z0-9-]+(/[a-z0-9-]+){0,3}$` enforces 1-4 lowercase path segments separated by `/`.
+3. `vessel_type` and `vessel_role` pattern `^[a-z0-9-]+$` enforces a single lowercase segment.
+4. `domain` constrained to VesselDomainEnum permissible values.
+5. All new fields are optional -- omission is valid and expected for the common case (no overrides).
+6. PlatformRecord `id` is the only required field in the record.

--- a/specs/181-linkml-platform-overrides/media/linkedin-planning.md
+++ b/specs/181-linkml-platform-overrides/media/linkedin-planning.md
@@ -1,0 +1,11 @@
+"Which exercises involved British submarines?" — a straightforward question that the current data model structurally cannot answer.
+
+The problem: STAC item metadata stores nationalities and vessel classes as flat, disconnected lists. You can filter for British vessels or submarines, but not British submarines — because nothing links which nationality belongs to which vessel.
+
+This week I'm restructuring the LinkML schema to replace those flat lists with a per-platform record array. Each platform carries its own nationality, vessel class, and domain as a unit, making compound queries a matter of standard predicate evaluation rather than impossible cross-referencing. Six optional override fields on track properties give analysts the final word when registry defaults need correcting.
+
+It's a schema-only change — no runtime logic, no UI — but it's the structural foundation that save-time resolution, CQL2 filtering, and eventually natural language search all build against.
+
+Planning post with full details: [link to full post]
+
+#FutureDebrief #MaritimeAnalysis #OpenSource

--- a/specs/181-linkml-platform-overrides/media/planning-post.md
+++ b/specs/181-linkml-platform-overrides/media/planning-post.md
@@ -1,0 +1,48 @@
+---
+layout: future-post
+title: "Planning: Per-Platform Schema Overrides"
+date: 2026-04-14
+track: [momentum]
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, schema, stac, e10-catalog-discovery]
+excerpt: "Restructuring STAC metadata so compound queries like 'British submarines' become possible"
+---
+
+## What We're Building
+
+Today you can ask "which plots have a British vessel?" and you can ask "which plots have a submarine?" What you cannot ask is "which plots have a British submarine?" — because the current STAC metadata stores nationalities and vessel classes as flat, disconnected lists. There's a `debrief:nationalities` array with `["GB", "FR"]` and a `debrief:vessel_classes` array with `["surface/warship/frigate/type23", "subsurface/submarine/ssn/trafalgar"]`, but nothing connecting which nationality belongs to which vessel. The data is there. The structure isn't.
+
+This week we're updating the LinkML schema to fix that. The core change is a new `debrief:platforms` array on STAC items — instead of flat lists, each platform gets its own record carrying nationality, vessel class, domain, and type together as a unit. A `PlatformRecord` with `{id: "NELSON", nationality: "GB", vessel_class: "surface/warship/frigate/type23", domain: "surface"}` is unambiguous. Compound predicates just work.
+
+We're also adding six optional override fields to `TrackProperties` in the GeoJSON schema: `display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, and `domain`. These are analyst-set overrides — they're only populated when someone explicitly provides values that differ from the platform registry (#180). When absent, downstream consumers resolve values from the registry at runtime. This keeps the GeoJSON lightweight while giving analysts the final word on any track's identity.
+
+## How It Fits
+
+This is the second item in the E10 foundation phase (NL-Assisted Catalog Discovery). The platform registry (#180, complete) established the hierarchical vessel class tree — the structure where `NELSON`'s identity is derived from its position at `surface/warship/frigate/type23/NELSON`. This feature encodes those structures into the LinkML schema so that generated Pydantic models and TypeScript types enforce the contracts across every service and frontend.
+
+Everything downstream depends on these schema structures. Save-time resolution (#183) needs `PlatformRecord` to know what shape to produce. The CQL2 `array_filter` evaluator (#185) needs the `debrief:platforms` array to know what shape to query against. The filter bar UI (#186) needs TypeScript types for compound predicates. And eventually, NL query generation (#188) translates natural language into CQL2 that targets these structures. Without the schema, none of those features have a type-safe contract to build against.
+
+## Key Decisions
+
+- **VesselDomainEnum moves from `stac-extension.yaml` to `common.yaml`** — the `domain` field appears on both `TrackProperties` (in `geojson.yaml`) and `PlatformRecord` (in `stac-extension.yaml`). Having GeoJSON depend on the STAC extension is semantically backwards, so the enum moves to the shared foundation module. Both files already import `common.yaml`.
+
+- **PlatformRecord is a STAC extension entity, not a general-purpose type** — it represents fully-resolved metadata produced at save-time by merging registry lookups with analyst overrides. It lives in `stac-extension.yaml` alongside its only consumers: `StacExtensionProperties` and `StacItemSummary`.
+
+- **Flat aggregate fields stay during the transition** — `debrief:vessel_classes`, `debrief:nationalities`, and `debrief:track_names` remain in the schema. All 100 exercise fixtures and any real catalog data use them. We add `debrief:platforms` alongside them, and a later cleanup item removes the flat fields after all consumers have migrated.
+
+- **Only `id` is required on PlatformRecord** — a record with just `{id: "UNKNOWN_CONTACT"}` is valid. This handles unregistered platforms with no registry data and no analyst overrides. Sparse records are a natural state, not an error.
+
+- **Override fields use established pattern constraints** — `nationality` is `^[A-Z]{2}$` (ISO 3166-1 alpha-2), `vessel_class` is `^[a-z0-9-]+(/[a-z0-9-]+){0,3}$` (1-4 slash-delimited lowercase segments), and `domain` reuses the existing `VesselDomainEnum`. No new conventions to learn.
+
+- **Targeted fixtures, not wholesale changes** — we're adding ~7 new golden fixtures covering the new structures (fully-populated records, sparse records, invalid values) without modifying the existing 100-item exercise set. The exercise catalog gets regenerated with `debrief:platforms` in a separate item (#184).
+
+## What We'd Love Feedback On
+
+- **Override field granularity**: We have six fields (`display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`). Some of these are derivable from others — `vessel_type` is the leaf of `vessel_class`, `domain` is the first segment. Should we keep the redundancy for query convenience, or drop the derived fields and compute them at runtime?
+
+- **PlatformRecord identity**: The `id` field matches `platform_id` on `TrackProperties`. Should the same platform appearing in multiple tracks within a plot produce one `PlatformRecord` or multiple? (We're leaning toward one — deduplication at save-time — but the schema doesn't enforce it.)
+
+- **Transition timeline for flat aggregates**: The old `debrief:vessel_classes` / `debrief:nationalities` fields stay for now. Is there a consumer we should be aware of that would break if they were eventually removed? Better to know now.
+
+-> [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/181-linkml-platform-overrides/plan.md
+++ b/specs/181-linkml-platform-overrides/plan.md
@@ -5,19 +5,19 @@
 
 ## Summary
 
-Add optional per-platform override fields (`display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`) to TrackProperties in the LinkML schema. Define a new `PlatformRecord` entity and add a `debrief:platforms` structured array to the STAC extension, replacing the semantic role of flat aggregate fields while preserving them for backward compatibility. Regenerate all derived types (Pydantic, TypeScript, JSON Schema) and update golden fixtures.
+Add optional per-platform override fields (`display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`) to TrackProperties in the LinkML schema. Define a new `PlatformRecord` entity and add a `debrief:platforms` structured array to the STAC extension. **Remove** the flat aggregate fields (`vessel_classes`, `nationalities`, `track_names`) from StacExtensionProperties and StacItemSummary -- they are replaced entirely by `platforms`. Regenerate all derived types, migrate all consumer code and fixtures, and ensure `task verify` passes.
 
 ## Technical Context
 
-**Language/Version**: Python 3.11 (schema generation, tests), TypeScript 5.x (generated types, type checking)  
+**Language/Version**: Python 3.11 (schema generation, services, tests), TypeScript 5.x (generated types, consumer code, tests)  
 **Primary Dependencies**: LinkML >= 1.7.0 (schema source), Pydantic v2 (generated Python models), gen-pydantic/gen-typescript/gen-json-schema (code generators)  
-**Storage**: N/A (schema definitions only; no runtime storage changes)  
-**Testing**: pytest (Python golden fixture + round-trip tests), vitest + tsc (TypeScript type checking)  
+**Storage**: N/A (schema definitions; no runtime storage changes)  
+**Testing**: pytest (Python golden fixture + round-trip + service tests), vitest (TypeScript filter engine + component tests), tsc (type checking)  
 **Target Platform**: Cross-platform (schema artifacts consumed by all services and frontends)  
-**Project Type**: Monorepo schema module (`shared/schemas/`)  
+**Project Type**: Monorepo -- changes span `shared/schemas/`, `shared/components/`, `shared/data/`, `apps/vscode/`, `apps/web-shell/`, `services/stac/`, `scripts/`  
 **Performance Goals**: N/A (schema-time, not runtime)  
-**Constraints**: All existing fixtures must continue to validate (zero backward-compatibility regressions)  
-**Scale/Scope**: 3 LinkML YAML files modified, ~4-8 new fixture files, 3 generated output directories regenerated
+**Constraints**: `task verify` must pass with zero failures. No backward compatibility obligation (Constitution Article XIV).  
+**Scale/Scope**: 3 LinkML YAML files modified, ~15 TypeScript consumer files migrated, ~5 Python consumer files migrated, ~10 test files updated, 100 exercise fixtures regenerated, 3 generated output directories regenerated
 
 ## Constitution Check
 
@@ -27,17 +27,18 @@ Add optional per-platform override fields (`display_name`, `nationality`, `vesse
 |---------|-------------|--------|-------|
 | II.1 Single source of truth | LinkML master schemas define all data structures; derived types are never hand-written | PASS | All changes are to LinkML source; Pydantic/TS/JSON Schema are regenerated |
 | II.2 Schema tests mandatory | Derived schemas must pass adherence tests before merge | PASS | Golden fixture tests, round-trip tests, and structural comparison all run in CI |
-| II.3 Schema versioning | Breaking changes require version bump and migration path | PASS | No breaking changes -- all new fields are optional, all old fields preserved |
-| IV.1 Services never touch UI | Python services return data only | N/A | No service or UI changes in this feature |
+| II.3 Schema versioning | Breaking changes require version bump and migration path | PASS (XIV) | Breaking change permitted under Article XIV (pre-release freedom). No production users. |
+| IV.1 Services never touch UI | Python services return data only | PASS | Service changes (collection.py, models.py) only affect data structures, not UI |
 | VI.1 Schema tests gate merges | Derived schema adherence tests must pass | PASS | `task verify` runs lint + typecheck + test including schema tests |
 | VII.1 Tests before implementation | Define expected behaviour as executable tests before implementing | PASS | Golden fixtures (expected valid/invalid) define acceptance criteria |
 | VIII.1 Specs before code | No implementation without written specification | PASS | Spec written and approved before this plan |
 | IX.1 Minimal dependencies | External dependencies must be justified | PASS | No new dependencies added |
 | XIII.3 CI must pass | All automated checks green before merge | PASS | `task verify` is the gate |
+| XIV Pre-release freedom | Breaking changes permitted before v4.0.0 | INVOKED | Flat aggregate field removal is a breaking schema change, permitted by this article |
 | XV.1 Explicit types | All types must have explicit annotations | PASS | Generated types are fully typed by the LinkML generators |
 | XV.4 Schema types canonical | Generated types must be fully typed with no Any/any | PASS | gen-pydantic uses `--extra-fields forbid`; post-processing replaces `dict[str, Any]` with `dict[str, object]` |
 
-**Gate result**: PASS -- no violations.
+**Gate result**: PASS -- Article XIV invoked for breaking schema change. No other violations.
 
 ## Project Structure
 
@@ -60,38 +61,108 @@ specs/181-linkml-platform-overrides/
 ### Source Code (repository root)
 
 ```text
-shared/schemas/
-├── src/
-│   ├── linkml/
-│   │   ├── common.yaml              # MODIFIED: VesselDomainEnum moved here
-│   │   ├── geojson.yaml             # MODIFIED: 6 override fields on TrackProperties
-│   │   ├── stac-extension.yaml      # MODIFIED: PlatformRecord + platforms field
-│   │   └── debrief.yaml             # UNCHANGED (imports all modules transitively)
-│   ├── fixtures/
-│   │   ├── valid/
-│   │   │   ├── track-feature-platform-overrides-01.json    # NEW
-│   │   │   └── track-feature-platform-overrides-minimal-01.json  # NEW
-│   │   └── invalid/
-│   │       ├── track-feature-invalid-nationality.json      # NEW
-│   │       └── track-feature-invalid-domain.json           # NEW
-│   └── generated/
-│       ├── python/debrief_schemas/__init__.py    # REGENERATED
-│       ├── typescript/types.ts                   # REGENERATED
-│       └── json-schema/*.schema.json             # REGENERATED
-├── fixtures/
-│   └── stac-browser/
-│       ├── valid/
-│       │   ├── extension-platforms-full.json      # NEW
-│       │   └── extension-platforms-sparse.json    # NEW
-│       └── invalid/
-│           └── invalid-platform-nationality.json  # NEW
-└── tests/
-    ├── test_golden.py              # UNCHANGED (auto-discovers new fixtures)
-    ├── test_stac_extension.py      # MODIFIED: add platforms round-trip test
-    └── test_roundtrip.py           # UNCHANGED (TrackFeature round-trip auto-covers new optional fields)
+# Layer 1: Schema (source of truth)
+shared/schemas/src/linkml/
+├── common.yaml              # MODIFIED: VesselDomainEnum moved here
+├── geojson.yaml             # MODIFIED: 6 override fields on TrackProperties
+├── stac-extension.yaml      # MODIFIED: PlatformRecord + platforms; REMOVED vessel_classes, nationalities, track_names
+└── debrief.yaml             # UNCHANGED (imports all modules transitively)
+
+# Layer 2: Generated types (auto-regenerated)
+shared/schemas/src/generated/
+├── python/debrief_schemas/__init__.py    # REGENERATED
+├── typescript/types.ts                   # REGENERATED
+└── json-schema/*.schema.json             # REGENERATED
+
+# Layer 3: Fixtures (must match current schema)
+shared/schemas/src/fixtures/
+├── valid/
+│   ├── track-feature-platform-overrides-01.json    # NEW
+│   └── track-feature-platform-overrides-minimal-01.json  # NEW
+└── invalid/
+    ├── track-feature-invalid-nationality.json      # NEW
+    └── track-feature-invalid-domain.json           # NEW
+
+shared/schemas/fixtures/stac-browser/
+├── valid/
+│   ├── extension-basic.json           # MODIFIED: flat fields → platforms
+│   ├── extension-partial-path.json    # MODIFIED: flat fields → platforms
+│   ├── extension-empty-arrays.json    # MODIFIED: flat fields → platforms
+│   ├── extension-platforms-full.json   # NEW
+│   └── extension-platforms-sparse.json # NEW
+├── invalid/
+│   ├── invalid-platform-nationality.json  # NEW (or repurposed)
+│   └── invalid-uppercase-vessel.json      # MODIFIED: test platforms[].vessel_class
+└── exercise-*/item.json               # REGENERATED (100 items, via generation script)
+
+# Layer 4: Schema tests
+shared/schemas/tests/
+├── test_golden.py              # UNCHANGED (auto-discovers fixtures)
+├── test_stac_extension.py      # MODIFIED: remove flat-field assertions, add platforms tests
+└── test_roundtrip.py           # UNCHANGED (auto-covers new optional fields)
+
+# Layer 5: Consumer code — TypeScript
+shared/components/src/filter-engine/
+├── types.ts                    # MODIFIED: CatalogOverviewItem replaces flat fields with platforms
+├── matchers.ts                 # MODIFIED: match on platforms[] instead of flat arrays
+└── cql2-json.ts                # MODIFIED: STAC property name mappings
+
+shared/components/src/FilterBar/
+├── useDistinctValues.ts        # MODIFIED: derive values from platforms[]
+└── useTaxonomyMatchCounts.ts   # MODIFIED: iterate platforms[].vessel_class
+
+shared/components/src/ExerciseListView/
+└── types.ts                    # MODIFIED: replace flat fields with platforms
+
+apps/vscode/src/
+├── types/stac.ts               # MODIFIED: StacBrowserItem replaces flat fields with platforms
+├── services/stacService.ts     # MODIFIED: read debrief:platforms from item properties
+├── panels/catalogOverviewPanel.ts  # MODIFIED: map platforms to message format
+└── webview/messages.ts         # MODIFIED: CatalogItem type uses platforms
+
+apps/web-shell/src/
+├── App.tsx                     # MODIFIED: transform platforms to internal format
+└── mocks/stacService.ts        # MODIFIED: mock data uses platforms
+
+# Layer 5: Consumer code — Python
+services/stac/src/debrief_stac/
+├── collection.py               # MODIFIED: summaries use platforms
+└── models.py                   # MODIFIED: CatalogSummaries uses platforms
+
+scripts/
+└── enrich-legacy-catalog.py    # MODIFIED: write debrief:platforms instead of flat fields
+
+# Layer 6: Consumer tests
+shared/components/src/filter-engine/__tests__/
+├── matchers.test.ts            # MODIFIED: mock data + assertions
+├── cql2-json.test.ts           # MODIFIED: property name changes
+└── fixtures.ts                 # MODIFIED: mock item builder
+
+shared/components/src/FilterBar/__tests__/
+├── useDistinctValues.test.ts   # MODIFIED: mock data + assertions
+└── useTaxonomyMatchCounts.test.ts  # MODIFIED: mock data + assertions
+
+shared/components/src/StacBrowser/__tests__/
+└── useBrowserFilter.test.ts    # MODIFIED: mock data
+
+shared/components/src/ExerciseListView/
+└── __fixtures__/mockData.ts    # MODIFIED: mock items use platforms
+
+apps/vscode/
+├── tests/unit/stacTreeProvider.test.ts  # MODIFIED: mock data
+└── src/webview/messages.test.ts         # MODIFIED: mock data
+
+services/stac/tests/
+└── test_collection.py          # MODIFIED: summary assertions
+
+# Storybook stories (mock data updates)
+shared/components/src/StacBrowser/StacBrowser.stories.tsx   # MODIFIED
+shared/components/src/FilterBar/FilterBar.stories.tsx       # MODIFIED
+shared/components/src/FilterBar/SavedFilters.stories.tsx    # MODIFIED
+shared/components/src/TimelineView/TimelineView.stories.tsx # MODIFIED
 ```
 
-**Structure Decision**: All changes are within the existing `shared/schemas/` module. No new directories or projects created. The schema module already has the correct structure for source LinkML, fixtures, generated output, and tests.
+**Structure Decision**: Changes span 6 layers of the existing monorepo structure. No new directories or projects created. The schema module owns the source of truth; generated types propagate changes; consumers and fixtures are updated atomically.
 
 ## Media Components
 
@@ -99,7 +170,7 @@ None - backend/infrastructure feature. No visual components, Storybook stories, 
 
 ## Storybook E2E Testing
 
-None - no interactive UI components.
+None - no interactive UI components. Storybook story mock data is updated but no new visual behaviour to test.
 
 ## VS Code Webview E2E Testing
 
@@ -107,4 +178,6 @@ None - no extension workflow changes.
 
 ## Complexity Tracking
 
-No constitution violations to justify. All changes are additive and follow established patterns.
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Breaking schema change (Art. II.3) | Clean data model with one canonical representation for platform metadata | Keeping flat fields alongside `platforms` creates dual-representation cruft with no production users to protect. Article XIV explicitly permits this. |

--- a/specs/181-linkml-platform-overrides/plan.md
+++ b/specs/181-linkml-platform-overrides/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: LinkML Per-Platform Override Fields
+
+**Branch**: `181-linkml-platform-overrides` | **Date**: 2026-04-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/181-linkml-platform-overrides/spec.md`
+
+## Summary
+
+Add optional per-platform override fields (`display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`) to TrackProperties in the LinkML schema. Define a new `PlatformRecord` entity and add a `debrief:platforms` structured array to the STAC extension, replacing the semantic role of flat aggregate fields while preserving them for backward compatibility. Regenerate all derived types (Pydantic, TypeScript, JSON Schema) and update golden fixtures.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 (schema generation, tests), TypeScript 5.x (generated types, type checking)  
+**Primary Dependencies**: LinkML >= 1.7.0 (schema source), Pydantic v2 (generated Python models), gen-pydantic/gen-typescript/gen-json-schema (code generators)  
+**Storage**: N/A (schema definitions only; no runtime storage changes)  
+**Testing**: pytest (Python golden fixture + round-trip tests), vitest + tsc (TypeScript type checking)  
+**Target Platform**: Cross-platform (schema artifacts consumed by all services and frontends)  
+**Project Type**: Monorepo schema module (`shared/schemas/`)  
+**Performance Goals**: N/A (schema-time, not runtime)  
+**Constraints**: All existing fixtures must continue to validate (zero backward-compatibility regressions)  
+**Scale/Scope**: 3 LinkML YAML files modified, ~4-8 new fixture files, 3 generated output directories regenerated
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Requirement | Status | Notes |
+|---------|-------------|--------|-------|
+| II.1 Single source of truth | LinkML master schemas define all data structures; derived types are never hand-written | PASS | All changes are to LinkML source; Pydantic/TS/JSON Schema are regenerated |
+| II.2 Schema tests mandatory | Derived schemas must pass adherence tests before merge | PASS | Golden fixture tests, round-trip tests, and structural comparison all run in CI |
+| II.3 Schema versioning | Breaking changes require version bump and migration path | PASS | No breaking changes -- all new fields are optional, all old fields preserved |
+| IV.1 Services never touch UI | Python services return data only | N/A | No service or UI changes in this feature |
+| VI.1 Schema tests gate merges | Derived schema adherence tests must pass | PASS | `task verify` runs lint + typecheck + test including schema tests |
+| VII.1 Tests before implementation | Define expected behaviour as executable tests before implementing | PASS | Golden fixtures (expected valid/invalid) define acceptance criteria |
+| VIII.1 Specs before code | No implementation without written specification | PASS | Spec written and approved before this plan |
+| IX.1 Minimal dependencies | External dependencies must be justified | PASS | No new dependencies added |
+| XIII.3 CI must pass | All automated checks green before merge | PASS | `task verify` is the gate |
+| XV.1 Explicit types | All types must have explicit annotations | PASS | Generated types are fully typed by the LinkML generators |
+| XV.4 Schema types canonical | Generated types must be fully typed with no Any/any | PASS | gen-pydantic uses `--extra-fields forbid`; post-processing replaces `dict[str, Any]` with `dict[str, object]` |
+
+**Gate result**: PASS -- no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/181-linkml-platform-overrides/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research decisions
+├── data-model.md        # Entity changes and relationships
+├── quickstart.md        # Step-by-step implementation guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── media/
+    ├── planning-post.md # Blog post draft
+    └── linkedin-planning.md # LinkedIn summary
+```
+
+### Source Code (repository root)
+
+```text
+shared/schemas/
+├── src/
+│   ├── linkml/
+│   │   ├── common.yaml              # MODIFIED: VesselDomainEnum moved here
+│   │   ├── geojson.yaml             # MODIFIED: 6 override fields on TrackProperties
+│   │   ├── stac-extension.yaml      # MODIFIED: PlatformRecord + platforms field
+│   │   └── debrief.yaml             # UNCHANGED (imports all modules transitively)
+│   ├── fixtures/
+│   │   ├── valid/
+│   │   │   ├── track-feature-platform-overrides-01.json    # NEW
+│   │   │   └── track-feature-platform-overrides-minimal-01.json  # NEW
+│   │   └── invalid/
+│   │       ├── track-feature-invalid-nationality.json      # NEW
+│   │       └── track-feature-invalid-domain.json           # NEW
+│   └── generated/
+│       ├── python/debrief_schemas/__init__.py    # REGENERATED
+│       ├── typescript/types.ts                   # REGENERATED
+│       └── json-schema/*.schema.json             # REGENERATED
+├── fixtures/
+│   └── stac-browser/
+│       ├── valid/
+│       │   ├── extension-platforms-full.json      # NEW
+│       │   └── extension-platforms-sparse.json    # NEW
+│       └── invalid/
+│           └── invalid-platform-nationality.json  # NEW
+└── tests/
+    ├── test_golden.py              # UNCHANGED (auto-discovers new fixtures)
+    ├── test_stac_extension.py      # MODIFIED: add platforms round-trip test
+    └── test_roundtrip.py           # UNCHANGED (TrackFeature round-trip auto-covers new optional fields)
+```
+
+**Structure Decision**: All changes are within the existing `shared/schemas/` module. No new directories or projects created. The schema module already has the correct structure for source LinkML, fixtures, generated output, and tests.
+
+## Media Components
+
+None - backend/infrastructure feature. No visual components, Storybook stories, or UI changes.
+
+## Storybook E2E Testing
+
+None - no interactive UI components.
+
+## VS Code Webview E2E Testing
+
+None - no extension workflow changes.
+
+## Complexity Tracking
+
+No constitution violations to justify. All changes are additive and follow established patterns.

--- a/specs/181-linkml-platform-overrides/quickstart.md
+++ b/specs/181-linkml-platform-overrides/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart: LinkML Per-Platform Override Fields
+
+**Feature**: 181-linkml-platform-overrides  
+**Date**: 2026-04-13
+
+## Prerequisites
+
+- Python 3.11+ with `uv` installed
+- Node.js 18+ with `pnpm` installed
+- Feature #180 (platform registry) complete on `main`
+
+## Implementation Steps
+
+### Step 1: Move VesselDomainEnum to common.yaml
+
+1. Open `shared/schemas/src/linkml/common.yaml`
+2. Add `VesselDomainEnum` to the `enums` section (copy definition from stac-extension.yaml)
+3. Open `shared/schemas/src/linkml/stac-extension.yaml`
+4. Remove `VesselDomainEnum` from the `enums` section
+5. Add `common` to the `imports` list
+
+### Step 2: Add Override Fields to TrackProperties
+
+1. Open `shared/schemas/src/linkml/geojson.yaml`
+2. Add six optional fields to `TrackProperties.attributes` after the existing `tuas` field:
+   - `display_name` (string, optional)
+   - `nationality` (string, optional, pattern `^[A-Z]{2}$`)
+   - `vessel_class` (string, optional, pattern `^[a-z0-9-]+(/[a-z0-9-]+){0,3}$`)
+   - `vessel_type` (string, optional, pattern `^[a-z0-9-]+$`)
+   - `vessel_role` (string, optional, pattern `^[a-z0-9-]+$`)
+   - `domain` (VesselDomainEnum, optional)
+
+### Step 3: Add PlatformRecord and Platforms Field
+
+1. Open `shared/schemas/src/linkml/stac-extension.yaml`
+2. Add `PlatformRecord` class with fields: `id` (required), `name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain` (all optional)
+3. Add `platforms` field to `StacExtensionProperties` (optional, multivalued PlatformRecord)
+4. Add `platforms` field to `StacItemSummary` (optional, multivalued PlatformRecord)
+
+### Step 4: Regenerate Types
+
+```bash
+cd shared/schemas
+make generate
+```
+
+This runs `generate-pydantic`, `generate-jsonschema`, and `generate-typescript` in sequence.
+
+### Step 5: Add Golden Fixtures
+
+1. Add valid TrackFeature fixtures with override fields to `shared/schemas/src/fixtures/valid/`
+2. Add invalid TrackFeature fixtures to `shared/schemas/src/fixtures/invalid/`
+3. Add valid/invalid STAC extension fixtures with platforms to `shared/schemas/fixtures/stac-browser/valid/` and `invalid/`
+
+### Step 6: Run Tests
+
+```bash
+# Schema tests (Python)
+cd shared/schemas
+uv run pytest tests/ -v
+
+# TypeScript type checking
+pnpm -r typecheck
+
+# Full verification
+cd ../..
+task verify
+```
+
+## Verification Checklist
+
+- [ ] `VesselDomainEnum` is in `common.yaml`, not in `stac-extension.yaml`
+- [ ] `TrackProperties` has 6 new optional fields in `geojson.yaml`
+- [ ] `PlatformRecord` class defined in `stac-extension.yaml`
+- [ ] `platforms` field on `StacExtensionProperties` and `StacItemSummary`
+- [ ] Generated Pydantic models include new fields
+- [ ] Generated TypeScript types include new fields
+- [ ] Generated JSON Schema includes new fields
+- [ ] New valid fixtures pass validation
+- [ ] New invalid fixtures fail validation
+- [ ] Existing fixtures still pass (backward compatibility)
+- [ ] `task verify` passes

--- a/specs/181-linkml-platform-overrides/quickstart.md
+++ b/specs/181-linkml-platform-overrides/quickstart.md
@@ -30,12 +30,14 @@
    - `vessel_role` (string, optional, pattern `^[a-z0-9-]+$`)
    - `domain` (VesselDomainEnum, optional)
 
-### Step 3: Add PlatformRecord and Platforms Field
+### Step 3: Add PlatformRecord and Replace Flat Fields
 
 1. Open `shared/schemas/src/linkml/stac-extension.yaml`
 2. Add `PlatformRecord` class with fields: `id` (required), `name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain` (all optional)
 3. Add `platforms` field to `StacExtensionProperties` (optional, multivalued PlatformRecord)
-4. Add `platforms` field to `StacItemSummary` (optional, multivalued PlatformRecord)
+4. **Remove** `vessel_classes`, `nationalities`, `track_names` from `StacExtensionProperties`
+5. Add `platforms` field to `StacItemSummary` (optional, multivalued PlatformRecord)
+6. **Remove** `vessel_classes`, `nationalities`, `track_names` from `StacItemSummary`
 
 ### Step 4: Regenerate Types
 
@@ -44,28 +46,59 @@ cd shared/schemas
 make generate
 ```
 
-This runs `generate-pydantic`, `generate-jsonschema`, and `generate-typescript` in sequence.
-
-### Step 5: Add Golden Fixtures
+### Step 5: Update Golden Fixtures
 
 1. Add valid TrackFeature fixtures with override fields to `shared/schemas/src/fixtures/valid/`
 2. Add invalid TrackFeature fixtures to `shared/schemas/src/fixtures/invalid/`
-3. Add valid/invalid STAC extension fixtures with platforms to `shared/schemas/fixtures/stac-browser/valid/` and `invalid/`
+3. Update existing STAC extension valid/invalid fixtures to use `platforms` instead of flat fields
+4. Add new STAC extension fixtures (`extension-platforms-full.json`, `extension-platforms-sparse.json`)
+5. Update exercise fixture generation script to produce `debrief:platforms` format
+6. Regenerate all 100 exercise fixtures
 
-### Step 6: Run Tests
+### Step 6: Migrate TypeScript Consumer Code
+
+Update all TypeScript files that reference the removed flat fields:
+
+1. **Types**: Replace `vesselClasses`, `nationalities`, `trackNames` with `platforms` array on:
+   - `apps/vscode/src/types/stac.ts` (StacBrowserItem)
+   - `shared/components/src/filter-engine/types.ts` (CatalogOverviewItem)
+   - `shared/components/src/ExerciseListView/types.ts`
+   - `apps/vscode/src/webview/messages.ts` (CatalogItem)
+
+2. **Services**: Update to read/write `debrief:platforms`:
+   - `apps/vscode/src/services/stacService.ts`
+   - `apps/vscode/src/panels/catalogOverviewPanel.ts`
+   - `apps/web-shell/src/App.tsx`
+
+3. **Filter engine**: Derive flat values from `platforms[]`:
+   - `shared/components/src/filter-engine/matchers.ts`
+   - `shared/components/src/filter-engine/cql2-json.ts`
+   - `shared/components/src/FilterBar/useDistinctValues.ts`
+   - `shared/components/src/FilterBar/useTaxonomyMatchCounts.ts`
+
+4. **Mocks and stories**: Update mock data:
+   - `apps/web-shell/src/mocks/stacService.ts`
+   - All Storybook `.stories.tsx` files with STAC mock data
+
+### Step 7: Migrate Python Consumer Code
+
+1. `services/stac/src/debrief_stac/collection.py` -- summaries aggregate from `platforms`
+2. `services/stac/src/debrief_stac/models.py` -- CatalogSummaries uses `platforms`
+3. `scripts/enrich-legacy-catalog.py` -- write `debrief:platforms` instead of flat properties
+
+### Step 8: Update Tests
+
+1. `shared/schemas/tests/test_stac_extension.py` -- remove flat-field assertions, add platforms tests
+2. `services/stac/tests/test_collection.py` -- update summary assertions
+3. All TypeScript test files with mock STAC data (see plan.md Layer 6 for full list)
+
+### Step 9: Run Verification
 
 ```bash
-# Schema tests (Python)
-cd shared/schemas
-uv run pytest tests/ -v
-
-# TypeScript type checking
-pnpm -r typecheck
-
-# Full verification
-cd ../..
 task verify
 ```
+
+This runs lint, typecheck, and test. All must pass.
 
 ## Verification Checklist
 
@@ -73,10 +106,14 @@ task verify
 - [ ] `TrackProperties` has 6 new optional fields in `geojson.yaml`
 - [ ] `PlatformRecord` class defined in `stac-extension.yaml`
 - [ ] `platforms` field on `StacExtensionProperties` and `StacItemSummary`
-- [ ] Generated Pydantic models include new fields
-- [ ] Generated TypeScript types include new fields
-- [ ] Generated JSON Schema includes new fields
+- [ ] `vessel_classes`, `nationalities`, `track_names` REMOVED from StacExtensionProperties and StacItemSummary
+- [ ] Generated Pydantic models reflect removals and additions
+- [ ] Generated TypeScript types reflect removals and additions
+- [ ] Generated JSON Schema reflects removals and additions
+- [ ] All STAC extension fixtures use `platforms`, no flat aggregate fields remain
+- [ ] All 100 exercise fixtures regenerated with `debrief:platforms`
+- [ ] All TypeScript consumer code compiles (no references to removed fields)
+- [ ] All Python consumer code passes type checking
 - [ ] New valid fixtures pass validation
 - [ ] New invalid fixtures fail validation
-- [ ] Existing fixtures still pass (backward compatibility)
-- [ ] `task verify` passes
+- [ ] `task verify` passes with zero failures

--- a/specs/181-linkml-platform-overrides/research.md
+++ b/specs/181-linkml-platform-overrides/research.md
@@ -52,23 +52,35 @@
 
 **Rationale**: Reuses existing patterns where they exist (nationality, vessel_class) and derives new patterns (vessel_type, vessel_role) from the established convention of lowercase alphanumeric segments.
 
-## Decision 4: Backward Compatibility Strategy for STAC Extension
+## Decision 4: Remove Flat Aggregate Fields (No Backward Compatibility)
 
-**Context**: Existing STAC items use flat aggregate fields (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`). The new `debrief:platforms` array replaces the semantic role of these fields but we cannot break existing data.
+**Context**: Existing STAC items use flat aggregate fields (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`). The new `debrief:platforms` array replaces them entirely.
 
-**Decision**: Keep all existing flat aggregate fields. Add `platforms` as a new optional field alongside them. Do not remove any existing fields in this feature.
+**Decision**: Remove `vessel_classes`, `nationalities`, and `track_names` from StacExtensionProperties and StacItemSummary. Replace with `platforms` only. Update all consumers and fixtures atomically.
 
 **Rationale**:
-- All 100 exercise fixtures and any real catalog data use the flat aggregate fields.
-- The save-time resolution handler (#183) will be responsible for populating `platforms` and deciding when to stop writing flat aggregates.
-- Constitution Article XIV (Pre-Release Freedom) permits breaking changes, but there is no benefit to a breaking change here -- the additive approach is simpler and safer.
-- The flat fields can be deprecated and removed in a later cleanup item after all consumers have migrated to `platforms`.
+- Constitution Article XIV (Pre-Release Freedom) explicitly permits breaking changes before v4.0.0. We are not in production.
+- Keeping dead fields alongside their replacement creates ambiguity about which is authoritative and confuses developers.
+- A clean break now avoids the tech debt of maintaining two parallel representations and a future deprecation/migration cycle.
+- All 100 exercise fixtures are script-generated and can be regenerated. The preview/workspace/samples data is regenerated separately in #184.
+
+**Blast radius** (from codebase analysis):
+- 3 LinkML schema files (source of truth)
+- ~15 TypeScript consumer files (types, services, filter engine, stories, mocks)
+- ~5 Python consumer files (stac service, enrichment script, collection summaries)
+- ~10 test files (assertions, mock data)
+- ~100 exercise fixture JSON files (script-regenerated)
+- ~7 STAC browser valid/invalid fixtures
+
+**Alternatives Considered**:
+1. **Keep flat fields during transition** -- Rejected. Creates dual-representation cruft with no production users to protect. Every downstream item would need to handle both formats.
+2. **Deprecation period** -- Rejected. Constitution XIV suspends deprecation rules before v4.0.0.
 
 ## Decision 5: Fixture Coverage Strategy
 
-**Context**: Need to add fixtures covering the new schema structures without disrupting the existing 100-item exercise fixture set.
+**Context**: Need to add fixtures for new structures AND migrate all existing fixtures away from removed flat fields.
 
-**Decision**: Add targeted fixtures in both fixture locations:
+**Decision**: Full fixture migration:
 
 1. **Core fixtures** (`shared/schemas/src/fixtures/`):
    - `valid/track-feature-platform-overrides-01.json` -- TrackFeature with all six override fields populated
@@ -80,22 +92,41 @@
    - `valid/extension-platforms-full.json` -- StacExtensionProperties with fully-populated platforms array
    - `valid/extension-platforms-sparse.json` -- StacExtensionProperties with sparse record (id-only)
    - `invalid/invalid-platform-nationality.json` -- Platform record with invalid nationality
+   - Update existing valid fixtures (`extension-basic.json`, `extension-partial-path.json`, `extension-empty-arrays.json`) to use `platforms` instead of flat fields
+   - Update existing invalid fixtures to test new structure constraints
+   - Remove `invalid-uppercase-vessel.json` (tests a removed field) or repurpose for `platforms[].vessel_class`
 
-3. **Existing exercise fixtures**: Not modified. They will gain `debrief:platforms` when the catalog is regenerated (#184).
+3. **Exercise fixtures** (100 items): Update the fixture generation script (`shared/schemas/scripts/generate-stac-fixtures.py`) to produce `debrief:platforms` format, then regenerate all 100 exercises.
 
-**Rationale**: Targeted fixtures test the new fields without modifying the carefully-balanced 100-item exercise set. The exercise set is regenerated separately in #184.
+**Rationale**: All fixtures must conform to the current schema. Leaving old-format fixtures would cause validation failures.
 
-## Decision 6: StacItemSummary Consumer Impact
+## Decision 6: Consumer Migration Strategy
 
-**Context**: `StacItemSummary` has two representations:
-- Generated snake_case version in `shared/schemas/src/generated/typescript/types.ts`
-- Local camelCase version in `apps/vscode/src/types/stac.ts` (used by all VS Code consumers)
+**Context**: Removing the flat fields from the schema means all consumers must migrate atomically or `task verify` fails. Key consumers:
+- `apps/vscode/src/types/stac.ts` -- local camelCase `StacBrowserItem` type
+- `apps/vscode/src/services/stacService.ts` -- reads `debrief:` properties from STAC items
+- `shared/components/src/filter-engine/` -- types, matchers, CQL2 JSON serialization
+- `shared/components/src/FilterBar/` -- distinct value extraction, taxonomy counts
+- `shared/components/src/ExerciseListView/` -- display types
+- `apps/web-shell/src/` -- mock service, App.tsx
+- `services/stac/src/debrief_stac/` -- collection summaries, models
+- `scripts/enrich-legacy-catalog.py` -- enrichment script
 
-The filter engine uses its own `CatalogOverviewItem` interface.
+**Decision**: Migrate all consumers in this feature. For filter engine matchers and display code that need flat lists, derive them from the `platforms` array at the point of use.
 
-**Decision**: This feature only updates the LinkML schema and regenerates types. Consumer updates (VS Code types, stacService, filter engine matchers) are out of scope and will be done in downstream features (#183 for stacService, #185 for filter engine).
+**Rationale**:
+- `task verify` must pass -- leaving broken references is not an option.
+- The derivation pattern is simple: `items.flatMap(i => i.platforms ?? []).map(p => p.nationality).filter(Boolean)` for nationalities, similar for vessel classes and names.
+- The filter engine's `CatalogOverviewItem` type gains a `platforms` field. Matchers that currently match on `vesselClasses[]` and `nationalities[]` will match on `platforms[].vessel_class` and `platforms[].nationality` instead.
+- The CQL2 array_filter evaluator (#185) is a more sophisticated version of this matching -- what we build here is straightforward property access on the platforms array, not the compound predicate engine.
 
-**Rationale**: The spec explicitly scopes this feature to schema + generation + fixtures. Consumer code changes depend on the save-time resolution logic (#183) and CQL2 array_filter (#185), which are separate items.
+**Consumer-specific notes**:
+- `stacService.ts`: Read `debrief:platforms` from item properties instead of three separate fields. Map to camelCase `platforms` on `StacBrowserItem`.
+- `CatalogOverviewItem` / `StacBrowserItem`: Replace `vesselClasses`, `nationalities`, `trackNames` with `platforms` array.
+- Filter matchers: Update to iterate `platforms[]` for vessel class and nationality matching.
+- `useDistinctValues`: Extract distinct values from `platforms` array.
+- Collection summaries (`debrief_stac`): Aggregate from `platforms` arrays instead of flat fields.
+- Enrichment script: Write `debrief:platforms` instead of three separate properties.
 
 ## Technical Notes
 
@@ -118,5 +149,11 @@ debrief.yaml (master -- no changes needed)
 
 ### Test Files Affected
 - `test_golden.py` -- will auto-discover new valid/invalid fixtures
-- `test_stac_extension.py` -- will need new test for platforms round-trip
+- `test_stac_extension.py` -- must be updated: remove flat-field assertions, add platforms round-trip test, update exercise fixture validation
 - `test_roundtrip.py` -- existing TrackFeature round-trip tests should pass (new fields are optional)
+- `test_collection.py` -- must be updated: collection summary tests reference flat fields
+- Filter engine tests (`matchers.test.ts`, `cql2-json.test.ts`, `useBrowserFilter.test.ts`, `useDistinctValues.test.ts`, `useTaxonomyMatchCounts.test.ts`) -- mock data and assertions must use `platforms`
+- `stacTreeProvider.test.ts`, `messages.test.ts` -- mock data must use `platforms`
+
+### Platform Registry Note
+The `vessel_classes` root key in `shared/data/platform-registry.json` is the **registry's own structure**, not the STAC flat aggregate field. It is NOT being renamed or removed. The registry defines a tree of vessel classes; the STAC extension fields that aggregate class paths into flat lists are what's being removed.

--- a/specs/181-linkml-platform-overrides/research.md
+++ b/specs/181-linkml-platform-overrides/research.md
@@ -1,0 +1,122 @@
+# Research: LinkML Per-Platform Override Fields
+
+**Feature**: 181-linkml-platform-overrides  
+**Date**: 2026-04-13
+
+## Decision 1: Where to Define VesselDomainEnum for Cross-Module Use
+
+**Context**: The `domain` field on TrackProperties (in `geojson.yaml`) needs the `VesselDomainEnum` (surface/subsurface/unknown), which is currently defined in `stac-extension.yaml`. However, `geojson.yaml` does not import `stac-extension.yaml`, and having GeoJSON depend on STAC extension is semantically wrong.
+
+**Decision**: Move `VesselDomainEnum` from `stac-extension.yaml` to `common.yaml`.
+
+**Rationale**:
+- `common.yaml` is the shared foundation module already imported by both `geojson.yaml` and (after this change) `stac-extension.yaml`.
+- VesselDomainEnum represents domain-level classification (like `TrackTypeEnum`, `FeatureKindEnum`), not STAC-specific semantics. It belongs alongside other domain enums.
+- Moving it avoids creating a `geojson -> stac-extension` dependency, which would be semantically backwards (GeoJSON features should not depend on STAC extensions).
+- `stac-extension.yaml` gains a `common` import, which is clean and consistent with the pattern used by other modules.
+
+**Alternatives Considered**:
+1. **Add `stac-extension` import to `geojson.yaml`** -- Rejected. Creates a backwards semantic dependency. GeoJSON features are more fundamental than STAC extensions.
+2. **Duplicate the enum in both files** -- Rejected. Violates "single source of truth" (Constitution Article II.1).
+3. **Use string with pattern constraint instead of enum** -- Rejected. Loses schema-level validation and type safety. Downstream consumers would need to validate domain values themselves.
+
+## Decision 2: PlatformRecord Class Location
+
+**Context**: The new `PlatformRecord` class (id, name, nationality, vessel_class, vessel_type, vessel_role, domain) is used by `StacExtensionProperties.platforms` and `StacItemSummary.platforms`. Need to decide which schema file defines it.
+
+**Decision**: Define `PlatformRecord` in `stac-extension.yaml`.
+
+**Rationale**:
+- PlatformRecord is a STAC extension concept -- it represents the fully-resolved metadata that appears on STAC items.
+- Both consumers (`StacExtensionProperties`, `StacItemSummary`) are already defined in `stac-extension.yaml`.
+- After Decision 1, `stac-extension.yaml` will import `common.yaml`, giving it access to `VesselDomainEnum` for the `domain` field.
+
+**Alternatives Considered**:
+1. **Define in `common.yaml`** -- Rejected. PlatformRecord is STAC-specific (it represents resolved metadata on STAC items), not a general-purpose domain type.
+2. **Define in `geojson.yaml`** -- Rejected. PlatformRecord is not a GeoJSON concept.
+
+## Decision 3: TrackProperties Override Fields -- Pattern Constraints
+
+**Context**: The six new fields on TrackProperties need appropriate validation constraints. The epic document specifies patterns but we need to decide on exact LinkML expressions.
+
+**Decision**: Apply the following constraints:
+
+| Field | Type | Constraint | Notes |
+|-------|------|-----------|-------|
+| `display_name` | string | None | Free-text, any human-readable name |
+| `nationality` | string | `pattern: "^[A-Z]{2}$"` | ISO 3166-1 alpha-2 (matches existing `nationalities` pattern) |
+| `vessel_class` | string | `pattern: "^[a-z0-9-]+(/[a-z0-9-]+){0,3}$"` | Matches existing `vessel_classes` pattern on StacExtensionProperties |
+| `vessel_type` | string | `pattern: "^[a-z0-9-]+$"` | Leaf segment of class path -- single lowercase segment |
+| `vessel_role` | string | `pattern: "^[a-z0-9-]+$"` | Parent of leaf -- single lowercase segment |
+| `domain` | VesselDomainEnum | Enum constraint | Reuses moved enum from common.yaml |
+
+**Rationale**: Reuses existing patterns where they exist (nationality, vessel_class) and derives new patterns (vessel_type, vessel_role) from the established convention of lowercase alphanumeric segments.
+
+## Decision 4: Backward Compatibility Strategy for STAC Extension
+
+**Context**: Existing STAC items use flat aggregate fields (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`). The new `debrief:platforms` array replaces the semantic role of these fields but we cannot break existing data.
+
+**Decision**: Keep all existing flat aggregate fields. Add `platforms` as a new optional field alongside them. Do not remove any existing fields in this feature.
+
+**Rationale**:
+- All 100 exercise fixtures and any real catalog data use the flat aggregate fields.
+- The save-time resolution handler (#183) will be responsible for populating `platforms` and deciding when to stop writing flat aggregates.
+- Constitution Article XIV (Pre-Release Freedom) permits breaking changes, but there is no benefit to a breaking change here -- the additive approach is simpler and safer.
+- The flat fields can be deprecated and removed in a later cleanup item after all consumers have migrated to `platforms`.
+
+## Decision 5: Fixture Coverage Strategy
+
+**Context**: Need to add fixtures covering the new schema structures without disrupting the existing 100-item exercise fixture set.
+
+**Decision**: Add targeted fixtures in both fixture locations:
+
+1. **Core fixtures** (`shared/schemas/src/fixtures/`):
+   - `valid/track-feature-platform-overrides-01.json` -- TrackFeature with all six override fields populated
+   - `valid/track-feature-platform-overrides-minimal-01.json` -- TrackFeature with only `display_name` (partial overrides)
+   - `invalid/track-feature-invalid-nationality.json` -- Three-letter nationality code
+   - `invalid/track-feature-invalid-domain.json` -- Domain value outside enum
+
+2. **STAC extension fixtures** (`shared/schemas/fixtures/stac-browser/`):
+   - `valid/extension-platforms-full.json` -- StacExtensionProperties with fully-populated platforms array
+   - `valid/extension-platforms-sparse.json` -- StacExtensionProperties with sparse record (id-only)
+   - `invalid/invalid-platform-nationality.json` -- Platform record with invalid nationality
+
+3. **Existing exercise fixtures**: Not modified. They will gain `debrief:platforms` when the catalog is regenerated (#184).
+
+**Rationale**: Targeted fixtures test the new fields without modifying the carefully-balanced 100-item exercise set. The exercise set is regenerated separately in #184.
+
+## Decision 6: StacItemSummary Consumer Impact
+
+**Context**: `StacItemSummary` has two representations:
+- Generated snake_case version in `shared/schemas/src/generated/typescript/types.ts`
+- Local camelCase version in `apps/vscode/src/types/stac.ts` (used by all VS Code consumers)
+
+The filter engine uses its own `CatalogOverviewItem` interface.
+
+**Decision**: This feature only updates the LinkML schema and regenerates types. Consumer updates (VS Code types, stacService, filter engine matchers) are out of scope and will be done in downstream features (#183 for stacService, #185 for filter engine).
+
+**Rationale**: The spec explicitly scopes this feature to schema + generation + fixtures. Consumer code changes depend on the save-time resolution logic (#183) and CQL2 array_filter (#185), which are separate items.
+
+## Technical Notes
+
+### Schema Generation Pipeline
+- **Script**: `shared/schemas/scripts/generate.py`
+- **Master schema**: `shared/schemas/src/linkml/debrief.yaml` (imports all modules)
+- **Makefile**: `shared/schemas/Makefile` with targets `generate-pydantic`, `generate-typescript`, `generate-jsonschema`
+- **Post-processing**: The generate script applies coordinate type fixes, nullable array patches, and union type patches. No post-processing is expected for the new fields (they are simple optional scalars and arrays).
+
+### Import Dependency Chain (after changes)
+```
+common.yaml (VesselDomainEnum moved here)
+  ↑ imported by
+geojson.yaml (TrackProperties gains override fields using VesselDomainEnum)
+  ↑ imported by
+stac-extension.yaml (gains common import; PlatformRecord + platforms field)
+  ↑ imported by
+debrief.yaml (master -- no changes needed)
+```
+
+### Test Files Affected
+- `test_golden.py` -- will auto-discover new valid/invalid fixtures
+- `test_stac_extension.py` -- will need new test for platforms round-trip
+- `test_roundtrip.py` -- existing TrackFeature round-trip tests should pass (new fields are optional)

--- a/specs/181-linkml-platform-overrides/spec.md
+++ b/specs/181-linkml-platform-overrides/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: LinkML Per-Platform Override Fields
+
+**Feature Branch**: `181-linkml-platform-overrides`  
+**Created**: 2026-04-13  
+**Status**: Draft  
+**Input**: User description: "[E10] LinkML schema update -- per-platform override fields on TrackProperties; debrief:platforms STAC extension replacing flat aggregates; regen Pydantic + TS types (requires #180)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Schema Declares Per-Platform Override Fields (Priority: P1)
+
+As a developer working on the enrichment pipeline, I need the LinkML schema to include optional per-platform metadata fields on TrackProperties so that analysts can override registry-derived values on individual tracks and downstream tools (save-time resolution, CQL2 filtering) have a well-defined schema to work against.
+
+**Why this priority**: The override fields are the foundation for the entire E10 enrichment model. Without them in the schema, no downstream consumer (save-time resolution #183, CQL2 array_filter #185, filter bar #186) can be built. Every other story in this feature and most items in the E10 epic depend on these fields existing.
+
+**Independent Test**: Can be tested by running the LinkML generators and verifying the new optional fields appear in the generated Pydantic models and TypeScript types, and that existing valid fixtures still pass validation (backward compatibility).
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated LinkML geojson.yaml schema, **When** I inspect TrackProperties, **Then** I see six new optional fields: `display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`.
+2. **Given** an existing valid TrackFeature JSON fixture that omits the new fields, **When** I validate it against the updated schema, **Then** validation passes (backward compatible).
+3. **Given** a TrackFeature JSON fixture that includes one or more of the new optional fields with valid values, **When** I validate it, **Then** validation passes.
+4. **Given** a TrackFeature JSON with `nationality` set to a three-letter code (e.g., "GBR"), **When** I validate it, **Then** validation fails because `nationality` must be an ISO 3166-1 alpha-2 code (two uppercase letters).
+5. **Given** a TrackFeature JSON with `domain` set to "air", **When** I validate it, **Then** validation fails because `domain` is constrained to VesselDomainEnum values (surface, subsurface, unknown).
+
+---
+
+### User Story 2 - STAC Extension Carries Structured Platform Array (Priority: P1)
+
+As a developer building the CQL2 array_filter evaluator (#185), I need the STAC extension schema to define a `debrief:platforms` array of structured platform records so that compound predicates like "nationality = GB AND domain = subsurface" can be evaluated against per-platform data rather than disconnected flat lists.
+
+**Why this priority**: Replacing flat aggregates with structured per-platform records is the core schema change that makes joined queries possible. This is co-equal with Story 1 because both are needed before any downstream consumer can proceed.
+
+**Independent Test**: Can be tested by validating STAC item fixtures against the updated schema, confirming that the new `debrief:platforms` array is accepted and the old flat aggregate fields remain valid during the transition period.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated stac-extension.yaml schema, **When** I inspect StacExtensionProperties, **Then** I see a new optional `platforms` field that is a multivalued array of PlatformRecord objects.
+2. **Given** a PlatformRecord, **When** I inspect its schema definition, **Then** it contains fields: `id` (required), `name` (optional), `nationality` (optional, two uppercase letters), `vessel_class` (optional, slash-delimited path), `vessel_type` (optional), `vessel_role` (optional), `domain` (optional, constrained to surface/subsurface/unknown).
+3. **Given** a STAC item fixture with a `debrief:platforms` array containing two fully-populated platform records, **When** I validate it, **Then** validation passes.
+4. **Given** a STAC item fixture with a `debrief:platforms` array containing a record with only `id` populated (all other fields absent), **When** I validate it, **Then** validation passes (sparse records are valid for unregistered platforms).
+5. **Given** a STAC item fixture that still uses the old flat aggregate fields without `debrief:platforms`, **When** I validate it, **Then** validation passes (backward compatible during transition).
+
+---
+
+### User Story 3 - Regenerated Types Match Schema (Priority: P2)
+
+As a developer consuming Debrief schemas in Python or TypeScript, I need the generated Pydantic models and TypeScript types to reflect the updated LinkML schema so that I get compile-time and runtime validation of the new fields without manual type definitions.
+
+**Why this priority**: Generated types are how the schema is consumed by all services and frontends. Without regeneration, developers would need to cast or ignore types, defeating the schema-first approach.
+
+**Independent Test**: Can be tested by running the schema generators and verifying the output includes the new fields with correct types, optionality, and constraints. Round-trip tests confirm cross-language consistency.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated LinkML schema, **When** I run the Pydantic generator, **Then** the output TrackProperties model includes six new optional fields with correct types and validators.
+2. **Given** the updated LinkML schema, **When** I run the TypeScript generator, **Then** the output TrackProperties interface includes six new optional fields with correct types.
+3. **Given** the updated LinkML schema, **When** I run the generators for StacExtensionProperties, **Then** the output includes an optional platforms array with the PlatformRecord structure.
+4. **Given** the generated types, **When** I run the existing schema adherence test suite, **Then** all tests pass.
+
+---
+
+### User Story 4 - Golden Fixtures Updated (Priority: P2)
+
+As a developer maintaining the test suite, I need the golden fixture set to include examples of the new schema structures so that schema adherence tests cover the new fields and downstream developers have reference data to work from.
+
+**Why this priority**: Fixtures are how the schema is validated in CI. Without updated fixtures, the new fields are never tested and regressions could go undetected.
+
+**Independent Test**: Can be tested by running the fixture validation suite and confirming that new valid fixtures pass and new invalid fixtures correctly fail.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated fixture set, **When** I look for TrackFeature fixtures, **Then** I find at least one valid fixture that includes per-platform override fields.
+2. **Given** the updated fixture set, **When** I look for STAC item fixtures, **Then** I find at least one valid fixture with a `debrief:platforms` array containing fully-populated records.
+3. **Given** the updated fixture set, **When** I look for STAC item fixtures, **Then** I find at least one valid fixture with a `debrief:platforms` array containing a sparse record (only `id`).
+4. **Given** the updated fixture set, **When** I look for invalid fixtures, **Then** I find at least one fixture with an invalid nationality value that fails validation.
+5. **Given** the complete fixture set (old and new), **When** I run the full validation suite, **Then** all valid fixtures pass and all invalid fixtures correctly fail.
+
+---
+
+### Edge Cases
+
+- What happens when a TrackFeature includes override fields but no `platform_id`? This cannot occur because `platform_id` is already required on TrackProperties.
+- What happens when `vessel_class` contains an invalid path format (e.g., uppercase letters, spaces)? Validation rejects it via the pattern constraint on the field.
+- What happens when `debrief:platforms` is an empty array? This is valid -- a plot with no tracks has no platforms to list.
+- What happens when `debrief:platforms` contains duplicate platform IDs? This is permitted at the schema level; deduplication is the responsibility of the save-time resolution handler (#183).
+- What happens when old-format STAC items (flat aggregates only, no `debrief:platforms`) are loaded? They remain valid because all new fields are optional and old fields are preserved during the transition.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The schema MUST add six optional fields to TrackProperties: `display_name` (string), `nationality` (string, two uppercase letters), `vessel_class` (string, slash-delimited path), `vessel_type` (string), `vessel_role` (string), `domain` (constrained to surface/subsurface/unknown).
+- **FR-002**: The schema MUST define a new PlatformRecord entity with fields: `id` (required string), `name` (optional string), `nationality` (optional string, two uppercase letters), `vessel_class` (optional string, slash-delimited path), `vessel_type` (optional string), `vessel_role` (optional string), `domain` (optional, constrained to surface/subsurface/unknown).
+- **FR-003**: StacExtensionProperties MUST add an optional `platforms` field as a multivalued array of PlatformRecord, representing fully-resolved per-platform metadata for the STAC item.
+- **FR-004**: The existing flat aggregate fields on StacExtensionProperties (`vessel_classes`, `nationalities`, `track_names`) MUST remain in the schema during the transition period for backward compatibility.
+- **FR-005**: StacItemSummary MUST add an optional `platforms` field mirroring the StacExtensionProperties structure, so the summary type used for filtering carries per-platform data.
+- **FR-006**: Generated Pydantic models, JSON Schema, and TypeScript types MUST be regenerated from the updated LinkML schema, and all generated output MUST pass existing adherence tests.
+- **FR-007**: The golden fixture set MUST be updated to include valid examples of TrackFeatures with override fields, STAC items with `debrief:platforms` arrays (fully-populated and sparse), and at least one invalid example testing constraint enforcement.
+- **FR-008**: All existing valid fixtures MUST continue to pass validation against the updated schema (backward compatibility).
+- **FR-009**: The `domain` field on both TrackProperties and PlatformRecord MUST reuse the existing VesselDomainEnum (surface, subsurface, unknown).
+- **FR-010**: The `nationality` field on both TrackProperties and PlatformRecord MUST be constrained to exactly two uppercase letters.
+
+### Key Entities
+
+- **TrackProperties**: Properties of a vessel track GeoJSON feature. Extended with six optional override fields that allow analysts to annotate individual tracks with platform metadata, overriding registry-derived values.
+- **PlatformRecord**: A new entity representing fully-resolved metadata for a single platform within a STAC item. Contains platform identity (`id`, `name`) and classification (`nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`). Only `id` is required; all other fields may be absent for unregistered platforms.
+- **StacExtensionProperties**: Extension properties on STAC items in the `debrief:` namespace. Extended with a `platforms` array of PlatformRecord that replaces flat aggregate fields for per-platform joined queries.
+- **StacItemSummary**: Lightweight projection of a STAC item for UI filtering. Extended with the same `platforms` array to enable compound filtering at the summary level.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All six override fields are present and optional on TrackProperties in the generated Pydantic model, TypeScript types, and JSON Schema -- verified by schema adherence tests.
+- **SC-002**: The PlatformRecord entity is defined with the correct field set and constraints -- verified by validating golden fixtures against the generated schema.
+- **SC-003**: The `debrief:platforms` array is present on StacExtensionProperties and StacItemSummary in all generated outputs -- verified by schema adherence tests.
+- **SC-004**: 100% of existing valid golden fixtures pass validation against the updated schema with zero backward-compatibility regressions.
+- **SC-005**: At least 3 new valid golden fixtures and 1 new invalid golden fixture are added covering the new schema structures.
+- **SC-006**: The full verification suite (lint, typecheck, test) passes on the feature branch with zero failures.
+
+## Assumptions
+
+- The platform registry (#180) is complete and provides the VesselDomainEnum and vessel classification path conventions that this schema update references.
+- The existing flat aggregate fields (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`) will be deprecated and removed in a future item, not in this one. This feature only adds the new structures alongside them.
+- The `vessel_class` path format follows the convention established by #180: lowercase alphanumeric segments separated by forward slashes (e.g., `surface/warship/frigate/type23`).
+- Schema generation tooling (LinkML generators) is already configured and working in the repository.
+- The VesselDomainEnum already exists in the STAC extension schema and will be reused (not duplicated) for the `domain` field on TrackProperties and PlatformRecord.
+
+## Dependencies
+
+- **#180 (Platform Registry)**: Must be complete (it is). Provides the vessel class tree structure, domain enum values, and path conventions that the schema update codifies.
+
+## Out of Scope
+
+- Save-time registry resolution logic (covered by #183)
+- Import handler warnings for unregistered platforms (covered by #182)
+- CQL2 `array_filter` evaluator (covered by #185)
+- Removal of flat aggregate fields from StacExtensionProperties (future deprecation item)
+- UI display of registry-derived vs. analyst-set values (future item)
+- Platform registry file format or loader changes

--- a/specs/181-linkml-platform-overrides/spec.md
+++ b/specs/181-linkml-platform-overrides/spec.md
@@ -13,37 +13,53 @@ As a developer working on the enrichment pipeline, I need the LinkML schema to i
 
 **Why this priority**: The override fields are the foundation for the entire E10 enrichment model. Without them in the schema, no downstream consumer (save-time resolution #183, CQL2 array_filter #185, filter bar #186) can be built. Every other story in this feature and most items in the E10 epic depend on these fields existing.
 
-**Independent Test**: Can be tested by running the LinkML generators and verifying the new optional fields appear in the generated Pydantic models and TypeScript types, and that existing valid fixtures still pass validation (backward compatibility).
+**Independent Test**: Can be tested by running the LinkML generators and verifying the new optional fields appear in the generated Pydantic models and TypeScript types, and that existing valid fixtures still pass validation.
 
 **Acceptance Scenarios**:
 
 1. **Given** the updated LinkML geojson.yaml schema, **When** I inspect TrackProperties, **Then** I see six new optional fields: `display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`.
-2. **Given** an existing valid TrackFeature JSON fixture that omits the new fields, **When** I validate it against the updated schema, **Then** validation passes (backward compatible).
-3. **Given** a TrackFeature JSON fixture that includes one or more of the new optional fields with valid values, **When** I validate it, **Then** validation passes.
-4. **Given** a TrackFeature JSON with `nationality` set to a three-letter code (e.g., "GBR"), **When** I validate it, **Then** validation fails because `nationality` must be an ISO 3166-1 alpha-2 code (two uppercase letters).
-5. **Given** a TrackFeature JSON with `domain` set to "air", **When** I validate it, **Then** validation fails because `domain` is constrained to VesselDomainEnum values (surface, subsurface, unknown).
+2. **Given** a TrackFeature JSON fixture that includes one or more of the new optional fields with valid values, **When** I validate it, **Then** validation passes.
+3. **Given** a TrackFeature JSON with `nationality` set to a three-letter code (e.g., "GBR"), **When** I validate it, **Then** validation fails because `nationality` must be an ISO 3166-1 alpha-2 code (two uppercase letters).
+4. **Given** a TrackFeature JSON with `domain` set to "air", **When** I validate it, **Then** validation fails because `domain` is constrained to VesselDomainEnum values (surface, subsurface, unknown).
 
 ---
 
-### User Story 2 - STAC Extension Carries Structured Platform Array (Priority: P1)
+### User Story 2 - Flat Aggregates Replaced by Structured Platform Array (Priority: P1)
 
-As a developer building the CQL2 array_filter evaluator (#185), I need the STAC extension schema to define a `debrief:platforms` array of structured platform records so that compound predicates like "nationality = GB AND domain = subsurface" can be evaluated against per-platform data rather than disconnected flat lists.
+As a developer building the CQL2 array_filter evaluator (#185), I need the STAC extension schema to define a `debrief:platforms` array of structured platform records AND remove the old flat aggregate fields so that the data model is clean, there is one canonical way to query platform metadata, and compound predicates like "nationality = GB AND domain = subsurface" work against per-platform data.
 
-**Why this priority**: Replacing flat aggregates with structured per-platform records is the core schema change that makes joined queries possible. This is co-equal with Story 1 because both are needed before any downstream consumer can proceed.
+**Why this priority**: The flat aggregates (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`) are structurally unable to represent joined queries. Keeping them alongside `debrief:platforms` would create ambiguity about which is authoritative. Per Constitution Article XIV, we have no backward compatibility obligation pre-v4.0.0.
 
-**Independent Test**: Can be tested by validating STAC item fixtures against the updated schema, confirming that the new `debrief:platforms` array is accepted and the old flat aggregate fields remain valid during the transition period.
+**Independent Test**: Can be tested by validating STAC item fixtures against the updated schema, confirming that `debrief:platforms` is accepted and the old flat fields are rejected.
 
 **Acceptance Scenarios**:
 
-1. **Given** the updated stac-extension.yaml schema, **When** I inspect StacExtensionProperties, **Then** I see a new optional `platforms` field that is a multivalued array of PlatformRecord objects.
+1. **Given** the updated stac-extension.yaml schema, **When** I inspect StacExtensionProperties, **Then** I see a `platforms` field and DO NOT see `vessel_classes`, `nationalities`, or `track_names`.
 2. **Given** a PlatformRecord, **When** I inspect its schema definition, **Then** it contains fields: `id` (required), `name` (optional), `nationality` (optional, two uppercase letters), `vessel_class` (optional, slash-delimited path), `vessel_type` (optional), `vessel_role` (optional), `domain` (optional, constrained to surface/subsurface/unknown).
 3. **Given** a STAC item fixture with a `debrief:platforms` array containing two fully-populated platform records, **When** I validate it, **Then** validation passes.
 4. **Given** a STAC item fixture with a `debrief:platforms` array containing a record with only `id` populated (all other fields absent), **When** I validate it, **Then** validation passes (sparse records are valid for unregistered platforms).
-5. **Given** a STAC item fixture that still uses the old flat aggregate fields without `debrief:platforms`, **When** I validate it, **Then** validation passes (backward compatible during transition).
+5. **Given** a STAC item fixture that still uses the old flat aggregate fields, **When** I validate it, **Then** validation fails (the old fields no longer exist in the schema).
 
 ---
 
-### User Story 3 - Regenerated Types Match Schema (Priority: P2)
+### User Story 3 - Consumer Code Migrated to Platforms (Priority: P1)
+
+As a developer working on the codebase, I need all consumer code that previously referenced the flat aggregate fields to be updated to use the `platforms` array so that the codebase compiles, passes type checking, and `task verify` succeeds.
+
+**Why this priority**: Removing fields from the schema without updating consumers would break the build. This must be done atomically with the schema change.
+
+**Independent Test**: Can be tested by running `task verify` (lint, typecheck, test) and confirming zero failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated types, **When** I run TypeScript type checking across the monorepo, **Then** there are no type errors referencing `vessel_classes`, `nationalities`, or `track_names` on STAC-related types.
+2. **Given** the updated filter engine, **When** I run the filter engine test suite, **Then** all tests pass using `platforms`-based matching.
+3. **Given** the updated stacService, **When** it reads a STAC item with `debrief:platforms`, **Then** it correctly populates the internal data structures with per-platform data.
+4. **Given** the updated CatalogOverviewItem type, **When** the filter bar extracts distinct values, **Then** it derives nationalities, vessel classes, and track names from the `platforms` array.
+
+---
+
+### User Story 4 - Regenerated Types Match Schema (Priority: P2)
 
 As a developer consuming Debrief schemas in Python or TypeScript, I need the generated Pydantic models and TypeScript types to reflect the updated LinkML schema so that I get compile-time and runtime validation of the new fields without manual type definitions.
 
@@ -55,26 +71,26 @@ As a developer consuming Debrief schemas in Python or TypeScript, I need the gen
 
 1. **Given** the updated LinkML schema, **When** I run the Pydantic generator, **Then** the output TrackProperties model includes six new optional fields with correct types and validators.
 2. **Given** the updated LinkML schema, **When** I run the TypeScript generator, **Then** the output TrackProperties interface includes six new optional fields with correct types.
-3. **Given** the updated LinkML schema, **When** I run the generators for StacExtensionProperties, **Then** the output includes an optional platforms array with the PlatformRecord structure.
+3. **Given** the updated LinkML schema, **When** I run the generators for StacExtensionProperties, **Then** the output includes an optional platforms array with the PlatformRecord structure and DOES NOT include vessel_classes, nationalities, or track_names.
 4. **Given** the generated types, **When** I run the existing schema adherence test suite, **Then** all tests pass.
 
 ---
 
-### User Story 4 - Golden Fixtures Updated (Priority: P2)
+### User Story 5 - Golden Fixtures Updated (Priority: P2)
 
-As a developer maintaining the test suite, I need the golden fixture set to include examples of the new schema structures so that schema adherence tests cover the new fields and downstream developers have reference data to work from.
+As a developer maintaining the test suite, I need the golden fixture set to use the new `debrief:platforms` structure (and not the old flat aggregates) so that schema adherence tests validate the correct format and downstream developers have reference data to work from.
 
-**Why this priority**: Fixtures are how the schema is validated in CI. Without updated fixtures, the new fields are never tested and regressions could go undetected.
+**Why this priority**: Fixtures are how the schema is validated in CI. All fixtures must conform to the current schema.
 
-**Independent Test**: Can be tested by running the fixture validation suite and confirming that new valid fixtures pass and new invalid fixtures correctly fail.
+**Independent Test**: Can be tested by running the fixture validation suite and confirming that all fixtures pass against the new schema.
 
 **Acceptance Scenarios**:
 
 1. **Given** the updated fixture set, **When** I look for TrackFeature fixtures, **Then** I find at least one valid fixture that includes per-platform override fields.
-2. **Given** the updated fixture set, **When** I look for STAC item fixtures, **Then** I find at least one valid fixture with a `debrief:platforms` array containing fully-populated records.
-3. **Given** the updated fixture set, **When** I look for STAC item fixtures, **Then** I find at least one valid fixture with a `debrief:platforms` array containing a sparse record (only `id`).
+2. **Given** the updated STAC extension fixtures, **When** I validate them, **Then** all use `platforms` arrays and none contain the old flat aggregate fields.
+3. **Given** the 100 exercise fixtures, **When** they are regenerated via the fixture generation script, **Then** all use `debrief:platforms` and pass schema validation.
 4. **Given** the updated fixture set, **When** I look for invalid fixtures, **Then** I find at least one fixture with an invalid nationality value that fails validation.
-5. **Given** the complete fixture set (old and new), **When** I run the full validation suite, **Then** all valid fixtures pass and all invalid fixtures correctly fail.
+5. **Given** the complete fixture set, **When** I run the full validation suite, **Then** all valid fixtures pass and all invalid fixtures correctly fail.
 
 ---
 
@@ -84,7 +100,7 @@ As a developer maintaining the test suite, I need the golden fixture set to incl
 - What happens when `vessel_class` contains an invalid path format (e.g., uppercase letters, spaces)? Validation rejects it via the pattern constraint on the field.
 - What happens when `debrief:platforms` is an empty array? This is valid -- a plot with no tracks has no platforms to list.
 - What happens when `debrief:platforms` contains duplicate platform IDs? This is permitted at the schema level; deduplication is the responsibility of the save-time resolution handler (#183).
-- What happens when old-format STAC items (flat aggregates only, no `debrief:platforms`) are loaded? They remain valid because all new fields are optional and old fields are preserved during the transition.
+- What happens when consumer code needs to display a flat list of nationalities? It derives the list from `platforms.map(p => p.nationality).filter(Boolean)`. The flat convenience is computed, not stored.
 
 ## Requirements *(mandatory)*
 
@@ -93,20 +109,21 @@ As a developer maintaining the test suite, I need the golden fixture set to incl
 - **FR-001**: The schema MUST add six optional fields to TrackProperties: `display_name` (string), `nationality` (string, two uppercase letters), `vessel_class` (string, slash-delimited path), `vessel_type` (string), `vessel_role` (string), `domain` (constrained to surface/subsurface/unknown).
 - **FR-002**: The schema MUST define a new PlatformRecord entity with fields: `id` (required string), `name` (optional string), `nationality` (optional string, two uppercase letters), `vessel_class` (optional string, slash-delimited path), `vessel_type` (optional string), `vessel_role` (optional string), `domain` (optional, constrained to surface/subsurface/unknown).
 - **FR-003**: StacExtensionProperties MUST add an optional `platforms` field as a multivalued array of PlatformRecord, representing fully-resolved per-platform metadata for the STAC item.
-- **FR-004**: The existing flat aggregate fields on StacExtensionProperties (`vessel_classes`, `nationalities`, `track_names`) MUST remain in the schema during the transition period for backward compatibility.
-- **FR-005**: StacItemSummary MUST add an optional `platforms` field mirroring the StacExtensionProperties structure, so the summary type used for filtering carries per-platform data.
+- **FR-004**: The flat aggregate fields `vessel_classes`, `nationalities`, and `track_names` MUST be removed from StacExtensionProperties. They are replaced entirely by the `platforms` array.
+- **FR-005**: StacItemSummary MUST add an optional `platforms` field and MUST remove `vessel_classes`, `nationalities`, and `track_names`.
 - **FR-006**: Generated Pydantic models, JSON Schema, and TypeScript types MUST be regenerated from the updated LinkML schema, and all generated output MUST pass existing adherence tests.
-- **FR-007**: The golden fixture set MUST be updated to include valid examples of TrackFeatures with override fields, STAC items with `debrief:platforms` arrays (fully-populated and sparse), and at least one invalid example testing constraint enforcement.
-- **FR-008**: All existing valid fixtures MUST continue to pass validation against the updated schema (backward compatibility).
+- **FR-007**: The golden fixture set MUST be updated: all STAC extension fixtures and exercise fixtures MUST use `debrief:platforms` and MUST NOT contain the removed flat aggregate fields.
+- **FR-008**: All consumer code referencing the removed flat fields MUST be migrated to use the `platforms` array. This includes the filter engine, stacService, CatalogOverviewItem, StacBrowserItem, and all test mocks.
 - **FR-009**: The `domain` field on both TrackProperties and PlatformRecord MUST reuse the existing VesselDomainEnum (surface, subsurface, unknown).
 - **FR-010**: The `nationality` field on both TrackProperties and PlatformRecord MUST be constrained to exactly two uppercase letters.
+- **FR-011**: The full verification suite (`task verify`) MUST pass with zero failures after all changes.
 
 ### Key Entities
 
 - **TrackProperties**: Properties of a vessel track GeoJSON feature. Extended with six optional override fields that allow analysts to annotate individual tracks with platform metadata, overriding registry-derived values.
 - **PlatformRecord**: A new entity representing fully-resolved metadata for a single platform within a STAC item. Contains platform identity (`id`, `name`) and classification (`nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`). Only `id` is required; all other fields may be absent for unregistered platforms.
-- **StacExtensionProperties**: Extension properties on STAC items in the `debrief:` namespace. Extended with a `platforms` array of PlatformRecord that replaces flat aggregate fields for per-platform joined queries.
-- **StacItemSummary**: Lightweight projection of a STAC item for UI filtering. Extended with the same `platforms` array to enable compound filtering at the summary level.
+- **StacExtensionProperties**: Extension properties on STAC items in the `debrief:` namespace. Now carries a `platforms` array of PlatformRecord. The former flat aggregate fields (`vessel_classes`, `nationalities`, `track_names`) are removed.
+- **StacItemSummary**: Lightweight projection of a STAC item for UI filtering. Carries the same `platforms` array. Former flat fields removed.
 
 ## Success Criteria *(mandatory)*
 
@@ -114,18 +131,21 @@ As a developer maintaining the test suite, I need the golden fixture set to incl
 
 - **SC-001**: All six override fields are present and optional on TrackProperties in the generated Pydantic model, TypeScript types, and JSON Schema -- verified by schema adherence tests.
 - **SC-002**: The PlatformRecord entity is defined with the correct field set and constraints -- verified by validating golden fixtures against the generated schema.
-- **SC-003**: The `debrief:platforms` array is present on StacExtensionProperties and StacItemSummary in all generated outputs -- verified by schema adherence tests.
-- **SC-004**: 100% of existing valid golden fixtures pass validation against the updated schema with zero backward-compatibility regressions.
+- **SC-003**: The `debrief:platforms` array is present on StacExtensionProperties and StacItemSummary; `vessel_classes`, `nationalities`, and `track_names` are absent -- verified by schema adherence tests.
+- **SC-004**: Zero references to the removed flat aggregate fields remain in non-documentation source files.
 - **SC-005**: At least 3 new valid golden fixtures and 1 new invalid golden fixture are added covering the new schema structures.
-- **SC-006**: The full verification suite (lint, typecheck, test) passes on the feature branch with zero failures.
+- **SC-006**: All 100 exercise fixtures are regenerated with `debrief:platforms` and pass schema validation.
+- **SC-007**: The full verification suite (`task verify`) passes on the feature branch with zero failures.
 
 ## Assumptions
 
 - The platform registry (#180) is complete and provides the VesselDomainEnum and vessel classification path conventions that this schema update references.
-- The existing flat aggregate fields (`debrief:vessel_classes`, `debrief:nationalities`, `debrief:track_names`) will be deprecated and removed in a future item, not in this one. This feature only adds the new structures alongside them.
 - The `vessel_class` path format follows the convention established by #180: lowercase alphanumeric segments separated by forward slashes (e.g., `surface/warship/frigate/type23`).
 - Schema generation tooling (LinkML generators) is already configured and working in the repository.
 - The VesselDomainEnum already exists in the STAC extension schema and will be reused (not duplicated) for the `domain` field on TrackProperties and PlatformRecord.
+- The exercise fixture generation script can be updated to produce `debrief:platforms` format.
+- Consumer code (filter engine, stacService, etc.) can derive flat convenience lists from the `platforms` array at runtime where needed for display.
+- Constitution Article XIV (Pre-Release Freedom) permits removing the flat fields without deprecation.
 
 ## Dependencies
 
@@ -135,7 +155,7 @@ As a developer maintaining the test suite, I need the golden fixture set to incl
 
 - Save-time registry resolution logic (covered by #183)
 - Import handler warnings for unregistered platforms (covered by #182)
-- CQL2 `array_filter` evaluator (covered by #185)
-- Removal of flat aggregate fields from StacExtensionProperties (future deprecation item)
-- UI display of registry-derived vs. analyst-set values (future item)
+- CQL2 `array_filter` evaluator for compound predicates (covered by #185)
 - Platform registry file format or loader changes
+- Updating preview/workspace/samples/local-store data (covered by #184)
+- Documentation-only references in old spec files (read-only historical context)

--- a/specs/181-linkml-platform-overrides/tasks.md
+++ b/specs/181-linkml-platform-overrides/tasks.md
@@ -1,0 +1,347 @@
+# Tasks: LinkML Per-Platform Override Fields
+
+**Input**: Design documents from `/specs/181-linkml-platform-overrides/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+---
+
+## Evidence Requirements
+
+**Evidence Directory**: `specs/181-linkml-platform-overrides/evidence/`
+**Media Directory**: `specs/181-linkml-platform-overrides/media/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| test-summary.md | pytest + vitest results across schema, service, and component tests | After all tests pass |
+| usage-example.md | Python + TypeScript code showing PlatformRecord validation | After type generation complete |
+| round-trip-evidence.md | Python -> JSON -> TypeScript -> JSON round-trip proof for new types | After round-trip tests pass |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| media/planning-post.md | Blog post announcing the feature | During /speckit.plan (done) |
+| media/linkedin-planning.md | LinkedIn summary for planning | During /speckit.plan (done) |
+| media/shipped-post.md | Blog post celebrating completion | During Polish phase |
+| media/linkedin-shipped.md | LinkedIn summary for shipped | During Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in debrief-future with evidence | Final task in Polish phase |
+| Blog PR | PR in debrief.github.io with post | Triggered by /speckit.pr |
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch hygiene and schema infrastructure preparation
+
+- [ ] T001 Verify branch 181-linkml-platform-overrides is up to date with main
+- [ ] T002 Verify `make generate` runs successfully in `shared/schemas/` before any changes (baseline)
+
+---
+
+## Phase 2: Foundation — Schema Changes (Blocking)
+
+**Purpose**: LinkML source-of-truth changes that MUST be complete before any generated types, fixtures, or consumer code can be updated.
+
+**CRITICAL**: No downstream work (Phases 3-7) can begin until this phase is complete.
+
+### Move VesselDomainEnum
+
+- [ ] T003 Move VesselDomainEnum from stac-extension.yaml to common.yaml `shared/schemas/src/linkml/common.yaml`
+- [ ] T004 Remove VesselDomainEnum from stac-extension.yaml and add `common` import `shared/schemas/src/linkml/stac-extension.yaml`
+
+### Add Override Fields to TrackProperties
+
+- [ ] T005 Add six optional override fields (display_name, nationality, vessel_class, vessel_type, vessel_role, domain) to TrackProperties `shared/schemas/src/linkml/geojson.yaml`
+
+### Add PlatformRecord and Replace Flat Fields
+
+- [ ] T006 Define PlatformRecord class with id (required), name, nationality, vessel_class, vessel_type, vessel_role, domain (all optional) `shared/schemas/src/linkml/stac-extension.yaml`
+- [ ] T007 Add platforms field (optional, multivalued PlatformRecord) to StacExtensionProperties `shared/schemas/src/linkml/stac-extension.yaml`
+- [ ] T008 Remove vessel_classes, nationalities, track_names from StacExtensionProperties `shared/schemas/src/linkml/stac-extension.yaml`
+- [ ] T009 Add platforms field (optional, multivalued PlatformRecord) to StacItemSummary `shared/schemas/src/linkml/stac-extension.yaml`
+- [ ] T010 Remove vessel_classes, nationalities, track_names from StacItemSummary `shared/schemas/src/linkml/stac-extension.yaml`
+
+### Regenerate Types
+
+- [ ] T011 Run `make generate` to regenerate Pydantic, TypeScript, and JSON Schema from updated LinkML `shared/schemas/Makefile`
+- [ ] T012 Verify generated Pydantic model includes TrackProperties override fields and PlatformRecord `shared/schemas/src/generated/python/debrief_schemas/__init__.py`
+- [ ] T013 Verify generated TypeScript types include TrackProperties override fields and PlatformRecord `shared/schemas/src/generated/typescript/types.ts`
+
+**Checkpoint**: Schema source of truth updated, types regenerated. Generated types will have new fields and missing old fields — consumer code will not compile yet.
+
+---
+
+## Phase 3: User Story 1 — Schema Declares Per-Platform Override Fields (Priority: P1)
+
+**Goal**: Validate that the six new optional fields on TrackProperties work correctly via golden fixtures.
+
+**Independent Test**: Run `uv run pytest tests/test_golden.py -v` in `shared/schemas/` — new valid fixtures pass, new invalid fixtures fail, existing fixtures still pass.
+
+### Implementation
+
+- [ ] T014 [P] Create valid fixture: TrackFeature with all six override fields populated `shared/schemas/src/fixtures/valid/track-feature-platform-overrides-01.json`
+- [ ] T015 [P] Create valid fixture: TrackFeature with partial overrides (display_name only) `shared/schemas/src/fixtures/valid/track-feature-platform-overrides-minimal-01.json`
+- [ ] T016 [P] Create invalid fixture: TrackFeature with three-letter nationality code `shared/schemas/src/fixtures/invalid/track-feature-invalid-nationality.json`
+- [ ] T017 [P] Create invalid fixture: TrackFeature with domain value outside VesselDomainEnum `shared/schemas/src/fixtures/invalid/track-feature-invalid-domain.json`
+- [ ] T018 Run golden fixture tests to verify new TrackFeature fixtures pass/fail correctly `shared/schemas/tests/test_golden.py`
+
+**Checkpoint**: TrackProperties override fields validated via golden fixtures.
+
+---
+
+## Phase 4: User Story 2 — Flat Aggregates Replaced by Structured Platform Array (Priority: P1)
+
+**Goal**: Validate that `debrief:platforms` works in STAC extension fixtures and the old flat fields are gone.
+
+**Independent Test**: Run `uv run pytest tests/test_stac_extension.py -v` in `shared/schemas/` — all STAC extension tests pass with platforms format.
+
+### STAC Extension Fixtures
+
+- [ ] T019 [P] Create valid fixture: StacExtensionProperties with fully-populated platforms array `shared/schemas/fixtures/stac-browser/valid/extension-platforms-full.json`
+- [ ] T020 [P] Create valid fixture: StacExtensionProperties with sparse platform record (id only) `shared/schemas/fixtures/stac-browser/valid/extension-platforms-sparse.json`
+- [ ] T021 [P] Create invalid fixture: PlatformRecord with three-letter nationality `shared/schemas/fixtures/stac-browser/invalid/invalid-platform-nationality.json`
+- [ ] T022 Update extension-basic.json: replace flat fields with platforms array `shared/schemas/fixtures/stac-browser/valid/extension-basic.json`
+- [ ] T023 [P] Update extension-partial-path.json: replace flat fields with platforms array `shared/schemas/fixtures/stac-browser/valid/extension-partial-path.json`
+- [ ] T024 [P] Update extension-empty-arrays.json: replace flat fields with empty platforms array `shared/schemas/fixtures/stac-browser/valid/extension-empty-arrays.json`
+- [ ] T025 Update invalid-uppercase-vessel.json: repurpose for platforms[].vessel_class uppercase test `shared/schemas/fixtures/stac-browser/invalid/invalid-uppercase-vessel.json`
+
+### Exercise Fixture Regeneration
+
+- [ ] T026 Update exercise fixture generation script to produce debrief:platforms instead of flat aggregate fields `shared/schemas/scripts/generate-stac-fixtures.py`
+- [ ] T027 Regenerate all 100 exercise fixtures with debrief:platforms format `shared/schemas/fixtures/stac-browser/`
+
+### STAC Extension Test Updates
+
+- [ ] T028 Update test_stac_extension.py: remove flat-field assertions, add platforms validation and round-trip tests `shared/schemas/tests/test_stac_extension.py`
+- [ ] T029 Run STAC extension tests to verify all pass `shared/schemas/tests/test_stac_extension.py`
+
+**Checkpoint**: All STAC extension fixtures use platforms format, no flat aggregate fields remain in fixtures or schema.
+
+---
+
+## Phase 5: User Story 3 — Consumer Code Migrated to Platforms (Priority: P1)
+
+**Goal**: All TypeScript and Python consumer code compiles and passes tests using `platforms` instead of removed flat fields.
+
+**Independent Test**: Run `task verify` — lint, typecheck, and all tests pass with zero failures.
+
+### TypeScript Type Definitions
+
+- [ ] T030 Update StacBrowserItem: replace vesselClasses, nationalities, trackNames with platforms array `apps/vscode/src/types/stac.ts`
+- [ ] T031 [P] Update CatalogOverviewItem: replace flat fields with platforms array `shared/components/src/filter-engine/types.ts`
+- [ ] T032 [P] Update ExerciseListView types: replace flat fields with platforms `shared/components/src/ExerciseListView/types.ts`
+- [ ] T033 [P] Update CatalogItem message type: replace flat fields with platforms `apps/vscode/src/webview/messages.ts`
+
+### TypeScript Services and Data Layer
+
+- [ ] T034 Update stacService.ts: read debrief:platforms from STAC item properties, map to camelCase platforms on StacBrowserItem `apps/vscode/src/services/stacService.ts`
+- [ ] T035 [P] Update catalogOverviewPanel.ts: map platforms to message format `apps/vscode/src/panels/catalogOverviewPanel.ts`
+- [ ] T036 [P] Update web-shell App.tsx: transform platforms to CatalogOverviewItem format `apps/web-shell/src/App.tsx`
+
+### Filter Engine Migration
+
+- [ ] T037 Update matchers.ts: match on platforms[].vessel_class and platforms[].nationality instead of flat arrays `shared/components/src/filter-engine/matchers.ts`
+- [ ] T038 [P] Update cql2-json.ts: update STAC property name mappings for platforms `shared/components/src/filter-engine/cql2-json.ts`
+- [ ] T039 Update useDistinctValues.ts: derive distinct nationalities, vessel classes, track names from platforms array `shared/components/src/FilterBar/useDistinctValues.ts`
+- [ ] T040 [P] Update useTaxonomyMatchCounts.ts: iterate platforms[].vessel_class for counting `shared/components/src/FilterBar/useTaxonomyMatchCounts.ts`
+- [ ] T041 [P] Update ExerciseListItemRow.tsx: derive vessel classes from platforms for display `shared/components/src/ExerciseListView/ExerciseListItemRow.tsx`
+
+### Python Consumer Migration
+
+- [ ] T042 Update collection.py: aggregate summaries from platforms array instead of flat fields `services/stac/src/debrief_stac/collection.py`
+- [ ] T043 [P] Update models.py: CatalogSummaries uses platforms structure `services/stac/src/debrief_stac/models.py`
+- [ ] T044 Update enrich-legacy-catalog.py: write debrief:platforms instead of flat aggregate properties `scripts/enrich-legacy-catalog.py`
+
+### Mock Data and Stories
+
+- [ ] T045 [P] Update web-shell mock stacService: use platforms in mock data `apps/web-shell/src/mocks/stacService.ts`
+- [ ] T046 [P] Update StacBrowser stories: use platforms in mock items `shared/components/src/StacBrowser/StacBrowser.stories.tsx`
+- [ ] T047 [P] Update FilterBar stories: use platforms in mock items `shared/components/src/FilterBar/FilterBar.stories.tsx`
+- [ ] T048 [P] Update SavedFilters stories: use platforms in mock items `shared/components/src/FilterBar/SavedFilters.stories.tsx`
+- [ ] T049 [P] Update TimelineView stories: use platforms in mock items `shared/components/src/TimelineView/TimelineView.stories.tsx`
+- [ ] T050 [P] Update catalogOverview.tsx webview: derive display values from platforms `apps/vscode/src/webview/web/catalogOverview.tsx`
+
+### Test Updates
+
+- [ ] T051 [P] Update filter engine matchers.test.ts: mock data and assertions use platforms `shared/components/src/filter-engine/__tests__/matchers.test.ts`
+- [ ] T052 [P] Update cql2-json.test.ts: property name assertions `shared/components/src/filter-engine/__tests__/cql2-json.test.ts`
+- [ ] T053 [P] Update filter engine fixtures.ts: mock item builder uses platforms `shared/components/src/filter-engine/__tests__/fixtures.ts`
+- [ ] T054 [P] Update useBrowserFilter.test.ts: mock items use platforms `shared/components/src/StacBrowser/__tests__/useBrowserFilter.test.ts`
+- [ ] T055 [P] Update useDistinctValues.test.ts: mock data and assertions `shared/components/src/FilterBar/__tests__/useDistinctValues.test.ts`
+- [ ] T056 [P] Update useTaxonomyMatchCounts.test.ts: mock data and assertions `shared/components/src/FilterBar/__tests__/useTaxonomyMatchCounts.test.ts`
+- [ ] T057 [P] Update ExerciseListView test: mock data uses platforms `shared/components/src/ExerciseListView/ExerciseListView.test.tsx`
+- [ ] T058 [P] Update ExerciseListView mockData.ts: fixtures use platforms `shared/components/src/ExerciseListView/__fixtures__/mockData.ts`
+- [ ] T059 [P] Update timeline-helpers.test.ts: mock items use platforms `shared/components/src/utils/__tests__/timeline-helpers.test.ts`
+- [ ] T060 [P] Update stacTreeProvider.test.ts: mock data uses platforms `apps/vscode/tests/unit/stacTreeProvider.test.ts`
+- [ ] T061 [P] Update messages.test.ts: mock data uses platforms `apps/vscode/src/webview/messages.test.ts`
+- [ ] T062 Update test_collection.py: summary assertions use platforms `services/stac/tests/test_collection.py`
+
+### Verification
+
+- [ ] T063 Run `task verify` — lint, typecheck, and all tests must pass with zero failures
+
+**Checkpoint**: All consumer code migrated. Zero references to removed flat fields in source code. `task verify` passes.
+
+---
+
+## Phase 6: User Story 4 — Regenerated Types Match Schema (Priority: P2)
+
+**Goal**: Confirm generated types are correct and round-trip tests pass.
+
+**Independent Test**: Run round-trip tests: `uv run pytest tests/test_roundtrip.py -v` in `shared/schemas/`.
+
+- [ ] T064 Verify TrackProperties round-trip: Python -> JSON -> Python with override fields `shared/schemas/tests/test_roundtrip.py`
+- [ ] T065 [P] Verify PlatformRecord round-trip: Python -> JSON -> Python `shared/schemas/tests/test_roundtrip.py`
+- [ ] T066 [P] Verify StacExtensionProperties round-trip with platforms array `shared/schemas/tests/test_stac_extension.py`
+- [ ] T067 Run full schema test suite: `uv run pytest tests/ -v` in shared/schemas `shared/schemas/tests/`
+
+**Checkpoint**: All round-trip tests pass, types are verified cross-language.
+
+---
+
+## Phase 7: User Story 5 — Golden Fixtures Updated (Priority: P2)
+
+**Goal**: Complete fixture coverage confirmed — all valid pass, all invalid fail, no old-format fixtures remain.
+
+**Independent Test**: Run `uv run pytest tests/test_golden.py tests/test_stac_extension.py -v` in `shared/schemas/`.
+
+- [ ] T068 Verify all 100 exercise fixtures pass validation with platforms format `shared/schemas/tests/test_stac_extension.py`
+- [ ] T069 Verify no fixture files contain debrief:vessel_classes, debrief:nationalities, or debrief:track_names
+- [ ] T070 Run complete schema test suite one final time: `uv run pytest tests/ -v`
+
+**Checkpoint**: All fixtures conform to updated schema. Full test suite green.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, evidence collection, media content, and PR creation.
+
+### Final Verification
+
+- [ ] T071 Run `task verify` (lint + typecheck + test) — must pass with zero failures
+- [ ] T072 Grep source code for residual references to removed fields (vessel_classes, nationalities, track_names on STAC types) — confirm zero in non-documentation files
+
+### Evidence Collection
+
+- [ ] T073 Capture test results using template (.specify/templates/evidence/test-summary-template.md) `specs/181-linkml-platform-overrides/evidence/test-summary.md`
+- [ ] T074 Create usage demonstration showing PlatformRecord validation in Python and TypeScript `specs/181-linkml-platform-overrides/evidence/usage-example.md`
+- [ ] T075 [P] Capture round-trip proof (Python -> JSON -> TypeScript -> JSON) `specs/181-linkml-platform-overrides/evidence/round-trip-evidence.md`
+
+### Media Content
+
+- [ ] T076 Create shipped blog post `specs/181-linkml-platform-overrides/media/shipped-post.md`
+- [ ] T077 [P] Create LinkedIn shipped summary `specs/181-linkml-platform-overrides/media/linkedin-shipped.md`
+
+### PR Creation
+
+- [ ] T078 Create PR and publish blog: run /speckit.pr
+
+**Task T078 must run last. It depends on all evidence and media tasks being complete.**
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundation)**: Depends on Phase 1 — BLOCKS all downstream phases
+- **Phase 3 (US1 — Override Fields)**: Depends on Phase 2 (needs regenerated types)
+- **Phase 4 (US2 — Platforms Array)**: Depends on Phase 2 (needs regenerated types); can run in parallel with Phase 3
+- **Phase 5 (US3 — Consumer Migration)**: Depends on Phase 2 (needs regenerated types); can run in parallel with Phases 3-4 but benefits from fixture patterns established there
+- **Phase 6 (US4 — Round-Trip Verification)**: Depends on Phase 2; can start after T011 (type generation)
+- **Phase 7 (US5 — Fixture Completeness)**: Depends on Phases 3, 4 (all fixtures must exist)
+- **Phase 8 (Polish)**: Depends on ALL prior phases
+
+### User Story Dependencies
+
+- **US1 (Override Fields)** and **US2 (Platforms Array)**: Independent — can proceed in parallel after Phase 2
+- **US3 (Consumer Migration)**: Independent of US1/US2 at the code level (uses generated types directly), but practically benefits from running after fixture phases to validate
+- **US4 (Round-Trip)**: Verification only — depends on types being generated (Phase 2)
+- **US5 (Fixture Completeness)**: Depends on US1 + US2 (all fixtures must be created/updated first)
+
+### Within Phase 5 (Consumer Migration)
+
+- Type definitions (T030-T033) FIRST — these define the interfaces
+- Services + filter engine (T034-T041) NEXT — depend on updated types
+- Python consumers (T042-T044) can run in parallel with TypeScript services
+- Mock data + stories (T045-T050) can run in parallel with services
+- Tests (T051-T062) should update after their corresponding source files
+- Final verification (T063) LAST
+
+### Parallel Opportunities
+
+- Phase 3 and Phase 4 can run in parallel (different fixture sets)
+- Within Phase 4: T019-T025 are all independent fixture files — fully parallel
+- Within Phase 5: T030-T033 (type defs) are parallel; T045-T050 (mocks/stories) are parallel; T051-T062 (tests) are parallel
+- Phase 6 can start as soon as Phase 2 completes
+- T074 and T075 (evidence) can run in parallel
+- T076 and T077 (media) can run in parallel
+
+---
+
+## Parallel Example: Phase 5 Consumer Migration
+
+```bash
+# Step 1: Update all type definitions in parallel
+T030: Update StacBrowserItem types
+T031: Update CatalogOverviewItem types
+T032: Update ExerciseListView types
+T033: Update CatalogItem message type
+
+# Step 2: Update services + filter engine (after types)
+T034: Update stacService.ts
+T035: Update catalogOverviewPanel.ts  (parallel)
+T036: Update web-shell App.tsx  (parallel)
+T037: Update matchers.ts
+T038: Update cql2-json.ts  (parallel)
+T039: Update useDistinctValues.ts
+T040: Update useTaxonomyMatchCounts.ts  (parallel)
+T041: Update ExerciseListItemRow.tsx  (parallel)
+
+# Step 3: Python consumers (parallel with Step 2)
+T042: Update collection.py
+T043: Update models.py  (parallel)
+T044: Update enrich-legacy-catalog.py
+
+# Step 4: All mocks, stories, and tests (parallel batch)
+T045-T062: All marked [P], can run in parallel
+
+# Step 5: Final verification
+T063: task verify
+```
+
+---
+
+## Implementation Strategy
+
+### Incremental Delivery
+
+1. **Phase 2** (Foundation) → Schema is the source of truth — get this right first
+2. **Phases 3-4** (Fixtures) → Validate the schema works via golden fixtures
+3. **Phase 5** (Consumer Migration) → Propagate schema changes through the codebase
+4. **Phase 6** (Round-Trip) → Prove cross-language consistency
+5. **Phase 7** (Completeness) → Final sweep confirming no old-format data remains
+6. **Phase 8** (Polish) → Evidence, media, PR
+
+### Key Principle
+
+The schema is the source of truth. Change it first (Phase 2), validate it with fixtures (Phases 3-4), then make everything else conform (Phase 5+). Never change consumer code before the schema is finalized.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies — safe to run in parallel
+- All 100 exercise fixtures are script-generated — update the script then regenerate, don't hand-edit
+- The `vessel_classes` root key in `shared/data/platform-registry.json` is the **registry's own structure** — it is NOT being renamed or removed
+- Constitution Article XIV (Pre-Release Freedom) permits the breaking schema change
+- Run `/speckit.pr` (T078) after all tasks complete to create PR with evidence


### PR DESCRIPTION
## Summary

- Specification, implementation plan, and task breakdown for **#181 — LinkML per-platform override fields** (Epic E10: NL-Assisted Catalog Discovery)
- Adds six optional override fields (`display_name`, `nationality`, `vessel_class`, `vessel_type`, `vessel_role`, `domain`) to TrackProperties
- Defines new `PlatformRecord` entity and `debrief:platforms` structured array on STAC extension
- **Removes** flat aggregate fields (`vessel_classes`, `nationalities`, `track_names`) — clean break per Constitution Article XIV (Pre-Release Freedom)
- Migrates all consumer code (filter engine, stacService, VS Code types, stories, tests) and regenerates all 100 exercise fixtures

## Artifacts

| Document | Purpose |
|----------|---------|
| `spec.md` | Feature specification — 5 user stories, 11 functional requirements |
| `plan.md` | Implementation plan — 6-layer project structure, constitution check |
| `research.md` | 6 design decisions (enum relocation, PlatformRecord location, constraints, no-backward-compat, fixture strategy, consumer migration) |
| `data-model.md` | Entity changes, field definitions, validation rules |
| `quickstart.md` | Step-by-step implementation guide |
| `tasks.md` | 78 tasks across 8 phases |
| `checklists/requirements.md` | Spec quality checklist (all items pass) |
| `media/planning-post.md` | Blog post draft |
| `media/linkedin-planning.md` | LinkedIn summary |

## Key decisions

- **Move VesselDomainEnum** from `stac-extension.yaml` to `common.yaml` for cross-module use
- **Remove flat fields** (`vessel_classes`, `nationalities`, `track_names`) entirely — no backward compat needed pre-v4.0.0
- **PlatformRecord** defined in `stac-extension.yaml` as a STAC-specific concept
- **Atomic consumer migration** — all ~40 consumer files updated in the same feature to keep `task verify` green

## Test plan

- [ ] Review spec.md for completeness and accuracy
- [ ] Review data-model.md field definitions and constraints
- [ ] Review research.md design decisions
- [ ] Review tasks.md ordering and dependencies
- [ ] Confirm scope expansion (flat field removal) is acceptable

https://claude.ai/code/session_01M92T19LMJyyFGJheYBHrhU