### PR TITLE
spec(182): import handler warnings for unregistered platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.49.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.49.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Only updated when a feature introduces a technology not already listed here.
 - TypeScript 5.x (VS Code extension + shared components, host + webview), Python 3.11 (no changes required — debrief-calc already returns the right shapes) + VS Code Extension API ^1.85.0, React 18.x, `@debrief/components` (`ChartPanelWrapper`, `TableRenderer`, `ChartRenderer`, `PanelContext`), `@debrief/utils` (`buildCsvContent`, `generateCsvFilename`, `sanitizeFilename`, NEW `parseCsvToTableDataset` and NEW `synthesizeTableDataset`), `@debrief/session-state` (`LogService` — extended with `recordFileSaved`), existing `apps/vscode/src/services/stacService.ts` (178-vscode-tabular-results)
 - Python 3.11, TypeScript 5.x + no new dependencies (both languages read JSON natively) (180-platform-registry)
 - Static JSON file at `shared/data/platform-registry.json` (180-platform-registry)
+- Python 3.11 + `debrief-data` (platform registry loader), `pydantic>=2.12.5` (existing), `debrief-schemas` (existing) (182-import-platform-warnings)
 
 ## Before Pushing
 
@@ -211,6 +212,6 @@ cd apps/web-shell && node run-playwright.mjs && cd ../..
 Note: `vitest` does not catch TypeScript type errors — only `tsc` (run during typecheck) does. The `pnpm build` step also runs `tsc`, but typecheck is the explicit CI gate.
 
 ## Recent Changes
+- 182-import-platform-warnings: Added Python 3.11 + `debrief-data` (platform registry loader), `pydantic>=2.12.5` (existing), `debrief-schemas` (existing)
 - 180-platform-registry: Added Python 3.11, TypeScript 5.x + no new dependencies (both languages read JSON natively)
 - 178-vscode-tabular-results: Added TypeScript 5.x (VS Code extension + shared components, host + webview), Python 3.11 (no changes required — debrief-calc already returns the right shapes) + VS Code Extension API ^1.85.0, React 18.x, `@debrief/components` (`ChartPanelWrapper`, `TableRenderer`, `ChartRenderer`, `PanelContext`), `@debrief/utils` (`buildCsvContent`, `generateCsvFilename`, `sanitizeFilename`, NEW `parseCsvToTableDataset` and NEW `synthesizeTableDataset`), `@debrief/session-state` (`LogService` — extended with `recordFileSaved`), existing `apps/vscode/src/services/stacService.ts`
-- 175-review-feedback: Added Python 3.11 (service, schema), TypeScript 5.x (frontend components, VS Code extension) + Pydantic v2 (models), LinkML >= 1.7.0 (schema), `ulid` (ID generation), React 18.x (UI), `@tanstack/react-virtual` (list virtualisation)

