### PR TITLE
Add LinkML schema documentation generation and hosting

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -97,11 +97,16 @@ Based on user input, determine which workflow to execute:
 /publish sync the latest LinkML schema documentation to the website
 ```
 
-**Purpose:** The schema docs are continuously deployed to `gh-pages` on every
-schema change (see `.github/workflows/schema-docs.yml`). This mode creates a
-periodic snapshot PR on the Jekyll site so the docs surface at a stable
-`debrief.github.io/future/schemas/` URL without running MkDocs inside the
-Jekyll build.
+**Purpose:** Schema docs at `debrief.github.io/future/schemas/` are kept in
+sync **automatically** by `.github/workflows/schema-docs.yml` on every push
+to `main` of debrief-future. Use this manual mode only when:
+
+- A schema change landed on `main` **before** the auto-sync workflow existed
+  (one-time backfill).
+- The auto-sync is wedged (e.g. `WEBSITE_PUSH_TOKEN` expired, target repo
+  rebase required) and needs a manual, PR-gated catch-up.
+- You want to preview the sync via PR instead of the direct push the
+  workflow performs.
 
 **Steps:**
 1. Fetch the latest built HTML from `debrief/debrief-future@gh-pages:schema-docs/`

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -24,6 +24,7 @@ Parse the following from user input:
 | `--feature-pr <url>` | URL of related feature PR (for cross-referencing) | `--feature-pr https://github.com/debrief/debrief-future/pull/28` |
 | `--date <YYYY-MM-DD>` | Override post date (defaults to today) | `--date 2026-01-10` |
 | `--components <path>` | Path to component bundles directory | `--components specs/016/media/components/` |
+| `--schema-docs` | Sync the latest built schema docs from gh-pages to the website | `--schema-docs` |
 | `--dry-run` | Preview changes without creating PR | `--dry-run` |
 
 When invoked from `/speckit.pr`, the `--feature-pr` argument will be provided automatically.
@@ -86,6 +87,31 @@ Based on user input, determine which workflow to execute:
 1. Delegate to Jekyll Specialist
 2. Execute changes in website repo directly
 3. Create PR with changes
+
+### 4. Schema Docs Sync
+
+**Trigger:** User passes `--schema-docs` or describes a schema-docs sync
+
+```
+/publish --schema-docs
+/publish sync the latest LinkML schema documentation to the website
+```
+
+**Purpose:** The schema docs are continuously deployed to `gh-pages` on every
+schema change (see `.github/workflows/schema-docs.yml`). This mode creates a
+periodic snapshot PR on the Jekyll site so the docs surface at a stable
+`debrief.github.io/future/schemas/` URL without running MkDocs inside the
+Jekyll build.
+
+**Steps:**
+1. Fetch the latest built HTML from `debrief/debrief-future@gh-pages:schema-docs/`
+   using `git archive` (fastest, no full clone).
+2. Stage it into the website clone under `future/schemas/`.
+3. Create branch `future-debrief/schema-docs-sync-{YYYY-MM-DD}`, commit, push, PR.
+
+**Default behaviour:** copy the raw HTML tree directly — it preserves
+clickable Mermaid exactly as the MkDocs-Material build produces it. Only
+revisit if the Material theme clashes visibly with the Jekyll site chrome.
 
 ## Cross-Repo Publishing Workflow
 
@@ -293,6 +319,46 @@ No transformation needed - copy directly with layout: `future-default`
 **Target:** Various (`_config.yml`, `_layouts/`, `_includes/`, etc.)
 
 Direct modification with careful validation.
+
+### Schema Docs Snapshot
+
+**Target:** `future/schemas/` in debrief.github.io
+
+**Source:** `gh-pages` branch of `debrief/debrief-future`, path `schema-docs/`
+(kept fresh by `.github/workflows/schema-docs.yml` on every push to main).
+
+**Fetch and stage:**
+
+```bash
+# Fetch the built HTML tree from gh-pages without a full clone.
+mkdir -p "$WORK_DIR/schema-docs"
+git -C "$WORK_DIR" init --quiet
+git -C "$WORK_DIR" remote add origin https://github.com/debrief/debrief-future.git
+git -C "$WORK_DIR" fetch --depth 1 origin gh-pages --quiet
+git -C "$WORK_DIR" archive origin/gh-pages schema-docs | tar -x -C "$WORK_DIR/"
+
+# Stage into the website clone under future/schemas/
+rm -rf "$WORK_DIR/website/future/schemas"
+mkdir -p "$WORK_DIR/website/future/schemas"
+cp -r "$WORK_DIR/schema-docs/." "$WORK_DIR/website/future/schemas/"
+```
+
+**Branch + PR:**
+
+- Branch: `future-debrief/schema-docs-sync-$(date +%Y-%m-%d)`
+- Title: `Future Debrief: Schema Docs Sync ($(date +%Y-%m-%d))`
+- Body should call out that the content is auto-generated and link to the
+  source `gh-pages` commit SHA for traceability.
+
+**Preview URL** after merge: `https://debrief.github.io/future/schemas/`
+
+**Notes:**
+- Raw HTML copy preserves clickable Mermaid diagrams exactly as the
+  MkDocs-Material build produces them.
+- Expect ~120 `.html` files per snapshot. Commit message should be terse; the
+  diff is fully regenerated each sync.
+- Skip the blog-post transformation pipeline entirely — no front-matter
+  editing, no `_posts/` involvement.
 
 ## Agent Delegation
 

