### PR TITLE
fix(ci): rewrite build path in venv activate scripts

### DIFF
--- a/.github/workflows/build-demo-artifact.yml
+++ b/.github/workflows/build-demo-artifact.yml
@@ -105,21 +105,34 @@ jobs:
 
       - name: Make venv relocatable
         run: |
-          # Rewrite shebang paths from build path to target path
+          # Rewrite build-path references to the runtime install path
+          # across every text file under venv/bin/. Python's `venv` emits
+          # two classes of scripts:
+          #   1. Shebanged tools (python, pip, ...) — previously handled.
+          #   2. Source-able activate scripts (activate, activate.fish,
+          #      activate.csh) that set VIRTUAL_ENV=<build path>. These
+          #      have NO shebang, so the old shebang-only check skipped
+          #      them — the verification step then flagged the leftover
+          #      build paths as a portability failure.
+          # The fix: rewrite any text file in venv/bin/, not just
+          # shebanged ones. Binary files are skipped via `file` check.
           BUILD_PATH="$PWD/artifact"
           TARGET_PATH="/opt/debrief"
 
-          # Update shebangs in bin scripts
           for script in artifact/venv/bin/*; do
-            if [ -f "$script" ] && head -1 "$script" | grep -q "^#!"; then
-              sed -i "s|$BUILD_PATH|$TARGET_PATH|g" "$script"
+            [ -f "$script" ] || continue
+            # Skip non-text files (e.g. precompiled binaries).
+            if ! file "$script" | grep -qE 'text|script|empty'; then
+              continue
             fi
+            sed -i "s|$BUILD_PATH|$TARGET_PATH|g" "$script"
           done
 
           # Verify rewrite
-          echo "Verifying path rewrite (first line of python script):"
+          echo "Verifying path rewrite:"
           head -1 artifact/venv/bin/python3 || true
           head -1 artifact/venv/bin/pip || true
+          grep '^VIRTUAL_ENV=' artifact/venv/bin/activate || true
 
       # T017: Build VS Code extension via pnpm workspace
       # The monorepo uses pnpm workspaces (pnpm-lock.yaml at repo root).


### PR DESCRIPTION
Follow-up to #458. That PR cleared the npm/pnpm blocker in *Build Demo Artifact*; the next step — "Verify venv portability" — then exposed a second, older bug that had been hiding behind it.

## The failure

\`\`\`
ERROR: Build path found in venv scripts
artifact/venv/bin/activate:VIRTUAL_ENV=/home/runner/work/…/artifact/venv
artifact/venv/bin/activate.fish:set -gx VIRTUAL_ENV /home/runner/…
artifact/venv/bin/activate.csh:setenv VIRTUAL_ENV /home/runner/…
\`\`\`

## Root cause

The "Make venv relocatable" step only \`sed\`'d files whose first line starts with a shebang. Python's \`venv\` emits two classes of scripts:

1. **Shebanged tools** (\`python\`, \`pip\`, ...) — previously handled.
2. **Source-able activate scripts** (\`activate\`, \`activate.fish\`, \`activate.csh\`) that set \`VIRTUAL_ENV=<build path>\`. These have **no** shebang, so the shebang-only loop skipped them; the verifier then flagged the leftover build paths as a portability failure.

## Fix

Rewrite any text file in \`venv/bin/\`, not just shebanged ones. Non-text files (the precompiled python interpreter on Linux) are skipped via a \`file\` check matching \`text|script|empty\`.

\`\`\`sh
for script in artifact/venv/bin/*; do
  [ -f "$script" ] || continue
  if ! file "$script" | grep -qE 'text|script|empty'; then
    continue
  fi
  sed -i "s|$BUILD_PATH|$TARGET_PATH|g" "$script"
done
\`\`\`

## Verified locally

\`\`\`
$ python3 -m venv /tmp/testvenv --copies
$ file /tmp/testvenv/bin/activate /tmp/testvenv/bin/activate.fish \\
       /tmp/testvenv/bin/activate.csh /tmp/testvenv/bin/python3
activate:       ASCII text
activate.fish:  ASCII text
activate.csh:   ASCII text, with very long lines
python3:        Mach-O 64-bit executable    ← skipped (correctly)
\`\`\`

On Ubuntu CI, \`python3\` is an ELF executable, same outcome.

## Test plan

- [x] YAML parses
- [x] Local venv-creation dry-run classifies the right files as text vs binary
- [ ] Post-merge: verify Build Demo Artifact goes green end-to-end
- [ ] Post-merge: verify Test Demo Environment (downstream consumer) also turns green