--- a/specs/182-import-platform-warnings/checklists/requirements.md
+++ b/specs/182-import-platform-warnings/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Import Handler Warnings for Unregistered Platforms
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. No [NEEDS CLARIFICATION] markers present.
+- This is a non-UI feature (service/handler enhancement) — UI Feature Validation section is not applicable.
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/182-import-platform-warnings/contracts/validate-platforms.md
+++ b/specs/182-import-platform-warnings/contracts/validate-platforms.md
@@ -1,0 +1,114 @@
+# Contract: Platform ID Validation
+
+**Feature**: 182-import-platform-warnings  
+**Date**: 2026-04-13
+
+## Internal Function Contract
+
+This feature adds one internal function to `import_catalog.py`. It is not a public API — it's an internal helper called during the import pipeline. Documented here for implementation clarity and test design.
+
+### `_validate_platform_ids`
+
+**Signature**:
+```python
+def _validate_platform_ids(
+    features: list[dict[str, Any]],
+    file_rel: str,
+    registry: PlatformRegistry,
+    warnings: list[ImportWarning],
+) -> None:
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `features` | `list[dict[str, Any]]` | GeoJSON Feature dicts from the parse result |
+| `file_rel` | `str` | Relative path to the source file (for warning attribution) |
+| `registry` | `PlatformRegistry` | Loaded platform registry instance |
+| `warnings` | `list[ImportWarning]` | Mutable list to append warnings to |
+
+**Behaviour**:
+
+1. Extract all `platform_id` values from `feature["properties"]["platform_id"]` across all features.
+2. Deduplicate into a set. Discard empty strings and whitespace-only strings.
+3. For each unique platform ID, call `registry.resolve(platform_id)`.
+4. If `resolve()` returns `None`, append an `ImportWarning` to `warnings`:
+   - `file`: `file_rel`
+   - `code`: `"UNREGISTERED_PLATFORM"`
+   - `message`: `"Platform '{platform_id}' is not registered in the platform registry"`
+
+**Postconditions**:
+- `warnings` may have 0 to N new entries appended (where N = number of unique unregistered platform IDs)
+- Features are not modified
+- No exceptions raised
+
+### Modified: `import_legacy_data`
+
+**Existing signature** (unchanged):
+```python
+def import_legacy_data(
+    source_dir: Path,
+    catalog_path: Path,
+    catalog_title: str = "Debrief Legacy Sample Data",
+) -> ImportResult:
+```
+
+**New behaviour**:
+1. At function start: attempt to load the platform registry via `load_registry()`.
+   - On success: store the registry instance.
+   - On failure (`FileNotFoundError`, `RegistryError`): set registry to `None`, append a single `ImportWarning` with code `REGISTRY_UNAVAILABLE`.
+2. After each file parse (after `parse(source_file)` succeeds): if registry is not `None`, call `_validate_platform_ids(features, file_rel, registry, result.warnings)`.
+3. All existing behaviour is unchanged — the validation step is additive only.
+
+## Warning Output Examples
+
+### Successful validation with unregistered platforms
+
+```python
+ImportResult(
+    catalog_path="/path/to/catalog",
+    files_processed=1,
+    files_succeeded=1,
+    warnings=[
+        ImportWarning(
+            file="data/exercise1.rep",
+            code="UNREGISTERED_PLATFORM",
+            message="Platform 'PHANTOM' is not registered in the platform registry",
+        ),
+        ImportWarning(
+            file="data/exercise1.rep",
+            code="UNREGISTERED_PLATFORM",
+            message="Platform 'CONTACT_BRAVO' is not registered in the platform registry",
+        ),
+    ],
+)
+```
+
+### Registry unavailable
+
+```python
+ImportResult(
+    catalog_path="/path/to/catalog",
+    files_processed=1,
+    files_succeeded=1,
+    warnings=[
+        ImportWarning(
+            file="",
+            code="REGISTRY_UNAVAILABLE",
+            message="Platform registry could not be loaded: [Errno 2] No such file or directory: '/path/to/registry.json'. Platform validation skipped.",
+        ),
+    ],
+)
+```
+
+### All platforms registered
+
+```python
+ImportResult(
+    catalog_path="/path/to/catalog",
+    files_processed=1,
+    files_succeeded=1,
+    warnings=[],  # No warnings
+)
+```

--- a/specs/182-import-platform-warnings/data-model.md
+++ b/specs/182-import-platform-warnings/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: Import Handler Warnings for Unregistered Platforms
+
+**Feature**: 182-import-platform-warnings  
+**Date**: 2026-04-13
+
+## Overview
+
+This feature introduces no new data entities. It uses the existing `ImportWarning` model and `PlatformRegistry` API to validate platform IDs during import. This document describes the existing entities and the new warning codes.
+
+## Existing Entities (No Changes)
+
+### ImportWarning
+
+**Location**: `services/io/src/debrief_io/models.py`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `str` | Relative path to the source file that produced the warning |
+| `code` | `str` | Machine-readable warning code for programmatic filtering |
+| `message` | `str` | Human-readable description of the warning |
+
+### ImportResult
+
+**Location**: `services/io/src/debrief_io/models.py`
+
+Contains `warnings: list[ImportWarning]` — warnings are accumulated in-place during import. This feature appends to this list; no structural changes needed.
+
+### PlatformRegistry
+
+**Location**: `shared/data/src/debrief_data/registry.py`
+
+Used via `resolve(platform_id: str) -> ResolvedPlatform | None`. Returns `None` for unregistered platforms. Already fully implemented in #180.
+
+### ResolvedPlatform
+
+**Location**: `shared/data/src/debrief_data/registry.py`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Platform identifier (e.g., "NELSON") |
+| `name` | `str` | Full name (e.g., "HMS Nelson") |
+| `nationality` | `str` | ISO 3166-1 alpha-2 code |
+| `vessel_class` | `str` | Full taxonomy path (e.g., "surface/warship/frigate/type23") |
+| `vessel_type` | `str` | Leaf of class path (e.g., "type23") |
+| `vessel_role` | `str` | Parent of leaf (e.g., "frigate") |
+| `domain` | `str` | First segment (e.g., "surface") |
+| `short_name` | `str \| None` | Abbreviated name (e.g., "NLSN") |
+
+## New Warning Codes
+
+| Code | Emitted When | Cardinality | Example Message |
+|------|-------------|-------------|-----------------|
+| `UNREGISTERED_PLATFORM` | A unique `platform_id` from a parsed file is not found in the registry | Once per unregistered platform ID per source file | `Platform 'PHANTOM' is not registered in the platform registry` |
+| `REGISTRY_UNAVAILABLE` | The platform registry fails to load (missing file or invalid content) | Once per import call (not per file) | `Platform registry could not be loaded: [error detail]. Platform validation skipped.` |
+
+## Validation Flow
+
+```
+import_legacy_data(source_dir, catalog_path)
+│
+├── registry = load_registry()  # Once at start
+│   └── On failure: registry = None, emit REGISTRY_UNAVAILABLE warning
+│
+└── For each source file:
+    ├── parse_result = parse(source_file)
+    ├── _validate_platform_ids(features, file_rel, registry, warnings)
+    │   ├── Collect unique non-empty platform_ids from features
+    │   ├── For each unique ID: registry.resolve(id)
+    │   └── If None: append ImportWarning(UNREGISTERED_PLATFORM)
+    └── [existing: create STAC plot, write features, merge sensors]
+```
+
+## Data Relationships
+
+```
+Source File (REP/DPF)
+  └─ contains Track(s)
+       └─ each has platform_id (string)
+              │
+              ├── resolve against PlatformRegistry
+              │     ├── Found: no action (platform is registered)
+              │     └── Not found: emit ImportWarning(UNREGISTERED_PLATFORM)
+              │
+              └── written to features.geojson properties.platform_id
+                  (unchanged — this feature does not modify feature output)
+```

--- a/specs/182-import-platform-warnings/media/linkedin-planning.md
+++ b/specs/182-import-platform-warnings/media/linkedin-planning.md
@@ -1,0 +1,11 @@
+Load a legacy maritime exercise file containing a platform called AMBUSH. The platform registry has no entry for it. Your next query for "UK submarines" silently omits it. Nobody knows.
+
+This week I'm adding import-time validation to Future Debrief that checks every extracted platform identifier against the registry and surfaces advisory warnings for anything unregistered. The import always succeeds -- data gets in regardless -- but the analyst gets a clear to-do list of platforms needing registry entries.
+
+The check sits at the single entry point for all format handlers, so every file type gets validated automatically. Warnings are deduplicated (one per platform per file, not per track position) and the registry load itself is graceful -- if it fails, you get one warning that validation was skipped, not a blocked import.
+
+It's a quality ratchet for the catalog discovery features we're building. Small piece of plumbing, but it's how the registry stays comprehensive as new data arrives.
+
+Planning post with full details: [link to full post]
+
+#FutureDebrief #MaritimeAnalysis #OpenSource

--- a/specs/182-import-platform-warnings/media/planning-post.md
+++ b/specs/182-import-platform-warnings/media/planning-post.md
@@ -1,0 +1,42 @@
+---
+layout: future-post
+title: "Planning: Import Handler Warnings for Unregistered Platforms"
+date: 2026-04-14
+track: [momentum]
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, import-pipeline, e10-catalog-discovery, platform-registry]
+excerpt: "Catching unregistered platforms at import time so the registry stays complete as new data arrives"
+---
+
+## What We're Building
+
+The platform registry (#180) is in place -- ten known platforms organised in a vessel class tree, queryable by nationality, domain, vessel type. But it only works if the registry actually contains every platform in your data. Load a legacy file with a platform called `AMBUSH` and nothing tells you it's missing from the registry. Your next "show me all UK submarines" query silently omits it.
+
+This week we're adding a post-parse validation step to the import pipeline. After `import_legacy_data()` parses a REP or DPF file, it checks every extracted platform identifier against the registry. Unregistered platforms produce advisory warnings -- the import always succeeds, but the analyst gets a clear list of platforms needing registry entries.
+
+The key word is "advisory". We never block an import because of missing metadata. The data gets in, the warnings tell you what to clean up, and the registry gradually becomes comprehensive as new exercises are loaded. It's a quality ratchet, not a gate.
+
+## How It Fits
+
+This is item 3 of 11 in the E10 epic (NL-Assisted Catalog Discovery). The sequence is deliberate: #180 built the registry, #181 updated the schemas to carry registry-derived fields, and now #182 connects the registry to the point where new data enters the system. Downstream, #183 will resolve platform metadata at save time and #184 will regenerate the sample catalog with proper vessel class data -- but neither of those features works well if the registry has gaps nobody knows about.
+
+The validation sits inside `import_legacy_data()`, which is the single entry point for all format handlers. One check point covers REP and DPF files today, and any new format handler added later gets platform validation for free. The import function already returns a result object with a warnings list, so there's no new API surface -- just new warning types flowing through the existing channel.
+
+The registry itself is loaded via `debrief-data`, the in-repo workspace package we created in #180. That package already exposes `load_registry()` and `resolve_platform()`. The new validation code is a thin consumer: load registry, iterate platform IDs, check each one.
+
+## Key Decisions
+
+- **Validation inside `import_legacy_data()`, not per-parser** -- each format parser (REP, DPF) extracts platform IDs, but the registry check happens after parsing completes. This avoids duplicating validation logic across parsers and means new format handlers get it automatically.
+- **Deduplicated warnings** -- if a file contains 500 track positions for `AMBUSH`, you get one `UNREGISTERED_PLATFORM` warning for that file, not 500. The deduplication is per platform per source file. Clear signal, no noise.
+- **Graceful registry load failure** -- if the registry JSON is missing or corrupt, the import still succeeds. A single `REGISTRY_UNAVAILABLE` warning tells the analyst that platform validation was skipped. We never fail an import because of a metadata subsystem problem.
+- **Two warning codes, existing convention** -- `UNREGISTERED_PLATFORM` and `REGISTRY_UNAVAILABLE` follow the same pattern as existing import warnings. No new warning infrastructure needed.
+- **Test-driven implementation** -- unit tests for the validation logic in isolation (given these platform IDs and this registry, expect these warnings), plus integration tests that run the full import pipeline with files containing unknown platforms. Both layers need to pass before merge.
+
+## What We'd Love Feedback On
+
+- **Warning verbosity**: Each `UNREGISTERED_PLATFORM` warning will include the platform ID and the source file. Should it also suggest the most likely vessel class based on naming patterns, or is that overstepping for an import-time check?
+- **Batch import summaries**: When importing a directory of 50 files, the per-file warnings could add up. Should we also produce a deduplicated summary across all files ("these 4 platforms are unregistered across your import"), or is per-file granularity sufficient?
+- **Registry update workflow**: Once an analyst sees the warning, what should the next step look like? Right now, editing the registry means modifying a JSON file. We're not building a UI for that yet, but if the warning message should point somewhere specific, we'd like to get the wording right from the start.
+
+-> [Join the discussion](https://github.com/debrief/debrief-future/discussions)

--- a/specs/182-import-platform-warnings/plan.md
+++ b/specs/182-import-platform-warnings/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Import Handler Warnings for Unregistered Platforms
+
+**Branch**: `182-import-platform-warnings` | **Date**: 2026-04-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/182-import-platform-warnings/spec.md`
+
+## Summary
+
+Add a post-parse validation step to the import pipeline that checks all extracted `platform_id` values against the platform registry (#180) and emits deduplicated `UNREGISTERED_PLATFORM` warnings. The import always succeeds — warnings are advisory only. This gives analysts a clear list of platforms needing registry entries for full metadata enrichment in downstream features (#183, #184).
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: `debrief-data` (platform registry loader), `pydantic>=2.12.5` (existing), `debrief-schemas` (existing)  
+**Storage**: N/A (no new storage — warnings are returned in-memory on `ImportResult`)  
+**Testing**: pytest with existing fixtures in `services/io/tests/`  
+**Target Platform**: Linux (CI), macOS/Windows (developer)  
+**Project Type**: Python workspace member (`services/io/`)  
+**Performance Goals**: N/A — registry lookup is O(1) hash table per unique platform ID; negligible overhead  
+**Constraints**: Must not break existing imports; must handle missing/corrupt registry gracefully  
+**Scale/Scope**: ~10 registered platforms currently; typical import file has 1-20 unique platform IDs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Status | Notes |
+|---------|--------|-------|
+| I. Defence-Grade Reliability | PASS | No silent failures — unregistered platforms produce explicit warnings. Offline by default — registry is a local file. |
+| II. Schema Integrity | N/A | No schema changes in this feature (that's #181). |
+| III. Data Sovereignty | PASS | Source files are never modified. No new data persistence. Warnings are transient in-memory. |
+| IV. Architectural Boundaries | PASS | Change is entirely within the `services/io` Python service layer. No UI, no frontend changes. |
+| V. Extensibility | PASS | No vendor lock-in. Registry is a standard JSON file with pure-Python loader. |
+| VI. Testing | PASS | Unit tests for validation logic + integration tests for import pipeline. Plan includes both. |
+| VII. Test-Driven AI | PASS | Tests will be written before implementation (see quickstart.md). |
+| VIII. Documentation | PASS | Spec written before code. Warning code documented in data model. |
+| IX. Dependencies | PASS | Adding `debrief-data` — an in-repo workspace member, not an external dependency. Already vetted for #180. |
+| X. Security | PASS | No secrets, no network access. Local file operations only. |
+| XI. Internationalisation | N/A | Warning messages are programmatic (code + platform ID), not user-facing strings requiring translation. |
+| XIII. Contribution Standards | PASS | Atomic commits, PR review, CI must pass. |
+| XV. Strict Type Safety | PASS | All new code will have explicit type annotations. `PlatformRegistry` API is already fully typed. |
+
+**Gate result**: PASS — no violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/182-import-platform-warnings/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: technical research
+├── data-model.md        # Phase 1: data model
+├── contracts/           # Phase 1: API contracts
+│   └── validate-platforms.md
+├── quickstart.md        # Phase 1: implementation guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── media/
+    ├── planning-post.md
+    └── linkedin-planning.md
+```
+
+### Source Code (repository root)
+
+```text
+services/io/
+├── pyproject.toml                          # Add debrief-data dependency
+├── src/debrief_io/
+│   ├── import_catalog.py                   # Add registry validation call after parse
+│   └── models.py                           # No changes (ImportWarning already sufficient)
+└── tests/
+    ├── conftest.py                         # Add registry fixtures
+    ├── test_import_catalog.py              # Add integration tests
+    └── test_platform_validation.py         # New: unit tests for validation logic
+```
+
+**Structure Decision**: All changes are within the existing `services/io/` workspace member. A new `test_platform_validation.py` isolates the validation logic unit tests from the existing integration test file. The validation function itself lives in `import_catalog.py` alongside the existing import pipeline — it's a single internal function, not complex enough to warrant a separate module.
+
+## Media Components
+
+None - backend/infrastructure feature
+
+## Storybook E2E Testing
+
+None - no interactive UI components
+
+## VS Code Webview E2E Testing
+
+None - no extension workflow changes

--- a/specs/182-import-platform-warnings/quickstart.md
+++ b/specs/182-import-platform-warnings/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart: Import Handler Warnings for Unregistered Platforms
+
+**Feature**: 182-import-platform-warnings  
+**Date**: 2026-04-13
+
+## Prerequisites
+
+- Python 3.11+
+- `uv` package manager
+- Platform registry (#180) complete (it is)
+
+## Implementation Order
+
+Follow test-driven development: write tests first, then implementation.
+
+### Step 1: Add `debrief-data` dependency
+
+In `services/io/pyproject.toml`, add `debrief-data` to the dependencies:
+
+```toml
+dependencies = [
+    "pydantic>=2.12.5",
+    "debrief-schemas",
+    "debrief-data",
+]
+```
+
+Then sync:
+```bash
+uv sync
+```
+
+### Step 2: Write unit tests (`test_platform_validation.py`)
+
+Create `services/io/tests/test_platform_validation.py` with tests for `_validate_platform_ids()`:
+
+**Test cases to cover**:
+1. Features with all registered platform IDs produce no warnings
+2. Features with unregistered platform IDs produce one warning per unregistered ID
+3. Empty/whitespace platform IDs are skipped (no warning)
+4. Duplicate platform IDs in multiple features produce only one warning
+5. Case-sensitive: "nelson" (lowercase) is unregistered even though "NELSON" is registered
+6. Warning has correct code (`UNREGISTERED_PLATFORM`), file path, and message format
+7. Features with no `platform_id` property are skipped gracefully
+
+**Fixture**: Use the real `load_registry()` from `debrief_data` — the bundled registry file has 10 known platforms.
+
+### Step 3: Write integration tests (add to `test_import_catalog.py`)
+
+Add tests to the existing `TestImportLegacyData` class:
+
+**Test cases to cover**:
+1. Import REP file with registered platforms — no `UNREGISTERED_PLATFORM` warnings in result
+2. Import REP file with unregistered platforms — correct warnings in result
+3. Import with registry unavailable — `REGISTRY_UNAVAILABLE` warning, import still succeeds
+4. Verify existing tests still pass (regression check)
+
+### Step 4: Implement `_validate_platform_ids()`
+
+Add to `services/io/src/debrief_io/import_catalog.py`:
+
+```python
+from debrief_data import load_registry, PlatformRegistry
+
+def _validate_platform_ids(
+    features: list[dict[str, Any]],
+    file_rel: str,
+    registry: PlatformRegistry,
+    warnings: list[ImportWarning],
+) -> None:
+    """Check platform IDs against registry; append warnings for unregistered ones."""
+    platform_ids: set[str] = set()
+    for feature in features:
+        pid = feature.get("properties", {}).get("platform_id", "")
+        if pid and pid.strip():
+            platform_ids.add(pid)
+
+    for pid in sorted(platform_ids):
+        if registry.resolve(pid) is None:
+            warnings.append(
+                ImportWarning(
+                    file=file_rel,
+                    code="UNREGISTERED_PLATFORM",
+                    message=f"Platform '{pid}' is not registered in the platform registry",
+                )
+            )
+```
+
+### Step 5: Integrate into `import_legacy_data()`
+
+At the top of `import_legacy_data()`, load the registry:
+
+```python
+registry: PlatformRegistry | None = None
+try:
+    registry = load_registry()
+except (FileNotFoundError, RegistryError):
+    result.warnings.append(
+        ImportWarning(
+            file="",
+            code="REGISTRY_UNAVAILABLE",
+            message=f"Platform registry could not be loaded: {e}. Platform validation skipped.",
+        )
+    )
+```
+
+After each file parse succeeds (after existing warning collection), add:
+
+```python
+if registry is not None:
+    _validate_platform_ids(parse_result.features, file_rel, registry, result.warnings)
+```
+
+### Step 6: Verify
+
+```bash
+# Run unit tests
+uv run pytest services/io/tests/test_platform_validation.py -v
+
+# Run integration tests
+uv run pytest services/io/tests/test_import_catalog.py -v
+
+# Run full verification
+task verify
+```
+
+## Key Files
+
+| File | Action |
+|------|--------|
+| `services/io/pyproject.toml` | Add `debrief-data` dependency |
+| `services/io/src/debrief_io/import_catalog.py` | Add `_validate_platform_ids()` function + registry loading in `import_legacy_data()` |
+| `services/io/tests/test_platform_validation.py` | New: unit tests for validation logic |
+| `services/io/tests/test_import_catalog.py` | Add: integration tests for registry warnings |

--- a/specs/182-import-platform-warnings/research.md
+++ b/specs/182-import-platform-warnings/research.md
@@ -1,0 +1,105 @@
+# Research: Import Handler Warnings for Unregistered Platforms
+
+**Feature**: 182-import-platform-warnings  
+**Date**: 2026-04-13
+
+## R1: Where to Insert Registry Validation in the Import Pipeline
+
+**Decision**: Validate platform IDs against the registry inside `import_legacy_data()` in `import_catalog.py`, after each file is parsed and before STAC catalog creation.
+
+**Rationale**: The import pipeline processes files sequentially in a loop (line 309–413 of `import_catalog.py`). After `parse(source_file)` returns a `ParseResult`, all track features with `platform_id` properties are available. This is the earliest point where we have the complete set of platform IDs for a file — and the right place to validate them before the features are written to the catalog.
+
+Validating here (rather than inside individual handlers) means:
+- One validation call covers all formats (REP, DPF, DSF)
+- Deduplication is straightforward — collect unique IDs per file
+- The existing `ImportWarning` accumulation pattern is directly available
+
+**Alternatives considered**:
+- *Inside each handler*: Would require duplicating validation logic in `rep.py`, `dpf.py`, and `dsf.py`. Violates DRY. Also harder to deduplicate since handlers produce features incrementally.
+- *After the full batch*: Would lose per-file source context on warnings. An unregistered platform would have no file attribution.
+- *Separate post-processing step*: Unnecessary abstraction for a simple set-difference check.
+
+## R2: New Dependency — `debrief-data` for `debrief-io`
+
+**Decision**: Add `debrief-data` as a dependency of `services/io/` in its `pyproject.toml`.
+
+**Rationale**: The platform registry loader (`load_registry()` → `PlatformRegistry`) lives in the `debrief-data` workspace member at `shared/data/`. This is an in-repo workspace dependency, not an external package — it was built specifically for cross-service access to the platform registry (#180). Adding it is equivalent to importing from a sibling module.
+
+**Alternatives considered**:
+- *Copy the registry loading code*: Violates DRY and constitution Article II (single source of truth).
+- *Read the JSON file directly*: Bypasses the validated `PlatformRegistry` API, duplicates tree-walking logic, and loses the `resolve()` method.
+- *Pass registry as a parameter*: Considered for the validation function itself (good for testability), but `import_legacy_data()` should handle its own registry loading internally with graceful fallback.
+
+## R3: Registry Loading Strategy — Eager vs Lazy, Failure Handling
+
+**Decision**: Load the registry once at the start of `import_legacy_data()` with a try/except. On failure, set registry to `None` and emit a single `REGISTRY_UNAVAILABLE` warning. All subsequent validation calls are skipped when registry is `None`.
+
+**Rationale**: The registry is a small static file (~10 platforms, <5KB JSON). Loading it once per import call is negligible overhead. Loading eagerly (at the top of the function) rather than lazily (per-file) keeps the logic simple and avoids repeated file I/O.
+
+Catching both `FileNotFoundError` and `RegistryError` at load time ensures the import never fails due to registry issues — this is a best-effort validation step.
+
+**Alternatives considered**:
+- *Module-level singleton*: Would cache the registry across multiple `import_legacy_data()` calls, but makes testing harder and prevents registry updates between calls.
+- *Per-file loading*: Wasteful — the registry doesn't change between files in a single batch.
+- *Raising on registry failure*: Would violate FR-003 (import must never be blocked by registry gaps).
+
+## R4: Validation Function Design — Extract vs Inline
+
+**Decision**: Extract a standalone function `_validate_platform_ids()` that takes a list of features, the source file path, the registry, and appends warnings to a list. Called once per file after parsing.
+
+**Rationale**: A standalone function is independently testable with unit tests — no need to set up a full import pipeline to test the deduplication and edge case logic. The function signature:
+
+```python
+def _validate_platform_ids(
+    features: list[dict[str, Any]],
+    file_rel: str,
+    registry: PlatformRegistry,
+    warnings: list[ImportWarning],
+) -> None:
+```
+
+It collects unique non-empty `platform_id` values from feature properties, resolves each against the registry, and appends an `ImportWarning` with code `UNREGISTERED_PLATFORM` for each miss.
+
+**Alternatives considered**:
+- *Inline in the import loop*: Harder to unit test, mixes concerns.
+- *Separate module*: Over-engineering for a single function.
+- *Method on ImportResult*: Wrong responsibility — the result model should not know about the registry.
+
+## R5: Warning Deduplication Strategy
+
+**Decision**: Deduplicate at the unique-platform-ID-per-file level using a `set()` of platform IDs extracted from features before checking the registry.
+
+**Rationale**: A REP file can have hundreds of position records for the same platform, but only one `TrackBuilder` per platform ID. However, DPF files could have multiple track elements with the same name. The safest approach is to extract all `platform_id` values from all features for a given file, deduplicate them into a set, then check each unique ID once.
+
+This means:
+- One warning per unregistered platform per source file
+- A platform appearing in files A and B produces two warnings (one per file)
+- A platform appearing 500 times in one file produces one warning
+
+**Alternatives considered**:
+- *Global deduplication across all files*: Would lose per-file source context. An analyst importing 50 files needs to know which file introduced "UNKNOWN_VESSEL".
+- *No deduplication*: Could produce hundreds of duplicate warnings for a single platform in a large file.
+
+## R6: Warning Code Convention
+
+**Decision**: Use `UNREGISTERED_PLATFORM` as the warning code. Use `REGISTRY_UNAVAILABLE` for registry load failures.
+
+**Rationale**: The existing codebase uses `SCREAMING_SNAKE_CASE` for warning codes (e.g., `ORPHAN_SENSOR`, `NO_FEATURES`, `SCHEMA_VALIDATION`). The new codes follow this convention and are distinct enough for programmatic filtering.
+
+**Alternatives considered**:
+- *`UNKNOWN_PLATFORM`*: "Unknown" is ambiguous — the platform isn't unknown, it's just not in the registry.
+- *`MISSING_REGISTRY_ENTRY`*: Focuses on the registry rather than the platform — less intuitive for the analyst.
+
+## R7: Test Strategy
+
+**Decision**: Two test files — unit tests for the validation function (`test_platform_validation.py`) and integration tests added to the existing `test_import_catalog.py`.
+
+**Rationale**:
+- **Unit tests** (`test_platform_validation.py`): Test `_validate_platform_ids()` directly with synthetic features and a mock/real registry. Cover: registered platforms (no warnings), unregistered platforms (warnings emitted), empty IDs (skipped), deduplication, case sensitivity.
+- **Integration tests** (added to `test_import_catalog.py`): Import actual REP/DPF fixtures through the full pipeline and verify warnings appear in `ImportResult.warnings`. Cover: registry unavailable (graceful fallback), all-registered (no warnings), mixed (correct warnings).
+
+Both approaches align with constitution Article VI (unit + integration) and Article VII (tests before implementation).
+
+**Alternatives considered**:
+- *Only integration tests*: Slower, harder to cover edge cases like empty IDs or case sensitivity.
+- *Only unit tests*: Would miss integration issues like the registry not being loaded at the right point in the pipeline.

--- a/specs/182-import-platform-warnings/spec.md
+++ b/specs/182-import-platform-warnings/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Import Handler Warnings for Unregistered Platforms
+
+**Feature Branch**: `182-import-platform-warnings`  
+**Created**: 2026-04-13  
+**Status**: Draft  
+**Input**: User description: "[E10] Import handler warnings for unregistered platforms — check extracted platform_id values against registry after import; log warnings listing unregistered IDs (import still succeeds)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Unregistered Platform Warnings on Import (Priority: P1)
+
+As an analyst importing legacy data files (REP or DPF format), I want the system to check each extracted platform identifier against the platform registry and warn me about any unregistered platforms, so that I have a clear to-do list of platforms that need to be added to the registry for full metadata enrichment.
+
+**Why this priority**: This is the core purpose of the feature. Without this validation, unregistered platforms silently enter the catalog with no metadata, and the analyst has no way to know which platforms are missing from the registry until they encounter gaps downstream (e.g. missing nationality or vessel class in search results).
+
+**Independent Test**: Can be fully tested by importing a file containing a mix of registered and unregistered platform IDs and verifying that warnings are emitted only for the unregistered ones.
+
+**Acceptance Scenarios**:
+
+1. **Given** a REP file containing tracks for platforms "NELSON" (registered) and "UNKNOWN_VESSEL" (not in registry), **When** the file is imported, **Then** the import succeeds and the result includes a warning identifying "UNKNOWN_VESSEL" as an unregistered platform.
+2. **Given** a DPF file containing tracks for platforms "DEFENDER" (registered) and "PHANTOM" (not in registry), **When** the file is imported, **Then** the import succeeds and the result includes a warning identifying "PHANTOM" as an unregistered platform.
+3. **Given** a file where all platform IDs are present in the registry, **When** the file is imported, **Then** the import succeeds with no unregistered-platform warnings.
+
+---
+
+### User Story 2 - Import Never Blocked by Registry Gaps (Priority: P1)
+
+As an analyst, I need the import to always succeed regardless of whether platforms are registered, so that I can work with the data immediately and address registry gaps later at my convenience.
+
+**Why this priority**: Equally critical to the warning behaviour — if the registry check blocked imports, analysts would be unable to load new data until every platform was catalogued, which defeats the purpose of the advisory-only design.
+
+**Independent Test**: Can be fully tested by importing a file containing only unregistered platform IDs and verifying that all tracks are present in the resulting catalog, with warnings emitted but no errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a REP file where every platform ID is unregistered, **When** the file is imported, **Then** the import completes successfully with all tracks present in the output.
+2. **Given** a DPF file where every platform ID is unregistered, **When** the file is imported, **Then** the import completes successfully and warnings are emitted for each unregistered platform.
+
+---
+
+### User Story 3 - Consolidated Warning Summary (Priority: P2)
+
+As an analyst importing a file with multiple tracks, I want the warnings to be consolidated so that each unregistered platform is reported once per import (not once per track position), giving me a concise summary rather than a flood of duplicate messages.
+
+**Why this priority**: Usability refinement. A file with hundreds of position records for one unregistered platform should produce a single warning for that platform, not hundreds. This keeps the warning output actionable.
+
+**Independent Test**: Can be tested by importing a file with many position records for a single unregistered platform and verifying only one warning is produced for that platform ID.
+
+**Acceptance Scenarios**:
+
+1. **Given** a REP file with 500 position records for unregistered platform "CONTACT_ALPHA", **When** the file is imported, **Then** exactly one warning is emitted for "CONTACT_ALPHA" (not one per position record).
+2. **Given** a DPF file with three unregistered platforms each appearing in multiple tracks, **When** the file is imported, **Then** exactly three warnings are emitted (one per unique unregistered platform ID).
+
+---
+
+### User Story 4 - Warning Includes Source File Context (Priority: P3)
+
+As an analyst importing multiple files in a batch, I want each unregistered-platform warning to identify the source file, so I can trace which files introduced which unknown platforms.
+
+**Why this priority**: Useful for batch imports where many files are processed together. Knowing which source file produced the warning helps the analyst triage and prioritise registry additions.
+
+**Independent Test**: Can be tested by importing multiple files in a single batch where different files contain different unregistered platforms, and verifying each warning references the correct source file.
+
+**Acceptance Scenarios**:
+
+1. **Given** two files imported in the same batch — file A containing unregistered "VESSEL_X" and file B containing unregistered "VESSEL_Y", **When** both files are imported, **Then** the warning for "VESSEL_X" references file A and the warning for "VESSEL_Y" references file B.
+
+---
+
+### Edge Cases
+
+- What happens when a platform ID is an empty string or whitespace? The system should skip validation for empty/whitespace platform IDs (no warning emitted, as these are not meaningful identifiers).
+- What happens when the platform registry file cannot be loaded (missing or corrupt)? The import should still succeed — registry validation is a best-effort check. A single warning should indicate that registry validation was skipped due to a load failure.
+- What happens when the same unregistered platform appears across multiple files in a batch import? One warning per unique platform ID per source file is emitted (a platform unregistered in file A and file B produces two warnings, one referencing each file).
+- What happens when a platform is registered but under a different case (e.g., "nelson" vs "NELSON")? Platform ID lookup is case-sensitive, matching the existing registry behaviour. A case mismatch produces an unregistered-platform warning.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST check all extracted `platform_id` values against the platform registry after each file import completes.
+- **FR-002**: System MUST emit a warning for each unique `platform_id` that is not found in the registry, identifying the unregistered platform and the source file.
+- **FR-003**: System MUST NOT block or fail the import due to unregistered platforms — import always succeeds regardless of registry coverage.
+- **FR-004**: System MUST deduplicate warnings so that each unregistered platform ID produces at most one warning per source file, regardless of how many track positions reference that platform.
+- **FR-005**: System MUST skip registry validation for empty or whitespace-only platform IDs without emitting a warning.
+- **FR-006**: System MUST use a distinct warning code (e.g., `UNREGISTERED_PLATFORM`) to allow programmatic filtering of these warnings from other import warnings.
+- **FR-007**: System MUST gracefully handle registry load failures by skipping the validation step and emitting a single warning indicating that registry validation was unavailable.
+- **FR-008**: System MUST apply to all supported import formats (REP and DPF files).
+- **FR-009**: Platform ID lookup MUST be case-sensitive, consistent with the existing registry behaviour.
+
+### Key Entities
+
+- **Platform ID**: A string identifier extracted from imported data files that names a track (e.g., "NELSON", "DEFENDER"). Used as the lookup key against the platform registry.
+- **Platform Registry**: A static data file containing known platforms organised in a vessel-class hierarchy. Each platform entry includes name, nationality, and positional metadata (vessel class, type, role, domain). Used as the reference for validating platform IDs.
+- **Import Warning**: A structured record produced during import containing a warning code, human-readable message, and source file reference. Accumulated into the import result for the caller to inspect.
+
+## Assumptions
+
+- The platform registry (#180) is already implemented and available as a loadable data file with a resolve-by-ID capability.
+- The existing import pipeline already accumulates warnings in a structured list on the import result, with a defined warning model containing file, code, and message fields.
+- Import handlers already extract `platform_id` from track data in both REP and DPF formats.
+- This feature does not modify how `platform_id` values are extracted — it only validates them post-extraction.
+- This feature does not enrich track features with registry metadata (that is the responsibility of save-time resolution in #183).
+
+## Dependencies
+
+- **#180 (Platform Registry)**: Required — provides the registry data file and loader/resolver used for validation. Already complete.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of unregistered platform IDs produce a warning after import — no silent gaps in registry coverage go unreported.
+- **SC-002**: 0% of imports are blocked or fail due to unregistered platforms — the import success rate is unchanged by this feature.
+- **SC-003**: Warning output is concise — each unregistered platform ID appears at most once per source file, regardless of the number of track positions.
+- **SC-004**: Warning messages are actionable — each warning identifies the unregistered platform ID and the source file, giving the analyst enough context to act.
+- **SC-005**: Registry load failures do not degrade import functionality — imports complete successfully with a single advisory warning when the registry is unavailable.
+- **SC-006**: All existing import tests continue to pass — no regressions in import behaviour for files with fully registered platforms.

--- a/specs/182-import-platform-warnings/tasks.md
+++ b/specs/182-import-platform-warnings/tasks.md
@@ -1,0 +1,251 @@
+# Tasks: Import Handler Warnings for Unregistered Platforms
+
+**Input**: Design documents from `/specs/182-import-platform-warnings/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Tests are included — constitution requires unit and integration tests for all service code (Article VI).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing. US1 and US2 are combined into one phase because they are inseparable — the same code that emits warnings (US1) also ensures the import never blocks (US2).
+
+---
+
+## Evidence Requirements
+
+> **Purpose**: Capture artifacts that demonstrate the feature works as expected. These are used in PR descriptions, documentation, and future blog posts.
+
+**Evidence Directory**: `specs/182-import-platform-warnings/evidence/`
+**Media Directory**: `specs/182-import-platform-warnings/media/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| test-summary.md | pytest results for unit + integration tests | After all tests pass |
+| usage-example.md | Python code showing import with warnings | After pipeline integration complete |
+| sample-warnings.json | Example ImportResult.warnings output | After pipeline integration complete |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| media/planning-post.md | Blog post announcing the feature | During /speckit.plan (done) |
+| media/linkedin-planning.md | LinkedIn summary for planning | During /speckit.plan (done) |
+| media/shipped-post.md | Blog post celebrating completion | During Polish phase |
+| media/linkedin-shipped.md | LinkedIn summary for shipped | During Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in debrief-future with evidence | Final task in Polish phase |
+| Blog PR | PR in debrief.github.io with post | Triggered by /speckit.pr |
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add the `debrief-data` dependency so the import pipeline can access the platform registry.
+
+- [ ] T001 Add `debrief-data` to dependencies in `services/io/pyproject.toml`
+- [ ] T002 Run `uv sync` to install the new dependency
+
+---
+
+## Phase 2: Foundation — Validation Function (Blocking)
+
+**Purpose**: Implement the core `_validate_platform_ids()` function and its unit tests. This function is shared by all user stories.
+
+**CRITICAL**: No user story integration can begin until this phase is complete.
+
+### Tests
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T003 [test] Create unit test file `services/io/tests/test_platform_validation.py`
+- [ ] T004 [P][test] Test: all registered platforms produce no warnings `services/io/tests/test_platform_validation.py`
+- [ ] T005 [P][test] Test: unregistered platform produces warning with correct code and message `services/io/tests/test_platform_validation.py`
+- [ ] T006 [P][test] Test: empty and whitespace-only platform IDs are skipped `services/io/tests/test_platform_validation.py`
+- [ ] T007 [P][test] Test: duplicate platform IDs across features produce only one warning `services/io/tests/test_platform_validation.py`
+- [ ] T008 [P][test] Test: case-sensitive lookup ("nelson" vs "NELSON") `services/io/tests/test_platform_validation.py`
+- [ ] T009 [P][test] Test: features with no platform_id property are skipped `services/io/tests/test_platform_validation.py`
+
+### Implementation
+
+- [ ] T010 Implement `_validate_platform_ids()` function in `services/io/src/debrief_io/import_catalog.py`
+- [ ] T011 Verify all unit tests pass
+
+**Checkpoint**: Validation function works in isolation. All unit tests green.
+
+---
+
+## Phase 3: User Stories 1 & 2 — Core Warnings + Non-Blocking Import (Priority: P1)
+
+**Goal**: After importing a file, unregistered platform IDs produce `UNREGISTERED_PLATFORM` warnings. The import always succeeds regardless of registry coverage.
+
+**Independent Test**: Import a file with a mix of registered and unregistered platforms. Verify warnings are emitted for unregistered ones and all tracks are present in the output.
+
+### Tests
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T012 [test] Add integration test: import REP file with registered platforms — no UNREGISTERED_PLATFORM warnings `services/io/tests/test_import_catalog.py`
+- [ ] T013 [P][test] Add integration test: import REP file with unregistered platforms — correct warnings emitted and import succeeds `services/io/tests/test_import_catalog.py`
+- [ ] T014 [P][test] Add integration test: import DPF file with unregistered platforms — correct warnings emitted and import succeeds `services/io/tests/test_import_catalog.py`
+- [ ] T015 [P][test] Add integration test: registry unavailable — REGISTRY_UNAVAILABLE warning emitted, import still succeeds `services/io/tests/test_import_catalog.py`
+
+### Implementation
+
+- [ ] T016 Add registry loading with graceful fallback at the start of `import_legacy_data()` in `services/io/src/debrief_io/import_catalog.py`
+- [ ] T017 Call `_validate_platform_ids()` after each file parse in `import_legacy_data()` `services/io/src/debrief_io/import_catalog.py`
+- [ ] T018 Verify all integration tests pass
+- [ ] T019 Verify all existing import tests still pass (regression check)
+
+**Checkpoint**: Core feature works end-to-end. Import with mixed platforms produces correct warnings. Import never fails due to registry gaps.
+
+---
+
+## Phase 4: User Story 3 — Consolidated Warning Summary (Priority: P2)
+
+**Goal**: Each unregistered platform ID produces at most one warning per source file, regardless of how many track positions reference it.
+
+**Independent Test**: Import a file with many position records for one unregistered platform. Verify exactly one warning is produced.
+
+### Tests
+
+- [ ] T020 [test] Add integration test: file with many positions for one unregistered platform — exactly one warning `services/io/tests/test_import_catalog.py`
+- [ ] T021 [P][test] Add integration test: file with multiple unregistered platforms — exactly one warning per unique ID `services/io/tests/test_import_catalog.py`
+
+### Implementation
+
+> Deduplication is already built into `_validate_platform_ids()` (Phase 2, T010 — uses a `set()` of unique IDs). These tests verify the behaviour at the integration level.
+
+- [ ] T022 Verify deduplication integration tests pass
+
+**Checkpoint**: Warning deduplication verified at both unit and integration levels.
+
+---
+
+## Phase 5: User Story 4 — Warning Includes Source File Context (Priority: P3)
+
+**Goal**: Each unregistered-platform warning identifies the source file, enabling triage in batch imports.
+
+**Independent Test**: Import multiple files in a batch where different files contain different unregistered platforms. Verify each warning references the correct source file.
+
+### Tests
+
+- [ ] T023 [test] Add integration test: batch import with different unregistered platforms in different files — each warning references correct source file `services/io/tests/test_import_catalog.py`
+
+### Implementation
+
+> File attribution is already built into `_validate_platform_ids()` (Phase 2, T010 — `file_rel` parameter populates `ImportWarning.file`). This test verifies the behaviour at the integration level.
+
+- [ ] T024 Verify source file attribution integration test passes
+
+**Checkpoint**: All user stories complete and independently verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Full verification, evidence collection, media content, and PR creation.
+
+### Verification
+
+- [ ] T025 Run `task verify` (lint + typecheck + full test suite) and fix any failures
+- [ ] T026 Verify quickstart.md steps match actual implementation `specs/182-import-platform-warnings/quickstart.md`
+
+### Evidence Collection
+
+- [ ] T027 Capture test results using template (`.specify/templates/evidence/test-summary-template.md`) in `specs/182-import-platform-warnings/evidence/test-summary.md`
+- [ ] T028 Create usage demonstration in `specs/182-import-platform-warnings/evidence/usage-example.md`
+- [ ] T029 [P] Capture sample warning output in `specs/182-import-platform-warnings/evidence/sample-warnings.json`
+
+### Media Content
+
+- [ ] T030 Create shipped blog post in `specs/182-import-platform-warnings/media/shipped-post.md`
+- [ ] T031 [P] Create LinkedIn shipped summary in `specs/182-import-platform-warnings/media/linkedin-shipped.md`
+
+### PR Creation
+
+- [ ] T032 Create PR and publish blog: run /speckit.pr
+
+**Task T032 must run last. It depends on all evidence and media tasks being complete.**
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundation (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1+US2 (Phase 3)**: Depends on Phase 2 — core feature implementation
+- **US3 (Phase 4)**: Depends on Phase 2 — can run in parallel with Phase 3
+- **US4 (Phase 5)**: Depends on Phase 2 — can run in parallel with Phase 3 and 4
+- **Polish (Phase 6)**: Depends on Phases 3, 4, and 5 all complete
+
+### User Story Dependencies
+
+- **US1+US2 (P1)**: Depend on Foundation (Phase 2). No dependencies on other stories.
+- **US3 (P2)**: Depends on Foundation (Phase 2). Can run in parallel with US1+US2 since it tests the same validation function from a different angle.
+- **US4 (P3)**: Depends on Foundation (Phase 2). Can run in parallel with US1+US2 and US3.
+
+### Within Each Phase
+
+- Tests MUST be written and FAIL before implementation
+- Implementation validates against those tests
+- Phase complete when all tests pass
+
+### Parallel Opportunities
+
+- T004–T009 (unit tests) can all run in parallel
+- T012–T015 (integration tests for US1+US2) can run in parallel
+- T020–T021 (deduplication tests for US3) can run in parallel
+- Phases 3, 4, and 5 can run in parallel after Phase 2 completes
+- T029, T031 can run in parallel with other evidence/media tasks
+
+---
+
+## Parallel Example: Foundation Phase
+
+```bash
+# Launch all unit tests in parallel:
+Task: T004 "Test: all registered platforms produce no warnings"
+Task: T005 "Test: unregistered platform produces warning"
+Task: T006 "Test: empty/whitespace IDs skipped"
+Task: T007 "Test: duplicate IDs produce one warning"
+Task: T008 "Test: case-sensitive lookup"
+Task: T009 "Test: features without platform_id skipped"
+
+# Then implement (sequential):
+Task: T010 "Implement _validate_platform_ids()"
+Task: T011 "Verify all unit tests pass"
+```
+
+---
+
+## Implementation Strategy
+
+### Incremental Delivery
+
+1. **Phase 1**: Add dependency → ready to import registry
+2. **Phase 2**: Write unit tests (they fail) → implement validation function → tests pass
+3. **Phase 3**: Write integration tests (they fail) → wire into import pipeline → tests pass
+4. **Phase 4**: Write deduplication integration tests → verify they pass (no new code expected)
+5. **Phase 5**: Write file attribution integration test → verify it passes (no new code expected)
+6. **Phase 6**: Full verification, evidence, media, PR
+
+### Key Insight
+
+The core implementation is compact: one function (~20 lines) + one integration point (~10 lines). The bulk of the work is in testing — 7 unit tests + 6 integration tests verify all user stories, edge cases, and acceptance criteria. Phases 4 and 5 are verification-only phases: the deduplication and file attribution behaviours are already built into the validation function (Phase 2), and these phases confirm they work correctly through the full pipeline.
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent concerns, no dependencies
+- Each user story is independently testable via its integration tests
+- The validation function handles all edge cases (empty IDs, deduplication, case sensitivity) — unit tests verify each in isolation
+- Registry loading with graceful fallback is the only code that modifies `import_legacy_data()` beyond calling the validation function
+- Evidence is required — capture artifacts that prove the feature works
+- Run `/speckit.pr` after all tasks complete to create PR with evidence


### PR DESCRIPTION
## Summary

- Specification, implementation plan, and task breakdown for feature #182: import handler warnings for unregistered platforms
- After importing legacy data files (REP/DPF), the system checks extracted `platform_id` values against the platform registry (#180) and emits advisory `UNREGISTERED_PLATFORM` warnings — import always succeeds
- Part of E10 (NL-Assisted Catalog Discovery), connecting the registry to the point where new data enters the system

## Artifacts

| Document | Purpose |
|----------|---------|
| `spec.md` | Feature specification with 4 user stories, 9 FRs, 6 success criteria |
| `plan.md` | Technical context, constitution check (all PASS), project structure |
| `research.md` | 7 design decisions: validation insertion point, dependency, registry loading, function design, deduplication, warning codes, test strategy |
| `data-model.md` | Existing entities + new warning codes (`UNREGISTERED_PLATFORM`, `REGISTRY_UNAVAILABLE`) |
| `contracts/validate-platforms.md` | `_validate_platform_ids()` function contract |
| `quickstart.md` | 6-step TDD implementation guide |
| `tasks.md` | 32 tasks across 6 phases |
| `media/planning-post.md` | Blog post for debrief.github.io |
| `media/linkedin-planning.md` | LinkedIn summary |

## Key design decisions

- Single validation point in `import_legacy_data()` after each file parse — covers all formats
- New dependency: `debrief-data` (in-repo workspace member)
- Deduplicated warnings: one per unregistered platform per source file
- Graceful registry fallback: import succeeds with advisory warning when registry unavailable

## Test plan

- [ ] Spec quality checklist passes (all items checked)
- [ ] Constitution check passes pre- and post-design
- [ ] 32 tasks cover all 4 user stories with unit + integration tests planned

https://claude.ai/code/session_017wNiHPbwoY3BsSMu6wSPjT