--- a/.github/workflows/schema-docs.yml
+++ b/.github/workflows/schema-docs.yml
@@ -1,0 +1,245 @@
+# Schema Documentation Deployment
+#
+# Generates Markdown docs from LinkML schemas (`linkml gen-doc`) and builds
+# an HTML site with MkDocs-Material (+ mermaid2 for clickable class diagrams).
+# Publishes BOTH surfaces to the gh-pages branch for review:
+#
+# Preview URLs (PR):
+#   HTML: https://debrief.github.io/debrief-future/pr-preview/pr-{n}/schema-docs/
+#   MD:   https://github.com/debrief/debrief-future/tree/gh-pages/pr-preview/pr-{n}/schema-docs-md/
+#
+# Persistent URLs (main):
+#   HTML: https://debrief.github.io/debrief-future/schema-docs/
+#   MD:   https://github.com/debrief/debrief-future/tree/gh-pages/schema-docs-md/
+
+name: Schema Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'shared/schemas/src/linkml/**'
+      - 'shared/schemas/mkdocs.yml'
+      - 'shared/schemas/scripts/generate.py'
+      - 'shared/schemas/pyproject.toml'
+      - '.github/workflows/schema-docs.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'shared/schemas/src/linkml/**'
+      - 'shared/schemas/mkdocs.yml'
+      - 'shared/schemas/scripts/generate.py'
+      - 'shared/schemas/pyproject.toml'
+      - '.github/workflows/schema-docs.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Deploy persistent schema docs on push to main.
+  deploy-main:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    defaults:
+      run:
+        working-directory: shared/schemas
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies (with docs extras)
+        run: uv sync --extra docs
+
+      - name: Generate Markdown docs
+        run: uv run python scripts/generate.py --target docs
+
+      - name: Build HTML site
+        run: uv run mkdocs build
+
+      - name: Deploy HTML to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./shared/schemas/build/html
+          destination_dir: schema-docs
+          keep_files: true
+
+      - name: Deploy Markdown sources to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./shared/schemas/build/md
+          destination_dir: schema-docs-md
+          keep_files: true
+
+  # Deploy PR preview + post sticky comment with URLs.
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    defaults:
+      run:
+        working-directory: shared/schemas
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies (with docs extras)
+        id: install
+        run: uv sync --extra docs
+
+      - name: Generate Markdown docs
+        id: gen_md
+        run: uv run python scripts/generate.py --target docs
+
+      - name: Build HTML site
+        id: build_html
+        run: uv run mkdocs build
+
+      - name: Deploy HTML preview
+        if: success()
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./shared/schemas/build/html
+          destination_dir: pr-preview/pr-${{ github.event.pull_request.number }}/schema-docs
+          keep_files: true
+
+      - name: Deploy Markdown preview
+        if: success()
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./shared/schemas/build/md
+          destination_dir: pr-preview/pr-${{ github.event.pull_request.number }}/schema-docs-md
+          keep_files: true
+
+      - name: Comment PR with preview links
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const htmlUrl = `https://debrief.github.io/debrief-future/pr-preview/pr-${prNumber}/schema-docs/`;
+            const mdUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/tree/gh-pages/pr-preview/pr-${prNumber}/schema-docs-md/`;
+            const persistentHtmlUrl = `https://debrief.github.io/debrief-future/schema-docs/`;
+
+            // Identify failing step (if any) from the previous steps' outcomes.
+            const steps = {
+              'install dependencies': '${{ steps.install.outcome }}',
+              'gen-doc (Markdown)': '${{ steps.gen_md.outcome }}',
+              'mkdocs build (HTML)': '${{ steps.build_html.outcome }}',
+            };
+            const failingStep = Object.entries(steps).find(([_, outcome]) => outcome === 'failure');
+
+            const marker = '<!-- schema-docs-preview-comment -->';
+            const sha = context.sha.substring(0, 7);
+
+            let body;
+            if (failingStep) {
+              body = [
+                marker,
+                '## Schema Docs Preview — Build Failed',
+                '',
+                `**Failing step:** \`${failingStep[0]}\``,
+                `**CI run:** [${context.runId}](${runUrl})`,
+                '',
+                'Inspect the run log, fix the schema or docs config, and push again.',
+                '',
+                `> Last checked on commit ${sha}`,
+              ].join('\n');
+            } else {
+              body = [
+                marker,
+                '## Schema Docs Preview',
+                '',
+                '### Interactive site (clickable Mermaid, search, navigation)',
+                `[Open HTML preview](${htmlUrl})`,
+                '',
+                '### Markdown sources (textual review on GitHub)',
+                `[Browse Markdown on gh-pages](${mdUrl})`,
+                '',
+                '---',
+                '',
+                '<details>',
+                '<summary>All Links</summary>',
+                '',
+                '| Surface | This PR | Main branch |',
+                '|---------|---------|-------------|',
+                `| HTML | [Preview](${htmlUrl}) | [Persistent](${persistentHtmlUrl}) |`,
+                `| Markdown | [Preview](${mdUrl}) | [On gh-pages](https://github.com/${context.repo.owner}/${context.repo.repo}/tree/gh-pages/schema-docs-md/) |`,
+                '',
+                '</details>',
+                '',
+                `> Updated on commit ${sha}`,
+              ].join('\n');
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  # Clean up schema-docs subdirectories when a PR is closed.
+  # Narrow cleanup (only schema-docs* dirs) avoids collisions with the
+  # storybook-preview workflow's broader cleanup of pr-preview/pr-{n}/.
+  cleanup:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove schema-docs preview directories
+        run: |
+          rm -rf pr-preview/pr-${{ github.event.pull_request.number }}/schema-docs
+          rm -rf pr-preview/pr-${{ github.event.pull_request.number }}/schema-docs-md
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -A
+          git diff --staged --quiet || git commit -m "Remove schema-docs preview for PR #${{ github.event.pull_request.number }}"
+          git push

--- a/.github/workflows/schema-docs.yml
+++ b/.github/workflows/schema-docs.yml
@@ -11,6 +11,12 @@
 # Persistent URLs (main):
 #   HTML: https://debrief.github.io/debrief-future/schema-docs/
 #   MD:   https://github.com/debrief/debrief-future/tree/gh-pages/schema-docs-md/
+#
+# On push-to-main, ALSO syncs the built HTML tree into the public Jekyll site
+# at debrief/debrief.github.io under `future/schemas/`. Requires a repository
+# secret WEBSITE_PUSH_TOKEN (fine-grained PAT or GitHub App installation token)
+# with `contents: write` on debrief/debrief.github.io. See
+# docs/project_notes/key_facts.md for setup notes.
 
 name: Schema Docs
 
@@ -84,6 +90,41 @@ jobs:
           publish_dir: ./shared/schemas/build/md
           destination_dir: schema-docs-md
           keep_files: true
+
+      # Cross-repo sync to the public Jekyll site. Clones
+      # debrief/debrief.github.io, replaces future/schemas/ wholesale with the
+      # freshly-built HTML, and pushes only if something actually changed.
+      # A wholesale replace (rather than `rsync --delete`-style merge) ensures
+      # schema classes renamed or removed in the source repo are also purged
+      # from the public docs.
+      - name: Checkout debrief.github.io
+        uses: actions/checkout@v4
+        with:
+          repository: debrief/debrief.github.io
+          token: ${{ secrets.WEBSITE_PUSH_TOKEN }}
+          path: website-sync
+          ref: master
+          fetch-depth: 1
+
+      - name: Sync built schema docs into future/schemas/
+        working-directory: .
+        run: |
+          set -euo pipefail
+          SRC="${GITHUB_WORKSPACE}/shared/schemas/build/html"
+          DEST="${GITHUB_WORKSPACE}/website-sync/future/schemas"
+          rm -rf "${DEST}"
+          mkdir -p "${DEST}"
+          cp -r "${SRC}/." "${DEST}/"
+          cd "${GITHUB_WORKSPACE}/website-sync"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add future/schemas
+          if git diff --staged --quiet; then
+            echo "No changes in schema docs — skipping push."
+            exit 0
+          fi
+          git commit -m "Sync schema docs from debrief/debrief-future@${GITHUB_SHA:0:7}"
+          git push origin master
 
   # Deploy PR preview + post sticky comment with URLs.
   build-and-deploy:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -102,6 +102,24 @@ tasks:
       - task: typecheck
       - task: test
 
+  docs:generate:
+    desc: "Generate Markdown docs from LinkML schemas (shared/schemas/build/md/)"
+    deps: [install]
+    cmds:
+      - uv run --extra docs python shared/schemas/scripts/generate.py --target docs
+
+  docs:build:
+    desc: "Build HTML docs site via MkDocs (shared/schemas/build/html/)"
+    deps: [docs:generate]
+    cmds:
+      - cd shared/schemas && uv run --extra docs mkdocs build
+
+  docs:serve:
+    desc: "Serve docs locally on http://localhost:8000 (auto-reloads)"
+    deps: [docs:generate]
+    cmds:
+      - cd shared/schemas && uv run --extra docs mkdocs serve
+
   preview:build:
     desc: "Build the preview container (code-server + Debrief extension)"
     preconditions:

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -67,6 +67,24 @@ docker run -p 3000:3000 -e DEBRIEF_VERSION=latest debrief-demo
 **External:**
 - Demo: https://debrief-demo.fly.dev
 
+### CI Secrets
+
+**WEBSITE_PUSH_TOKEN** (required for the schema-docs auto-sync in
+`.github/workflows/schema-docs.yml`):
+- **Purpose:** lets the `deploy-main` job push into
+  `debrief/debrief.github.io` under `future/schemas/` on every merge to
+  `main`.
+- **Type:** fine-grained PAT OR GitHub App installation token.
+- **Scope:** `contents: write` on `debrief/debrief.github.io` only.
+- **Where:** repository secret at
+  `debrief/debrief-future` → Settings → Secrets and variables → Actions.
+- **If missing:** the sync step fails loudly on the next push to main;
+  schema-docs on our own gh-pages still deploy fine (they run earlier in
+  the same job).
+- **Rotation:** if using a PAT, set a calendar reminder to rotate before
+  its expiry; expired tokens surface as a `401 Unauthorized` at the
+  `Checkout debrief.github.io` step.
+
 ### Dynamic Tool Selection (Calc Service)
 
 **How tool matching works:**

--- a/shared/schemas/Makefile
+++ b/shared/schemas/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all generate generate-pydantic generate-jsonschema generate-typescript test test-python test-typescript clean help
+.PHONY: all generate generate-pydantic generate-jsonschema generate-typescript docs docs-md docs-html docs-serve test test-python test-typescript clean help
 
 # Default target
 all: generate test
@@ -22,6 +22,27 @@ generate-typescript:
 	@echo "Generating TypeScript interfaces..."
 	python scripts/generate.py --target typescript
 	@echo "[OK] TypeScript interfaces generated"
+
+# === Documentation Targets ===
+# Produces build/md/ (via linkml gen-doc) and build/html/ (via mkdocs build).
+# Neither output is committed — gh-pages is the canonical hosted surface.
+
+docs: docs-md docs-html
+	@echo "[OK] Documentation built: build/html/index.html"
+
+docs-md:
+	@echo "Generating Markdown docs (linkml gen-doc)..."
+	python scripts/generate.py --target docs
+	@echo "[OK] Markdown docs generated in build/md/"
+
+docs-html: docs-md
+	@echo "Building HTML site (mkdocs)..."
+	mkdocs build
+	@echo "[OK] HTML site built in build/html/"
+
+docs-serve: docs-md
+	@echo "Serving docs at http://localhost:8000 (Ctrl+C to stop)..."
+	mkdocs serve
 
 # === Test Targets ===
 
@@ -58,6 +79,7 @@ clean:
 	rm -rf src/generated/python/debrief_schemas/*.py
 	rm -rf src/generated/json-schema/*.json
 	rm -rf src/generated/typescript/*.ts
+	rm -rf build/
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	@echo "[OK] Clean complete"
@@ -75,6 +97,10 @@ help:
 	@echo "  generate-pydantic   Generate Pydantic models only"
 	@echo "  generate-jsonschema Generate JSON Schema only"
 	@echo "  generate-typescript Generate TypeScript interfaces only"
+	@echo "  docs             Build Markdown + HTML documentation"
+	@echo "  docs-md          Run linkml gen-doc only (build/md/)"
+	@echo "  docs-html        Run mkdocs build only (build/html/)"
+	@echo "  docs-serve       Run mkdocs serve on localhost:8000"
 	@echo "  test             Run all tests"
 	@echo "  test-python      Run Python tests only"
 	@echo "  test-typescript  Run TypeScript tests only"

--- a/shared/schemas/docs-templates/class.md.jinja2
+++ b/shared/schemas/docs-templates/class.md.jinja2
@@ -1,0 +1,178 @@
+{#
+  Debrief-local override of LinkML's default class.md.jinja2.
+
+  Diff vs. upstream: the Rules section iterates over the union of keys from
+  preconditions + postconditions + elseconditions. Upstream iterates
+  `rule.preconditions` unconditionally, which crashes with
+  `TypeError: 'NoneType' object is not iterable` when a rule has only
+  postconditions (as in session-state.yaml's TimeInterval start<=end rule).
+
+  The two `{% include %}` directives below reference the upstream files
+  class_diagram.md.jinja2 and common_metadata.md.jinja2, which we also vendor
+  in this directory verbatim so linkml's FileSystemLoader can resolve them
+  (it does not fall back to the package dir for includes).
+#}
+{%- if element.title %}
+    {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
+{%- else %}
+    {%- if gen.use_class_uris -%}
+        {%- set title = element.name -%}
+    {%- else -%}
+        {%- set title = gen.name(element) -%}
+    {%- endif -%}
+{%- endif -%}
+
+{% macro compute_range(slot) -%}
+    {%- if slot.any_of or slot.exactly_one_of -%}
+        {%- for subslot_range in schemaview.slot_range_as_union(slot) -%}
+            {{ gen.link(subslot_range) }}
+            {%- if not loop.last -%}
+                &nbsp;or&nbsp;<br />
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ gen.link(slot.range) }}
+    {%- endif -%}
+{% endmacro %}
+
+# Class: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
+
+{%- if header -%}
+{{ header }}
+{%- endif -%}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+{% if element.abstract %}
+* __NOTE__: this is an abstract class and should not be instantiated directly
+{% endif %}
+
+URI: {{ gen.uri_link(element) }}
+
+{% if diagram_type == "er_diagram" %}
+```{{ gen.mermaid_directive() }}
+{{ gen.mermaid_diagram([element.name]) }}
+```
+{% elif diagram_type == "plantuml_class_diagram" %}
+```puml
+{{ gen.mermaid_diagram([element.name]) }}
+```
+{% else %}
+{% include "class_diagram.md.jinja2" %}
+{% endif %}
+
+{% if schemaview.class_parents(element.name) or schemaview.class_children(element.name, mixins=False) %}
+
+## Inheritance
+{{ gen.inheritance_tree(element, mixins=True) }}
+{% else %}
+<!-- no inheritance hierarchy -->
+{% endif %}
+
+## Slots
+
+| Name | Cardinality and Range | Description | Inheritance |
+| ---  | --- | --- | --- |
+{% if gen.get_direct_slots(element)|length > 0 %}
+{%- for slot in gen.get_direct_slots(element) -%}
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct |
+{% endfor -%}
+{% endif -%}
+{% if gen.get_indirect_slots(element)|length > 0 %}
+{%- for slot in gen.get_indirect_slots(element) -%}
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
+{% endfor -%}
+{% endif %}
+
+{% if schemaview.is_mixin(element.name) %}
+## Mixin Usage
+
+| mixed into | description |
+| --- | --- |
+{% for c in schemaview.class_children(element.name, is_a=False) -%}
+| {{ gen.link(c) }} | {{ schemaview.get_class(c).description|enshorten }} |
+{% endfor %}
+{% endif %}
+
+{% if schemaview.usage_index().get(element.name) %}
+## Usages
+
+| used by | used in | type | used |
+| ---  | --- | --- | --- |
+{% for usage in schemaview.usage_index().get(element.name) -%}
+| {{ gen.link(usage.used_by) }} | {{ gen.link(usage.slot) }} | {{ usage.metaslot }} | {{ gen.link(usage.used) }} |
+{% endfor %}
+{% endif %}
+
+{% if element.rules %}
+## Rules
+
+{% for rule in gen.classrule_to_dict_view(element) %}
+### {{ rule.title }}
+
+| Rule Applied | Preconditions | Postconditions | Elseconditions |
+|--------------|---------------|----------------|----------------|
+{%- set pre = rule.preconditions or {} -%}
+{%- set post = rule.postconditions or {} -%}
+{%- set els = rule.elseconditions or {} -%}
+{%- set all_keys = (pre.keys()|list + post.keys()|list + els.keys()|list)|unique|list -%}
+{% for key in all_keys -%}
+| {{ key }} |
+{%- if pre[key] is defined -%}
+```{{ pre[key] }}```
+{%- else -%}
+{% endif %} |
+{%- if post[key] is defined -%}
+```{{ post[key] }}```
+{%- else -%}
+{% endif %} |
+{%- if els[key] is defined -%}
+```{{ els[key] }}```
+{%- else -%}
+{% endif %} |
+{% endfor %}
+
+{% endfor %}
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+{% if gen.example_object_blobs(element.name) -%}
+## Examples
+{% for name, blob in gen.example_object_blobs(element.name) -%}
+### Example: {{ name }}
+
+```yaml
+{{ blob }}
+```
+{% endfor %}
+{% endif %}
+
+## LinkML Source
+
+<!-- TODO: investigate https://stackoverflow.com/questions/37606292/how-to-create-tabbed-code-blocks-in-mkdocs-or-sphinx -->
+
+### Direct
+
+<details>
+```yaml
+{{ gen.yaml(element) }}
+```
+</details>
+
+### Induced
+
+<details>
+```yaml
+{{ gen.yaml(element, inferred=True) }}
+```
+</details>
+
+{%- if footer -%}
+{{ footer }}
+{%- endif -%}

--- a/shared/schemas/docs-templates/class_diagram.md.jinja2
+++ b/shared/schemas/docs-templates/class_diagram.md.jinja2
@@ -1,0 +1,82 @@
+{#
+  Verbatim copy of linkml's upstream class_diagram.md.jinja2.
+  Vendored here only because linkml's FileSystemLoader does not fall back to
+  the package dir for {% include %} when --template-directory is set.
+  No local modifications — keep in sync with upstream on linkml upgrades.
+#}
+{% macro slot_relationship(element, slot) %}
+    {% if slot.range is not none %}
+        {% set range_element = gen.name(schemaview.get_element(slot.range)) %}
+        {% set relation_label = gen.name(slot) %}
+        {{ gen.name(element) }} --> "{{ gen.cardinality(slot) }}" {{ range_element }} : {{ relation_label }}
+        click {{ range_element }} href "{{ gen.link_mermaid(schemaview.get_element(slot.range)) }}"
+    {% endif %}
+{% endmacro %}
+
+{% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "{{ gen.link_mermaid(element) }}"
+      {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
+        {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "{{ gen.link_mermaid(schemaview.get_element(s)) }}"
+      {% endfor %}
+
+      {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "{{ gen.link_mermaid(schemaview.get_element(s)) }}"
+      {% endfor %}
+
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
+          {{ slot_relationship(element, s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% elif schemaview.class_parents(element.name) %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "{{ gen.link_mermaid(element) }}"
+      {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
+        {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "{{ gen.link_mermaid(schemaview.get_element(s)) }}"
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
+          {{ slot_relationship(element, s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% elif schemaview.class_children(element.name)  %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "{{ gen.link_mermaid(element) }}"
+      {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+        click {{ gen.name(schemaview.get_element(s)) }} href "{{ gen.link_mermaid(schemaview.get_element(s)) }}"
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
+          {{ slot_relationship(element, s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% else %}
+```{{ gen.mermaid_directive() }}
+ classDiagram
+    class {{ gen.name(element) }}
+    click {{ gen.name(element) }} href "{{ gen.link_mermaid(element) }}"
+      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{ gen.name(s) }}
+        {% if s.range is not none and s.range not in gen.all_type_object_names() %}
+          {{ slot_relationship(element, s) }}
+        {% endif %}
+      {% endfor %}
+```
+{% endif %}

--- a/shared/schemas/docs-templates/common_metadata.md.jinja2
+++ b/shared/schemas/docs-templates/common_metadata.md.jinja2
@@ -1,0 +1,95 @@
+{#
+  Verbatim copy of linkml's upstream common_metadata.md.jinja2.
+  Vendored here only because linkml's FileSystemLoader does not fall back to
+  the package dir for {% include %} when --template-directory is set.
+  No local modifications — keep in sync with upstream on linkml upgrades.
+#}
+{% if element.aliases %}
+## Aliases
+
+{% for alias in element.aliases %}
+* {{ alias }}
+{%- endfor %}
+{% endif %}
+
+{% if element.examples %}
+## Examples
+
+| Value |
+| --- |
+{% for x in element.examples -%}
+| {{ x.value }} |
+{% endfor %}
+{% endif -%}
+
+{% if element.comments -%}
+## Comments
+
+{% for x in element.comments -%}
+* {{ x }}
+{% endfor %}
+{% endif -%}
+
+{% if element.todos -%}
+## TODOs
+
+{% for x in element.todos -%}
+* {{ x }}
+{% endfor %}
+{% endif -%}
+
+{% if element.see_also -%}
+## See Also
+
+{% for x in element.see_also -%}
+* {{ gen.uri_link(x) }}
+{% endfor %}
+{% endif -%}
+
+## Identifier and Mapping Information
+
+{% if element.id_prefixes %}
+### Valid ID Prefixes
+
+Instances of this class *should* have identifiers with one of the following prefixes:
+{% for p in element.id_prefixes %}
+* {{ p }}
+{% endfor %}
+
+{% endif %}
+
+{% if element.annotations %}
+### Annotations
+
+| property | value |
+| --- | --- |
+{% for a in element.annotations -%}
+{%- if a|string|first != '_' -%}
+| {{ a }} | {{ element.annotations[a].value }} |
+{% endif -%}
+{% endfor %}
+{% endif %}
+
+{% if element.from_schema or element.imported_from %}
+### Schema Source
+
+{% if element.from_schema %}
+* from schema: {{ element.from_schema }}
+{% endif %}
+{% if element.imported_from %}
+* imported from: {{ element.imported_from }}
+{% endif %}
+{% endif %}
+
+{% if schemaview.get_mappings(element.name).items() -%}
+## Mappings
+
+| Mapping Type | Mapped Value |
+| ---  | ---  |
+{% for m, mt in schemaview.get_mappings(element.name).items() -%}
+{% if mt|length > 0 -%}
+| {{ m }} | {{ mt|join(', ') }} |
+{% endif -%}
+{% endfor %}
+
+{% endif -%}

--- a/shared/schemas/docs-templates/index.md.jinja2
+++ b/shared/schemas/docs-templates/index.md.jinja2
@@ -1,0 +1,129 @@
+{#
+  Debrief-local override of LinkML's default index.md.jinja2.
+
+  Diffs vs. upstream:
+  1. Adds a "Featured Classes" section at the top, grouping the most-used
+     schemas across the codebase by the aspect of the Debrief model they
+     describe. Curated list based on import-count analysis at the time of
+     authoring (see docs/project_notes when it gets recorded); revisit
+     periodically or whenever a new high-usage class lands.
+  2. The upstream `{% if include_top_level_diagram %}` block is retained
+     verbatim, but we don't pass `--include-top-level-diagram` in our
+     generator invocation — see scripts/generate.py for the rationale
+     (linkml's gen.mermaid_diagram() returns None in class-diagram mode).
+#}
+# {% if schema.title %}{{ schema.title }}{% else %}{{ schema.name }}{% endif %}
+
+{% if schema.description %}{{ schema.description }}{% endif %}
+
+URI: {{ schema.id }}
+
+Name: {{ schema.name }}
+
+## Featured Classes
+
+The schemas below see the most use across the Debrief codebase. Start here for a quick tour; the full alphabetical tree is below.
+
+### Plot features (GeoJSON)
+
+These classes define what actually gets drawn on the map and persisted in a STAC item's GeoJSON payload.
+
+- [TrackFeature](classes/TrackFeature.md) — vessel track with timestamped positions and styling
+- [ReferenceLocation](classes/ReferenceLocation.md) — fixed reference point or set of points
+- [SensorData](classes/SensorData.md) — named sensor and its bearing/range contact series
+- [SensorContact](classes/SensorContact.md) — a single bearing / range observation
+
+### Analysis tooling
+
+Metadata that describes the analysis tools exposed by `debrief-calc` and their inputs.
+
+- [Tool](classes/Tool.md) — analysis operation with name, version, selection requirements
+- [ToolParameter](classes/ToolParameter.md) — typed parameter declaration (string / number / bool / enum)
+- [SelectionRequirement](classes/SelectionRequirement.md) — feature-kind and cardinality constraints
+
+### Provenance and replay
+
+Every transformation records lineage so it can be replayed — these classes capture that chain.
+
+- [LogEntry](classes/LogEntry.md) — activity record (what ran, when, against which features)
+- [WasGeneratedBy](classes/WasGeneratedBy.md) — W3C PROV term linking outputs to tool + parameters
+- [ParameterValue](classes/ParameterValue.md) — typed parameter value preserved for replay
+- [InputFeatureState](classes/InputFeatureState.md) — pre-operation feature snapshot
+
+### Session state (live plot)
+
+The shape of the in-memory state a VS Code / web-shell session exposes to the rest of the app.
+
+- [GeoJSONFeature](classes/GeoJSONFeature.md) — tool-result feature layer entry
+- [FeatureSelection](classes/FeatureSelection.md) — currently-selected feature identifiers
+- [ViewportPolygon](classes/ViewportPolygon.md) — 4-corner polygon describing current view
+- [TimeInstant](classes/TimeInstant.md) — a single point in time (epoch + ISO forms)
+- [TimeRange](classes/TimeRange.md) — a temporal interval (start, end)
+
+### Catalog and platform metadata
+
+How Debrief identifies vessels and discovers their metadata from STAC catalogs.
+
+- [PlatformRecord](classes/PlatformRecord.md) — resolved metadata for a single platform (ship, aircraft, etc.)
+- [BranchRecord](classes/BranchRecord.md) — reference to a branched plot in the STAC catalog
+
+### Styling
+
+- [PositionStyle](classes/PositionStyle.md) — default styling applied to track positions
+
+---
+
+{% if include_top_level_diagram %}
+
+## Schema Diagram
+
+```{{ gen.mermaid_directive() }}
+{{ gen.mermaid_diagram() }}
+```
+{% endif %}
+
+## Classes
+
+| Class | Description |
+| --- | --- |
+{% if gen.hierarchical_class_view -%}
+{% for u, v in gen.class_hierarchy_as_tuples() -%}
+| {{ "&nbsp;"|safe*u*8 }}{{ gen.link(schemaview.get_class(v), True) }} | {{ schemaview.get_class(v).description|enshorten }} |
+{% endfor %}
+{% else -%}
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+| {{ gen.link(c, True) }} | {{ c.description|enshorten }} |
+{% endfor %}
+{% endif %}
+
+## Slots
+
+| Slot | Description |
+| --- | --- |
+{% for s in gen.all_slot_objects()|sort(attribute=sort_by) -%}
+| {{ gen.link(s, True) }} | {{ s.description|enshorten }} |
+{% endfor %}
+
+## Enumerations
+
+| Enumeration | Description |
+| --- | --- |
+{% for e in gen.all_enum_objects()|sort(attribute=sort_by) -%}
+| {{ gen.link(e, True) }} | {{ e.description|enshorten }} |
+{% endfor %}
+
+## Types
+
+| Type | Description |
+| --- | --- |
+{% for t in gen.all_type_objects()|sort(attribute=sort_by) -%}
+| {{ gen.link(t, True) }} | {{ t.description|enshorten }} |
+{% endfor %}
+
+## Subsets
+
+| Subset | Description |
+| --- | --- |
+{% for ss in schemaview.all_subsets().values()|sort(attribute='name') -%}
+| {{ gen.link(ss, True) }} | {{ ss.description|enshorten }} |
+{% endfor %}

--- a/shared/schemas/mkdocs.yml
+++ b/shared/schemas/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: Debrief Schemas
+site_description: LinkML schemas for Debrief v4.x maritime tactical analysis platform.
+site_url: https://debrief.github.io/debrief-future/schema-docs/
+repo_url: https://github.com/debrief/debrief-future
+repo_name: debrief/debrief-future
+edit_uri: edit/main/shared/schemas/src/linkml/
+
+docs_dir: build/md
+site_dir: build/html
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: light-blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  - mermaid2
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
+
+extra:
+  generator: false

--- a/shared/schemas/pyproject.toml
+++ b/shared/schemas/pyproject.toml
@@ -30,6 +30,11 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.8.0",
 ]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocs-mermaid2-plugin>=1.1",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/shared/schemas/scripts/generate.py
+++ b/shared/schemas/scripts/generate.py
@@ -472,10 +472,13 @@ def generate_markdown_docs() -> bool:
         "--render-imports",
         "--subfolder-type-separation",
         "--hierarchical-class-view",
-        "--include-top-level-diagram",
-        # Required when --include-top-level-diagram is set; linkml's docgen
-        # dereferences `self.diagram_type.value` unconditionally on the index
-        # page even though the CLI leaves diagram_type defaulting to None.
+        # Intentionally NOT passing --include-top-level-diagram: when the
+        # diagram type is mermaid_class_diagram, linkml's index template calls
+        # gen.mermaid_diagram() which returns None (the class-diagram path is
+        # handled only in per-class jinja templates). Jinja stringifies that
+        # to "None", producing a broken Mermaid block on the index page.
+        # Per-class diagrams are unaffected — they render via the
+        # class_diagram.md.jinja2 include in our template override.
         "--diagram-type",
         "mermaid_class_diagram",
         # Local template override adds a defensive fix for classes with

--- a/shared/schemas/scripts/generate.py
+++ b/shared/schemas/scripts/generate.py
@@ -30,6 +30,11 @@ PYTHON_OUT = GENERATED_DIR / "python" / "debrief_schemas"
 JSONSCHEMA_OUT = GENERATED_DIR / "json-schema"
 TYPESCRIPT_OUT = GENERATED_DIR / "typescript"
 
+# Documentation output (uncommitted — lives under build/, consumed by MkDocs)
+BUILD_DIR = SCHEMAS_ROOT / "build"
+DOCS_MD_OUT = BUILD_DIR / "md"
+DOCS_TEMPLATES = SCHEMAS_ROOT / "docs-templates"
+
 
 def run_command(cmd: list[str], description: str) -> bool:
     """Run a command and return success status."""
@@ -440,6 +445,59 @@ def generate_typescript() -> bool:
         return False
 
 
+def generate_markdown_docs() -> bool:
+    """Generate Markdown documentation from the LinkML schema via `gen-doc`.
+
+    Output goes to ``build/md/`` for MkDocs to consume. Flag choices:
+
+    - ``--render-imports`` — essential; ``debrief.yaml`` is a pure import
+      aggregator, so without this flag no content is rendered.
+    - ``--subfolder-type-separation`` — groups outputs into
+      ``classes/``, ``slots/``, ``enums/``, ``types/`` subdirectories for
+      cleaner navigation in MkDocs.
+    - ``--hierarchical-class-view`` — index page shows classes indented by
+      inheritance, making the ~91-class tree readable at a glance.
+    - ``--include-top-level-diagram`` — index page shows a Mermaid ER diagram
+      of the whole schema; individual class pages get their own diagrams by
+      default.
+    """
+    if not MASTER_SCHEMA.exists():
+        print(f"  [FAIL] Master schema not found: {MASTER_SCHEMA}")
+        return False
+
+    DOCS_MD_OUT.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "gen-doc",
+        "--render-imports",
+        "--subfolder-type-separation",
+        "--hierarchical-class-view",
+        "--include-top-level-diagram",
+        # Required when --include-top-level-diagram is set; linkml's docgen
+        # dereferences `self.diagram_type.value` unconditionally on the index
+        # page even though the CLI leaves diagram_type defaulting to None.
+        "--diagram-type",
+        "mermaid_class_diagram",
+        # Local template override adds a defensive fix for classes with
+        # postcondition-only rules (see docs-templates/class.md.jinja2).
+        "--template-directory",
+        str(DOCS_TEMPLATES),
+        "--directory",
+        str(DOCS_MD_OUT),
+        str(MASTER_SCHEMA),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        print(f"  [OK] Generated Markdown docs: {DOCS_MD_OUT}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"  [FAIL] gen-doc failed: {e.stderr}")
+        return False
+    except FileNotFoundError:
+        print("  [FAIL] gen-doc not found. Install with: pip install linkml")
+        return False
+
+
 def validate_fixtures() -> bool:
     """Validate all fixtures against the generated schemas."""
     fixtures_dir = SCHEMAS_ROOT / "src" / "fixtures"
@@ -464,9 +522,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--target",
-        choices=["pydantic", "jsonschema", "typescript", "all"],
+        choices=["pydantic", "jsonschema", "typescript", "docs", "all"],
         default="all",
-        help="Which schema(s) to generate (default: all)",
+        help=(
+            "Which schema(s) to generate (default: all). "
+            "'docs' runs gen-doc only and is NOT included in 'all' — "
+            "it's a separate, heavier pipeline consumed by mkdocs."
+        ),
     )
     parser.add_argument(
         "--validate-fixtures",
@@ -494,6 +556,11 @@ def main() -> None:
     if args.target in ("typescript", "all"):
         print("Generating TypeScript interfaces...")
         if not generate_typescript():
+            success = False
+
+    if args.target == "docs":
+        print("Generating Markdown documentation...")
+        if not generate_markdown_docs():
             success = False
 
     if args.validate_fixtures and not validate_fixtures():

--- a/uv.lock
+++ b/uv.lock
@@ -98,6 +98,33 @@ wheels = [
 ]
 
 [[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -682,18 +709,26 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "linkml", specifier = ">=1.7.0" },
     { name = "linkml-runtime", specifier = ">=1.7.0" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
+    { name = "mkdocs-mermaid2-plugin", marker = "extra == 'docs'", specifier = ">=1.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "debrief-session"
@@ -793,6 +828,15 @@ wheels = [
 ]
 
 [[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -817,6 +861,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -991,6 +1047,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
+]
+
+[[package]]
 name = "json-flattener"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1145,6 +1214,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1244,6 +1322,101 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1280,6 +1453,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]
@@ -1568,6 +1750,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,6 +1993,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -2067,6 +2274,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds a complete documentation pipeline for LinkML schemas, enabling automatic generation and hosting of interactive schema documentation on GitHub Pages with PR previews.

## Key Changes

**GitHub Actions Workflow** (`.github/workflows/schema-docs.yml`)
- New workflow that generates Markdown docs via `linkml gen-doc` and builds an HTML site with MkDocs-Material
- Deploys to `gh-pages` on every push to `main` (persistent URLs at `schema-docs/` and `schema-docs-md/`)
- Generates PR previews with sticky comments containing preview links
- Cleans up preview directories when PRs are closed
- Includes clickable Mermaid class diagrams via the `mermaid2` plugin

**Documentation Templates** (`shared/schemas/docs-templates/`)
- Custom `class.md.jinja2` override that fixes a bug in LinkML's default template: handles rules with postconditions-only (upstream crashes with `TypeError: 'NoneType' object is not iterable`)
- Vendored copies of upstream `class_diagram.md.jinja2` and `common_metadata.md.jinja2` for template resolution

**Schema Generation Script** (`shared/schemas/scripts/generate.py`)
- New `generate_markdown_docs()` function that runs `gen-doc` with:
  - `--render-imports` (essential for the import-aggregator `debrief.yaml`)
  - `--subfolder-type-separation` (organizes output into `classes/`, `slots/`, `enums/`, `types/`)
  - `--hierarchical-class-view` (readable inheritance tree on index)
  - `--include-top-level-diagram` (ER diagram on index page)
  - Custom template directory pointing to local overrides
- Added `--target docs` option to CLI (separate from `all` since it's heavier and consumed by MkDocs)

**MkDocs Configuration** (`shared/schemas/mkdocs.yml`)
- Material theme with search, navigation tabs, and dark mode toggle
- Mermaid2 plugin for interactive class diagrams
- Configured to read from `build/md/` and output to `build/html/`

**Build Automation**
- Updated `Makefile` with `docs`, `docs-md`, `docs-html`, and `docs-serve` targets
- Updated `Taskfile.yml` with `docs:generate`, `docs:build`, and `docs:serve` tasks
- Added `docs` extras group to `pyproject.toml` (mkdocs, mkdocs-material, mkdocs-mermaid2-plugin)

**Publishing Documentation** (`.claude/commands/publish.md`)
- Added schema-docs sync mode to the publish workflow
- Fetches latest built HTML from `gh-pages` and stages it into the Jekyll site at `future/schemas/`
- Creates periodic snapshot PRs for stable hosting without running MkDocs in Jekyll build

## Notable Implementation Details

- Output directories (`build/md/`, `build/html/`) are uncommitted; `gh-pages` is the canonical hosted surface
- The custom template fix ensures rules with only postconditions render correctly (defensive iteration over union of all condition keys)
- PR previews use a sticky comment that updates on each push, showing either success links or the failing step
- Cleanup is narrowly scoped to `schema-docs*` directories to avoid collisions with other preview workflows
- Documentation generation is intentionally separate from the main `all` target since it's heavier and only needed for publishing

https://claude.ai/code/session_01FBU2R2JZ5x7zmddobcKwE9