### PR TITLE
Disable automatic task implementation handoff

### DIFF
--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -4,7 +4,7 @@ handoffs:
   - label: Implement Tasks
     agent: speckit.implement
     prompt: Execute the generated task plan
-    send: true
+    send: false
 ---
 
 ## User Input


### PR DESCRIPTION
## Summary
Disabled the automatic handoff to the task implementation agent by setting the `send` flag to `false` in the speckit tasks configuration.

## Changes
- Modified `.claude/commands/speckit.tasks.md` to set `send: false` for the "Implement Tasks" handoff
  - This prevents automatic execution of generated task plans
  - Tasks will now require manual triggering instead of being automatically sent to the implementation agent

## Details
This change gives users more control over task execution by requiring explicit action to proceed with implementation, rather than automatically sending tasks to the implementation agent.

https://claude.ai/code/session_018P5ddjVrAmEFNDQSQRA7e2