### PR TITLE
feat(spec-navigator): branch-preview deploy workflow

### DIFF
--- a/.github/workflows/spec-navigator-preview.yml
+++ b/.github/workflows/spec-navigator-preview.yml
@@ -1,0 +1,88 @@
+name: Preview Spec Navigator (branch)
+
+# Deploys a branch build of the Spec Navigator to
+#   https://debrief.github.io/debrief-future/spec-navigator-preview/<slug>/
+# where <slug> is the branch name with any non-[A-Za-z0-9-] characters
+# replaced by `-`. Preview deploys live next to production under the
+# same gh-pages branch; keep_files: true prevents this job from
+# clobbering /spec-navigator/ (the production build).
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to preview (default: the branch this workflow was dispatched from)'
+        required: false
+        type: string
+  push:
+    branches:
+      - 'preview/**'
+    paths:
+      - 'apps/spec-navigator/**'
+      - '.github/workflows/spec-navigator-preview.yml'
+
+jobs:
+  build-and-publish-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve branch + slug
+        id: branch
+        run: |
+          BRANCH="${{ inputs.branch || github.ref_name }}"
+          SLUG=$(printf '%s' "$BRANCH" | tr -c 'A-Za-z0-9-' '-' | sed -E 's/-+/-/g;s/^-|-$//g')
+          if [ -z "$SLUG" ]; then
+            echo "::error::Could not derive slug from branch '$BRANCH'"
+            exit 1
+          fi
+          if [ "$SLUG" = "main" ]; then
+            echo "::error::Refusing to publish 'main' as a preview — use the production workflow."
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "base_url=/debrief-future/spec-navigator-preview/$SLUG/" >> "$GITHUB_OUTPUT"
+          echo "Resolved: branch=$BRANCH slug=$SLUG"
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build spec-navigator (preview base URL)
+        env:
+          VITE_BASE_URL: ${{ steps.branch.outputs.base_url }}
+        run: pnpm --filter @debrief/spec-navigator build
+
+      - name: Deploy preview to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apps/spec-navigator/dist
+          destination_dir: spec-navigator-preview/${{ steps.branch.outputs.slug }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'chore(preview): deploy spec-navigator from ${{ steps.branch.outputs.branch }}'
+
+      - name: Summarise
+        run: |
+          echo "### Preview deployed :rocket:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Branch: \`${{ steps.branch.outputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Slug: \`${{ steps.branch.outputs.slug }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "URL: https://debrief.github.io/debrief-future/spec-navigator-preview/${{ steps.branch.outputs.slug }}/?pr=<n>" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/spec-navigator/README.md
+++ b/apps/spec-navigator/README.md
@@ -32,6 +32,29 @@ pnpm --filter @debrief/spec-navigator test      # Vitest unit tests
 node apps/spec-navigator/run-playwright.mjs     # Playwright E2E (cloud/CI)
 ```
 
+## Branch preview deploys
+
+A branch can be published alongside production for end-to-end testing without
+merging. Two trigger modes:
+
+- **Automatic**: push to any branch matching `preview/**` — the workflow runs
+  on paths `apps/spec-navigator/**` or the preview workflow file itself.
+- **Manual**: GitHub UI → Actions → *Preview Spec Navigator (branch)* →
+  **Run workflow** → pick the branch.
+
+URL pattern:
+
+```
+https://debrief.github.io/debrief-future/spec-navigator-preview/<slug>/?pr=<n>
+```
+
+`<slug>` is the branch name with non-`[A-Za-z0-9-]` characters replaced by
+`-`. Previews share the `gh-pages` branch with production under
+`keep_files: true` so this workflow never overwrites `/spec-navigator/`.
+Delete a preview by removing its folder from `gh-pages` directly.
+
+See `.github/workflows/spec-navigator-preview.yml`.
+
 ## Troubleshooting
 
 - **"Not authenticated"** — Open settings and paste a PAT. Permission scope


### PR DESCRIPTION
Adds a second GitHub Pages workflow that deploys a branch build of the Spec Navigator under `/spec-navigator-preview/<slug>/`, so fixes and experiments can be end-to-end tested against real PRs without merging to `main`.

## Why

Ship #191 left us with a navigator that can only be exercised by merging changes to `main` and waiting for the production workflow. Two small bugs (#454) and one incoming feature (open-PR-list) showed that a merge-to-test loop is too slow. A branch preview path closes the loop.

## How it works

- New workflow file: `.github/workflows/spec-navigator-preview.yml`.
- **Two triggers**:
  - `workflow_dispatch` with an optional `branch` input (Actions UI → Run workflow).
  - `push` to `preview/**` (plus path filter on `apps/spec-navigator/**` or the workflow itself).
- Slug = branch name stripped to `[A-Za-z0-9-]`. Refuses to publish `main` (that's the production workflow's job).
- Build runs with `VITE_BASE_URL=/debrief-future/spec-navigator-preview/<slug>/`. `vite.config.ts` already honours this env var — no code change needed.
- Deploy via `peaceiris/actions-gh-pages@v4` with `keep_files: true`, so this job can never clobber `/spec-navigator/` (production).
- The job writes the live URL into the workflow step summary.

## URL pattern

```
https://debrief.github.io/debrief-future/spec-navigator-preview/<slug>/?pr=<n>
```

Example: branch `fix/spec-navigator-pat-and-raw-cors` → `/spec-navigator-preview/fix-spec-navigator-pat-and-raw-cors/`.

## Clean-up

Previews accumulate under `gh-pages` alongside production. To remove one, delete its folder directly from the `gh-pages` branch. A follow-up could add a second workflow that prunes folders whose originating branch no longer exists remotely — not shipped here to keep scope tight.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Post-merge: dispatch the new workflow against `fix/spec-navigator-pat-and-raw-cors` (#454), verify the URL serves, and verify `/spec-navigator/` still works unchanged
- [ ] Post-merge: push to a `preview/...` branch, verify the automatic trigger fires

## Related

- Production workflow: `.github/workflows/spec-navigator-publish.yml`
- Shipped navigator: #453
- Pending fixes that will use this path for preview: #454