### PR TITLE
fix(spec-navigator): drawer steals grid space instead of floating

### DIFF
--- a/apps/spec-navigator/src/styles/app.css
+++ b/apps/spec-navigator/src/styles/app.css
@@ -48,7 +48,7 @@ body {
 
 .app-main {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px minmax(0, 1fr) auto;
   min-height: 0;
   overflow: hidden;
 }
@@ -56,7 +56,7 @@ body {
 @media (max-width: 720px) {
   .app-main {
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto 1fr auto;
   }
   .app-tree {
     max-height: 40vh;
@@ -238,22 +238,32 @@ body {
   cursor: pointer;
 }
 
-/* drawer */
+/* drawer — lives in the app-main grid's third column so it shares
+   horizontal space with the artefact view rather than floating over it. */
 .drawer {
-  position: fixed;
-  right: 0;
-  top: 48px;
-  bottom: 0;
   width: 340px;
+  min-height: 0;
   background: var(--color-surface);
   border-left: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
-  z-index: 10;
 }
 
 .drawer.is-collapsed {
   width: 36px;
+}
+
+@media (max-width: 720px) {
+  .drawer {
+    width: 100%;
+    max-height: 40vh;
+    border-left: none;
+    border-top: 1px solid var(--color-border);
+  }
+  .drawer.is-collapsed {
+    width: 100%;
+    max-height: 48px;
+  }
 }
 
 .drawer-header {


### PR DESCRIPTION
The drafts drawer used `position: fixed; right: 0; width: 340px` which **overlaid** the artefact view. At every viewport width, the right-hand 340 px of the rendered markdown was hidden under the drawer, so reviewers couldn't read the right edge of any spec.

## Fix

Make the drawer the third track of the `.app-main` CSS grid. The middle column now shrinks to fit when the drawer expands, so the markdown reflows to the available width.

- `.app-main` grid: `260px minmax(0, 1fr) auto` — `auto` on the drawer track respects its explicit width (340 px open / 36 px collapsed) without floating.
- Drop `position: fixed`, `right`, `top`, `bottom`, `z-index` on `.drawer`.
- Mobile (`max-width: 720px`): three-row stack (tree / view / drawer). Drawer capped at `40vh` when open, `48px` when collapsed, borders flip to match the vertical flow.

## Before / after

Before: right edge of every paragraph clipped — see screenshot in the PR discussion where "Attachments dropdown" is truncated to "Att..." on the right.

After: drawer + view sit side-by-side; collapsing the drawer gives the view back the full remaining width.

## Test plan

- [x] `pnpm --filter @debrief/spec-navigator test` — 141 / 141 passing (includes #454 regressions)
- [x] `pnpm --filter @debrief/spec-navigator typecheck` clean
- [x] `pnpm --filter @debrief/spec-navigator lint` clean
- [x] `pnpm --filter @debrief/spec-navigator build` — unchanged bundle size
- [ ] **Preview**: once #455 lands, dispatch preview deploy against this branch, visually verify at desktop (1280+) and mobile (375) viewports

## Related

- Follow-up to #453 (navigator) and #454 (PAT + CORS)
- Will be visually previewable via #455 once that merges