### PR TITLE
docs(174): scope one-off demo catalog thumbnail retro-capture

### DIFF
--- a/specs/174-thumbnail-capture/spec.md
+++ b/specs/174-thumbnail-capture/spec.md
@@ -74,6 +74,7 @@ As a maintainer or developer, I want to run a CLI command that opens every plot 
 2. **Given** the backfill script is running, **When** it processes each plot, **Then** it opens the plot, fits the view to all visible features, waits for basemap tiles to load, and captures the map view.
 3. **Given** a plot fails to render during backfill (e.g., corrupt data), **When** the script encounters the error, **Then** it logs a warning and continues to the next plot without stopping.
 4. **Given** the backfill script completes, **When** the maintainer opens the catalog browser, **Then** all plots show raster thumbnails in both the list view and preview pane.
+5. **Given** the demo STAC catalog at `preview/workspace/samples/local-store/` contains ~70 sample plots imported before Save-time capture existed, **When** the maintainer runs the backfill script against that catalog as a one-off under this spec, **Then** every sample plot directory gains committed `thumbnail.png` + `thumbnail-sm.png` files and updated `item.json` asset entries, shipped as part of this feature.
 
 ---
 
@@ -117,6 +118,7 @@ As a developer or service consumer, I need thumbnail images to be stored as stan
 - **FR-011**: The batch generation script MUST continue processing remaining plots if an individual plot fails.
 - **FR-012**: Thumbnail storage MUST be idempotent — re-saving or re-running the backfill overwrites existing thumbnails cleanly.
 - **FR-013**: Thumbnails MUST include visible basemap tiles (land/sea context), not just track geometry.
+- **FR-014**: As a one-off under this spec, the backfill script MUST be executed against the committed demo STAC catalog (`preview/workspace/samples/local-store/`), and the resulting `thumbnail.png`, `thumbnail-sm.png`, and updated `item.json` files MUST be committed to the repository so the deployed demo ships with populated thumbnails for all existing sample plots.
 
 ### Key Entities
 
@@ -176,3 +178,4 @@ As a developer or service consumer, I need thumbnail images to be stored as stan
 - **SC-004**: Thumbnail capture adds no more than 2 seconds to the Save operation under normal conditions (tiles already cached).
 - **SC-005**: All thumbnails include visible basemap context (land and sea boundaries), not just track geometry on a blank background.
 - **SC-006**: The catalog list view displays raster thumbnails for items that have them, with seamless fallback to SVG thumbnails for items that don't.
+- **SC-007**: After the one-off retro-capture, 100% of the ~70 sample plots in `preview/workspace/samples/local-store/` have both thumbnail sizes committed alongside `item.json`, verified by a count check in the PR evidence.

--- a/specs/174-thumbnail-capture/tasks.md
+++ b/specs/174-thumbnail-capture/tasks.md
@@ -160,8 +160,9 @@
 - [x] T034 Create backfill script: iterate catalog, open each plot, fit to window, wait for tiles, screenshot, resize with sharp, write PNGs + update item.json `apps/web-shell/scripts/generate-thumbnails.ts`
 - [x] T035 Add `"generate-thumbnails"` npm script to web-shell package.json `apps/web-shell/package.json`
 - [x] T036 Test: run backfill script against web-shell dev server and verify output files
+- [ ] T036a One-off retro-capture: run `pnpm --filter @debrief/web-shell generate-thumbnails` against the committed demo catalog at `preview/workspace/samples/local-store/`, verify `thumbnail.png` + `thumbnail-sm.png` exist in every item directory (expected: ~70 plots), confirm each `item.json` has the two thumbnail asset entries, then commit the generated PNGs and `item.json` updates in a single bulk commit. Capture a count check (plots with thumbnails / total plots) in PR evidence.
 
-**Checkpoint**: All existing plots have thumbnails.
+**Checkpoint**: All existing plots have thumbnails; demo catalog ships with committed thumbnails for every sample plot.
 
 ---
 


### PR DESCRIPTION
## Summary

- Scope a **one-off retro-capture** of thumbnails for the ~70 sample plots in the committed demo STAC catalog (`preview/workspace/samples/local-store/`), which were imported before Save-time capture existed and currently ship with no thumbnails.
- No code changes — spec + tasks only. The backfill script itself (T034) was already delivered; this commit adds the scope, the execution task, and the commit-artefacts requirement.

## Changes

**`specs/174-thumbnail-capture/spec.md`**
- US4 acceptance scenario 5 — one-off retro-capture against demo catalog with thumbnails committed.
- **FR-014** — MUST run backfill against `preview/workspace/samples/local-store/` and commit resulting `thumbnail.png` / `thumbnail-sm.png` / updated `item.json` files.
- **SC-007** — 100% coverage of the ~70 sample plots, verified by count check in PR evidence.

**`specs/174-thumbnail-capture/tasks.md`**
- **T036a** under Phase 6 — execute backfill, verify outputs, bulk-commit PNGs + `item.json` updates.
- Updated Phase 6 checkpoint.

## Test plan

- [ ] Review spec wording for clarity (US4 scenario 5, FR-014, SC-007).
- [ ] Review T036a wording — script command, verification expectations, commit guidance.
- [ ] Confirm the demo catalog path `preview/workspace/samples/local-store/` is the correct target (not `apps/vscode/test-data/local-store/` or similar).
- [ ] Follow-up PR will perform the actual retro-capture and commit the artefacts.