### PR TITLE
fix(spec-navigator): PAT-save re-fetch + raw-fetch CORS

### DIFF
--- a/apps/spec-navigator/src/github/__tests__/api.test.ts
+++ b/apps/spec-navigator/src/github/__tests__/api.test.ts
@@ -3,6 +3,7 @@ import {
   fetchPullRequest,
   fetchChangedFiles,
   fetchContentsListing,
+  fetchRawText,
   createIssueComment,
   ApiError,
 } from '../api';
@@ -130,5 +131,23 @@ describe('github/api error mapping (T084)', () => {
     await expect(
       fetchContentsListing('specs/191-spec-navigator', 'a'.repeat(40)),
     ).rejects.toMatchObject({ kind: 'pr-not-found' });
+  });
+
+  it('fetchRawText does NOT send Authorization to raw.githubusercontent.com', async () => {
+    // raw.githubusercontent.com rejects the CORS preflight when the
+    // request carries an Authorization header. Public repos resolve
+    // without it; private-repo support is via the Contents API instead.
+    const spy = vi.fn(async () => new Response('hello', { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+    const text = await fetchRawText('specs/191-spec-navigator/spec.md', 'a'.repeat(40));
+    expect(text).toBe('hello');
+    const [url, init] = spy.mock.calls[0];
+    expect(String(url)).toContain('raw.githubusercontent.com');
+    const headers = init?.headers as Headers;
+    expect(headers.has('Authorization')).toBe(false);
+    // The PAT must not appear in any header value either.
+    for (const [, value] of headers.entries()) {
+      expect(value).not.toContain(SECRET_PAT);
+    }
   });
 });

--- a/apps/spec-navigator/src/github/__tests__/auth.test.ts
+++ b/apps/spec-navigator/src/github/__tests__/auth.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getPat, setPat, clearPat, hasPat, _resetCacheForTests } from '../auth';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getPat,
+  setPat,
+  clearPat,
+  hasPat,
+  subscribePat,
+  _resetCacheForTests,
+} from '../auth';
 
 describe('auth PAT storage', () => {
   beforeEach(() => {
@@ -41,5 +48,19 @@ describe('auth PAT storage', () => {
       const msg = e instanceof Error ? e.message : String(e);
       expect(msg).not.toContain('pat-that-should-not-leak');
     }
+  });
+
+  it('subscribePat fires on setPat and clearPat; unsubscribe stops delivery', () => {
+    const listener = vi.fn();
+    const unsub = subscribePat(listener);
+    setPat('first-pat');
+    expect(listener).toHaveBeenCalledTimes(1);
+    setPat('second-pat');
+    expect(listener).toHaveBeenCalledTimes(2);
+    clearPat();
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsub();
+    setPat('after-unsubscribe');
+    expect(listener).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/spec-navigator/src/github/api.ts
+++ b/apps/spec-navigator/src/github/api.ts
@@ -153,6 +153,18 @@ export async function fetchChangedFiles(
   return res.map((f) => f.filename);
 }
 
+/**
+ * Headers for raw.githubusercontent.com. We intentionally do NOT send
+ * Authorization here: raw.githubusercontent.com answers the CORS
+ * preflight for a plain GET but refuses one with the Authorization
+ * header, so sending the PAT actively breaks the fetch. The repo is
+ * public, so unauthenticated GETs resolve. Private-repo support would
+ * require routing through the Contents API (base64-encoded bodies).
+ */
+function rawHeaders(): Headers {
+  return new Headers({ Accept: 'text/plain, */*' });
+}
+
 export async function fetchRawText(
   path: string,
   sha: string,
@@ -166,7 +178,7 @@ export async function fetchRawText(
     .join('/')}`;
   let response: Response;
   try {
-    response = await fetch(url, { headers: authHeaders() });
+    response = await fetch(url, { headers: rawHeaders() });
   } catch {
     throw new ApiError('network', errorMessage('network'));
   }
@@ -190,7 +202,7 @@ export async function fetchRawBlob(
     .join('/')}`;
   let response: Response;
   try {
-    response = await fetch(url, { headers: authHeaders() });
+    response = await fetch(url, { headers: rawHeaders() });
   } catch {
     throw new ApiError('network', errorMessage('network'));
   }

--- a/apps/spec-navigator/src/github/auth.ts
+++ b/apps/spec-navigator/src/github/auth.ts
@@ -9,6 +9,26 @@ const KEY = 'spec-navigator:github-pat';
 
 let cached: Credential | null | undefined = undefined;
 
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+/**
+ * Subscribe to PAT changes (set/clear) within this tab. Returns an
+ * unsubscribe function. Storage events across tabs are not proxied here —
+ * if needed, a future callsite can bridge `window.addEventListener('storage', …)`
+ * to `notify()`.
+ */
+export function subscribePat(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
 function readStorage(): Credential | null {
   if (cached !== undefined) return cached;
   try {
@@ -51,11 +71,13 @@ export function setPat(pat: string): void {
   const cred: Credential = { pat: pat.trim(), savedAt: new Date().toISOString() };
   localStorage.setItem(KEY, JSON.stringify(cred));
   cached = cred;
+  notify();
 }
 
 export function clearPat(): void {
   localStorage.removeItem(KEY);
   cached = null;
+  notify();
 }
 
 /**

--- a/apps/spec-navigator/src/state/__tests__/useFeature.test.ts
+++ b/apps/spec-navigator/src/state/__tests__/useFeature.test.ts
@@ -78,6 +78,58 @@ describe('useFeature', () => {
     expect(result.current.error).toContain('Not authenticated');
   });
 
+  it('re-fetches after setPat clears the notAuthenticated error', async () => {
+    clearPat();
+    _resetCacheForTests();
+    mockFetchByUrl((url) => {
+      if (url.endsWith('/pulls/42')) {
+        return {
+          status: 200,
+          body: {
+            number: 42,
+            state: 'open',
+            title: 't',
+            head: { sha: SHA, ref: 'feat' },
+          },
+        };
+      }
+      if (url.includes('/pulls/42/files')) {
+        return {
+          status: 200,
+          body: [
+            { filename: 'specs/191-spec-navigator/spec.md', status: 'modified' },
+          ],
+        };
+      }
+      if (url.includes('/contents/specs/191-spec-navigator?ref=')) {
+        return {
+          status: 200,
+          body: [
+            {
+              name: 'spec.md',
+              path: 'specs/191-spec-navigator/spec.md',
+              type: 'file',
+              size: 100,
+              download_url: 'https://raw.githubusercontent.com/x/y/z/spec.md',
+            },
+          ],
+        };
+      }
+      return null;
+    });
+    const { result } = renderHook(() => useFeature(42));
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+    // User saves a PAT — effect must re-run and clear the error.
+    setPat('late-arrival-pat');
+    await waitFor(() => {
+      expect(result.current.scope).not.toBeNull();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.artefacts.length).toBe(1);
+  });
+
   it('resolves scope + artefacts for a PR that touches a feature folder', async () => {
     mockFetchByUrl((url) => {
       if (url.endsWith('/pulls/42')) {

--- a/apps/spec-navigator/src/state/useFeature.ts
+++ b/apps/spec-navigator/src/state/useFeature.ts
@@ -7,7 +7,7 @@ import {
   fetchContentsListing,
   fetchPullRequest,
 } from '../github/api';
-import { hasPat } from '../github/auth';
+import { hasPat, subscribePat } from '../github/auth';
 import { strings } from '../strings';
 
 export interface UseFeatureResult {
@@ -71,6 +71,13 @@ export function useFeature(prNumber: number | null): UseFeatureResult {
   const [artefacts, setArtefacts] = useState<Artefact[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  // Bump this counter whenever the PAT changes so the fetch effect re-runs.
+  const [patVersion, setPatVersion] = useState<number>(0);
+
+  useEffect(() => {
+    const unsub = subscribePat(() => setPatVersion((v) => v + 1));
+    return unsub;
+  }, []);
 
   useEffect(() => {
     if (prNumber === null) return;
@@ -120,7 +127,7 @@ export function useFeature(prNumber: number | null): UseFeatureResult {
     return () => {
       cancelled = true;
     };
-  }, [prNumber]);
+  }, [prNumber, patVersion]);
 
   return { scope, artefacts, loading, error };
 }


### PR DESCRIPTION
Follow-up to #453. Two bugs surfaced on the first real end-to-end test against an open PR — both blocked the review flow at first use.

## The bugs

### 1. PAT save doesn't unblock the loading banner

`useFeature` only re-ran its fetch effect when `prNumber` changed. Opening the navigator without a PAT set `strings.errors.notAuthenticated` once, then the effect never re-fired even after the user saved a PAT in Settings. Reload was the only workaround.

### 2. Raw-content fetch fails the CORS preflight

`fetchRawText` / `fetchRawBlob` sent `Authorization: Bearer <pat>` to `raw.githubusercontent.com`, which refuses the CORS preflight. The browser threw `TypeError` on the fetch and the UI showed "Network error — your draft is safe." The repo is public, so unauthenticated GETs resolve cleanly.

## Fixes

- `auth.ts` exposes `subscribePat(listener)`; `setPat` / `clearPat` call `notify()`.
- `useFeature` subscribes and bumps a `patVersion`; the fetch effect depends on `[prNumber, patVersion]` and re-runs on save/clear.
- New `rawHeaders()` helper in `api.ts` sends only `Accept` — no Authorization — for raw.githubusercontent.com calls. Both `fetchRawText` and `fetchRawBlob` route through it. Inline comment documents that private-repo support would need the Contents API (base64-encoded bodies) instead.

## Regression tests

- `auth.test.ts`: `subscribePat` fires on set + clear; unsubscribe stops delivery.
- `useFeature.test.ts`: after a clearPat → "Not authenticated" banner, `setPat` re-fetches and clears the error.
- `api.test.ts`: `fetchRawText` never sets an Authorization header and the PAT does not appear in any request header value.

## Test plan

- [x] `pnpm --filter @debrief/spec-navigator test` — 141 (139 + 2 capture-only skips)
- [x] `pnpm exec playwright test` — 24 passing (+ 7 capture-gated skips)
- [x] `pnpm --filter @debrief/spec-navigator typecheck` clean
- [x] `pnpm --filter @debrief/spec-navigator lint` clean
- [x] `pnpm --filter @debrief/spec-navigator build` — 176 KB gzipped (budget 400 KB)
- [ ] Post-merge: verify end-to-end against PR #191 on the deployed navigator

## Related

- Follow-up to #453 (191-spec-navigator)
- Review in Spec Navigator (once deployed): https://debrief.github.io/debrief-future/spec-navigator/?pr=<num>