### PR TITLE
docs(217): Storyboarding panel + playback — planning stack

### DIFF
--- a/specs/217-storyboarding-playback/contracts/map-view-flyto.md
+++ b/specs/217-storyboarding-playback/contracts/map-view-flyto.md
@@ -1,0 +1,216 @@
+# Contract: `MapView.flyTo` + scene-click events
+
+**Feature**: 217-storyboarding-playback
+**Files**:
+- `shared/components/src/MapView/MapView.tsx` (extend)
+- `apps/vscode/src/webview/mapPanel.ts` (extend — public surface below)
+- `apps/vscode/src/webview/web/mapView.tsx` (internal wiring — not a public contract)
+
+**Status**: Language-neutral contract for the two new `MapView`
+capabilities that #217 needs: programmatic animated navigation and
+a Scene-rectangle click surface.
+
+---
+
+## 1. New `MapView` props
+
+```ts
+export interface MapViewProps extends ExistingMapViewProps {
+  // ── NEW for #217 ─────────────────────────────────────────────────
+
+  /**
+   * Animated viewport target. When set, the MapView animates to this
+   * viewport's centre + zoom via Leaflet `L.Map.flyTo`. `null` means
+   * "no pending animation" (the typical idle state).
+   *
+   * Each time this prop transitions to a new non-null value (or the
+   * same value with a different `token`), the MapView kicks off a new
+   * animation. The caller is responsible for generating a fresh token
+   * per transition (typically the `transitionId` from the playback
+   * service).
+   */
+  readonly flyToTarget?: FlyToTarget | null;
+
+  /**
+   * The Scene Features to render as faint rectangles on the map.
+   * Rendering rules defined in `contracts/scene-rectangle-layer.md`.
+   */
+  readonly sceneRectangles?: SceneRectangleLayerProps;
+
+  /** Fires when a Scene rectangle is clicked. The rectangle layer owns
+   *  click forwarding; MapView just re-exports the handler for convenience. */
+  onSceneRectangleClick?(sceneId: string): void;
+}
+
+export interface FlyToTarget {
+  /** Monotonically-increasing identifier — each new transition gets a
+   *  new token; repeated values are idempotent. */
+  readonly token: number;
+
+  /** Centre + zoom. Typically resolved from a Scene's `viewport`. */
+  readonly center: readonly [number, number];  // [lat, lon]
+  readonly zoom: number;
+
+  /** Animation duration in ms. `0` means "jump without animation". */
+  readonly durationMs: number;
+}
+```
+
+### Animation implementation
+
+```ts
+// Inside MapController (existing child of MapView):
+useEffect(() => {
+  if (!flyToTarget) return;
+  if (flyToTarget.durationMs === 0) {
+    map.setView(flyToTarget.center, flyToTarget.zoom, { animate: false });
+    onFlyToComplete?.(flyToTarget.token);
+    return;
+  }
+  map.flyTo(flyToTarget.center, flyToTarget.zoom, {
+    duration: flyToTarget.durationMs / 1000,
+    easeLinearity: 0.25,   // matches Leaflet's documented ease-in-out curve
+  });
+  const handler = () => {
+    map.off('moveend', handler);
+    onFlyToComplete?.(flyToTarget.token);
+  };
+  map.on('moveend', handler);
+  return () => { map.off('moveend', handler); };
+}, [flyToTarget?.token]);
+```
+
+Cancellation:
+
+- If a new `flyToTarget.token` arrives while a flight is in progress,
+  the effect cleanup's `map.off` releases the previous handler; the
+  new `map.flyTo` call aborts the previous animation (Leaflet's
+  documented behaviour — new movement commands cancel the in-flight
+  one).
+- If the token is cleared to `null`, the effect cleanup detaches the
+  listener; no `map.stop()` is issued — the animation completes or
+  is superseded by the next user interaction.
+
+---
+
+## 2. `MapPanel` public surface (extension side)
+
+`MapPanel` is the VS Code extension wrapper around the webview. The
+`StoryboardPlaybackService` talks to the map exclusively through this
+surface — never touches Leaflet directly from the extension host.
+
+```ts
+export class MapPanel {
+  // ── Existing public surface (unchanged) ───────────────────────────
+  public getCurrentFeatures(): DebriefFeature[];
+  public setFeatures(features: DebriefFeature[]): void;
+  public getCurrentPlot(): Plot | null;
+  public requestThumbnailCapture(): Promise<ThumbnailPair | null>;
+
+  // ── NEW for #217 ─────────────────────────────────────────────────
+
+  /** Kick off an animated flyTo. Generates a fresh token internally
+   *  and returns it; the caller uses it to correlate completion.
+   *  If `durationMs === 0` the map jumps without animation (setView
+   *  with animate:false) and `onFlyToComplete` fires synchronously
+   *  with the returned token. */
+  public flyToViewport(
+    viewport: Viewport,
+    durationMs: number,
+  ): number;
+
+  /** Push the active Storyboard's Scene rectangles to the webview.
+   *  Passing `null` clears the overlay. The webview-side
+   *  SceneRectangleLayer reads `scene.geometry.coordinates` (the
+   *  GeoJSON Polygon) for each rectangle — NOT
+   *  `scene.properties.viewport.corners` (Fix D). */
+  public setSceneRectangles(
+    scenes: ReadonlyArray<SceneFeature> | null,
+    activeStoryboardId: string | null,
+    currentSceneId: string | null,
+  ): void;
+
+  /** Event: fires when the user clicks a Scene rectangle on the map. */
+  public readonly onSceneRectangleClick: vscode.Event<string>;
+
+  /** Event: fires when an in-flight flyTo animation completes.
+   *  Emits the token that was returned from `flyToViewport`.
+   *  The playback service ALSO listens for webview visibility and
+   *  a durationMs+250ms safety timer (R8) — `onFlyToComplete` is
+   *  one of three independent clear triggers, not the sole path. */
+  public readonly onFlyToComplete: vscode.Event<number>;
+
+  /** NEW (arch-fix 2). Event: fires whenever `setFeatures` is called.
+   *  Emits the new `DebriefFeature[]`. The StoryboardPlaybackService
+   *  subscribes to drive its `onPlotFeaturesChanged(documentUri)`
+   *  lifecycle — recomputes sceneOrder + falls back via
+   *  `getMostRecentlyModifiedStoryboard` if the active Storyboard was
+   *  externally deleted. Follows the existing logPanelView
+   *  `_onFeaturesChanged` pattern (apps/vscode/src/views/logPanelView.ts:123). */
+  public readonly onFeaturesChanged: vscode.Event<DebriefFeature[]>;
+}
+```
+
+---
+
+## 3. Extension → MapPanel webview messages
+
+Added to the existing `MapPanelMessage` discriminated union (file
+`apps/vscode/src/webview/messages.ts`):
+
+```ts
+export type MapPanelMessage =
+  | ExistingMapPanelMessages
+  | { type: 'flyTo';
+      token: number;
+      center: readonly [number, number];
+      zoom: number;
+      durationMs: number; }
+  | { type: 'setSceneRectangles';
+      scenes: ReadonlyArray<{ sceneId: string; viewport: Viewport; timestamp: string }>;
+      activeStoryboardId: string | null;
+      currentSceneId: string | null; };
+```
+
+## 4. MapPanel webview → extension messages
+
+```ts
+export type MapPanelToExtensionMessage =
+  | ExistingInboundMessages
+  | { type: 'flyToComplete'; token: number }
+  | { type: 'sceneRectangleClicked'; sceneId: string };
+```
+
+---
+
+## 5. Integration with main GeoJSON layer
+
+`MapView`'s existing GeoJSON rendering layer filters out Storyboard
+Features (never rendered) and Scene Features (rendered separately by
+`SceneRectangleLayer` only when they belong to the active Storyboard).
+The filter is prop-controlled:
+
+```ts
+function shouldRenderInBaseLayer(feature: GeoJSON.Feature): boolean {
+  const kind = feature.properties?.kind;
+  return kind !== 'STORYBOARD' && kind !== 'STORYBOARD_SCENE';
+}
+```
+
+This keeps the base layer unaware of storyboard entities and
+guarantees FR-PLAY-015 (parent Storyboard Feature never renders).
+
+---
+
+## 6. Test contract
+
+| Test | Asserts |
+|---|---|
+| `flyTo with durationMs > 0 triggers L.Map.flyTo` | spies on `L.Map.flyTo`; verifies args |
+| `flyTo with durationMs === 0 triggers setView with animate:false` | spies on `L.Map.setView`; verifies options |
+| `new token during in-flight flyTo supersedes the previous flight` | two sequential tokens; only the second `flyTo` completes |
+| `onFlyToComplete fires with the correct token on moveend` | event spy; assert token value |
+| `onSceneRectangleClick fires with the clicked sceneId` | simulates click on rectangle; event spy |
+| `base GeoJSON layer filters out STORYBOARD and STORYBOARD_SCENE` | fixture plot with one of each; assert only non-storyboard Features rendered |
+| `setSceneRectangles(null) clears the overlay` | render then clear; assert 0 polygons in layer |
+| `onFeaturesChanged fires on every setFeatures call` | call setFeatures twice; event spy fires twice with the corresponding arrays (arch-fix 2) |

--- a/specs/217-storyboarding-playback/contracts/playback-service.md
+++ b/specs/217-storyboarding-playback/contracts/playback-service.md
@@ -1,0 +1,347 @@
+# Contract: `StoryboardPlaybackService` — public TypeScript API
+
+**Feature**: 217-storyboarding-playback
+**File**: `apps/vscode/src/services/storyboardPlayback.ts`
+**Status**: Language-neutral contract. Drives implementation + test
+names in `apps/vscode/src/services/__tests__/storyboardPlayback.test.ts`.
+
+Extension-host singleton (instantiated once in `extension.ts`, wired
+to `SessionManager`, `MapPanel`, and the `StoryboardPanelViewProvider`).
+All signatures are TypeScript strict-mode; no public method returns
+`any`. All mutation methods return `Promise<void>` because they
+delegate to `@debrief/components/storyboard` CRUD (which is async —
+Web Crypto is async; see #215 contract).
+
+---
+
+## 1. Imported types
+
+```ts
+import type { SessionManager } from '../services/sessionManager';
+import type { MapPanel } from '../webview/mapPanel';
+import type { StoryboardPanelViewProvider } from '../views/storyboardPanelView';
+import type {
+  StoryboardOptionViewModel,
+  SceneRowViewModel,
+  TransportViewModel,
+  MissingDataReason,
+} from '@debrief/components';
+```
+
+---
+
+## 2. Snapshot projection
+
+```ts
+export interface StoryboardPlaybackSnapshot {
+  readonly documentUri: string;     // STAC URI (SessionManager's session key)
+  readonly storyboards: readonly StoryboardOptionViewModel[];
+  readonly scenes: readonly SceneRowViewModel[];
+  readonly activeStoryboardId: string | null;
+  readonly currentSceneId: string | null;
+  readonly transport: TransportViewModel;
+}
+```
+
+All fields are transport-safe primitives.
+
+---
+
+## 3. Service interface
+
+```ts
+export interface StoryboardPlaybackService extends vscode.Disposable {
+
+  // ── Lifecycle ─────────────────────────────────────────────────────
+
+  /** Called by SessionManager when a plot is opened. Runs `validatePlot(plot)`;
+   *  if it throws, disables transport for this plot and surfaces a single
+   *  error toast (design-fix 2). Otherwise: seeds active selection from
+   *  `getMostRecentlyModifiedStoryboard(plot)` (the new #215 query —
+   *  research R7); narrows the scrubbable range via
+   *  `TimeRangeViewProvider.setScrubbableRange(...)` to the Scene window;
+   *  sets `debrief.storyboardActive` iff ≥ 1 Scene exists. */
+  onPlotOpened(documentUri: string): void;
+
+  /** Called by SessionManager when a plot is closed or the window is being
+   *  disposed. Restores the default scrubbable range via
+   *  `TimeRangeViewProvider.setScrubbableRange(null, null)`; clears context;
+   *  drops per-plot state. */
+  onPlotClosed(documentUri: string): void;
+
+  /** Called when the plot's FeatureCollection has been externally mutated
+   *  (via MapPanel's new `onFeaturesChanged: vscode.Event<DebriefFeature[]>`
+   *  event — arch-fix 2). Recomputes sceneOrder; if the active Storyboard
+   *  was deleted, falls back to `getMostRecentlyModifiedStoryboard`. */
+  onPlotFeaturesChanged(documentUri: string): void;
+
+  // ── Read API ──────────────────────────────────────────────────────
+
+  /** Returns the current snapshot. `storyboards = []` and all other fields at
+   *  their empty-state values if the documentUri is unknown. */
+  getSnapshot(documentUri: string): StoryboardPlaybackSnapshot;
+
+  /** Subscribe to snapshot changes. Emits on: plot-opened, plot-closed, plot-features-
+   *  changed, dropdown-switch, transport step, transition start/end. */
+  onSnapshotChange(
+    listener: (snap: StoryboardPlaybackSnapshot) => void,
+  ): vscode.Disposable;
+
+  // ── Transport ─────────────────────────────────────────────────────
+
+  /** Step forward. No-op during an in-flight transition, at the last Scene,
+   *  or when the Storyboard is empty. Resolves after the hard-block check;
+   *  does NOT await the animation. */
+  forward(documentUri: string): Promise<void>;
+
+  /** Step backward. Mirror of `forward`. */
+  backward(documentUri: string): Promise<void>;
+
+  /** Click-to-select. Must run hard-block check; animates to target via the
+   *  same transport path as Forward / Backward. */
+  goToScene(documentUri: string, sceneId: string): Promise<void>;
+
+  /** Dropdown switch. Recomputes sceneOrder and scrub window within the same
+   *  user interaction (no async work before the panel snapshot updates). */
+  setActiveStoryboard(documentUri: string, storyboardId: string | null): void;
+
+  // ── Storyboard CRUD (delegates to #215) ────────────────────────────
+  //
+  //  CRUD-during-flight guard (R9 / test-fix 1): if the service has a
+  //  non-null transitionId for the given documentUri, these methods
+  //  return immediately with no side effect (no toast, no CRUD call).
+  //  Panel overflow buttons are disabled via
+  //  `transport.transitionInFlight`.
+
+  /** Create a new Storyboard. Errors from #215 (DuplicateStoryboardName)
+   *  surface as VS Code error messages. On success, the new Storyboard
+   *  becomes the active selection. */
+  createStoryboard(
+    documentUri: string,
+    name: string,
+    description?: string,
+  ): Promise<void>;
+
+  /** Rename. Errors surface as VS Code error messages. */
+  renameStoryboard(
+    documentUri: string,
+    storyboardId: string,
+    newName: string,
+  ): Promise<void>;
+
+  /** Delete + cascade Scenes. Caller is responsible for the cascade-delete
+   *  confirmation modal (surfaced by the command handler, not the service).
+   *  On success, falls back to `getMostRecentlyModifiedStoryboard` for the
+   *  remaining Storyboards. */
+  deleteStoryboard(
+    documentUri: string,
+    storyboardId: string,
+  ): Promise<void>;
+
+  // ── Hard-block resolution ─────────────────────────────────────────
+
+  /** Invoked by the command handler after the analyst picks *Jump past this scene*.
+   *  Advances transport past the blocked Scene without animating into it. */
+  resolveHardBlockByJumpingPast(
+    documentUri: string,
+    blockedSceneId: string,
+    direction: 'forward' | 'backward',
+  ): Promise<void>;
+
+  /** Invoked by the hard-block modal's *Open for editing* action. Stubbed
+   *  until #218 — the service surfaces a read-only details toast via
+   *  `vscode.window.showInformationMessage` (no separate command
+   *  registration); leaves transport state unchanged. */
+  resolveHardBlockByOpeningForEditing(
+    documentUri: string,
+    blockedSceneId: string,
+  ): void;
+
+  // ── Disposal ─────────────────────────────────────────────────────
+  dispose(): void;   // also calls setScrubbableRange(null, null) per plot
+}
+```
+
+---
+
+## 4. Animation coordination
+
+The service internally manages a per-plot `TransitionController` that:
+
+1. Resolves the target `viewport` + `timestamp` for the target Scene.
+2. Calls `mapPanel.flyToViewport(viewport, durationMs)` (webview
+   postMessage → Leaflet `L.Map.flyTo`). `flyToViewport` returns a
+   `token: number` used to correlate completion.
+3. Runs a browser-`requestAnimationFrame` tween of the session's
+   `currentTime` from start → target over the same `durationMs`
+   using ease-in-out easing (default `t → t * t * (3 - 2 * t)`).
+4. Marks `transitionId = null` via **any of three clear triggers**
+   (R8 / test-fix 2):
+   - **primary**: `MapPanel.onFlyToComplete(token)` fires after
+     Leaflet's `moveend`.
+   - **visibility guard**: `webviewView.onDidChangeVisibility(false)`
+     on the Storyboard panel clears the transition immediately.
+     Triggered when the analyst switches tabs or hides the panel
+     mid-flight.
+   - **safety timer**: `setTimeout(durationMs + 250)` — caps the
+     hidden-webview case where Leaflet's `moveend` may fire late or
+     never.
+   Whichever fires first wins; the others are no-ops against a stale
+   token.
+
+**Cancellation**: if a scrub is detected during flight (via a
+`setCurrentTime` write whose source is not this service's tween), the
+service aborts the RAF tween at the current frame and clears
+`transitionId`. The subsequent `onFlyToComplete` for the cancelled
+token is ignored.
+
+**Zero-duration edge case** (`transition_duration_ms = 0`): the map
+jumps (`animate: false` passed to Leaflet); the time slider is snapped
+to the target timestamp without a RAF tween. The transport is not
+"in-flight" for any wall-clock duration.
+
+**Long-duration edge case** (e.g. 10 000 ms): transport buttons and
+keys stay disabled; cancel-by-row-click is supported — clicking a
+specific Scene row is treated as a transport command, which the
+service detects-and-cancels-then-restarts to the new target.
+
+---
+
+## 5. Hard-block flow
+
+```ts
+// Pseudocode — the service's forward() method
+async forward(documentUri: string): Promise<void> {
+  const state = this.states.get(documentUri);
+  if (!state) return;
+  if (!state.plotValid) return;                             // validatePlot gate
+  if (state.transitionId !== null) return;                  // in-flight
+  if (state.currentSceneIndex >= state.sceneOrder.length - 1) return;  // at last
+
+  const targetSceneId = state.sceneOrder[state.currentSceneIndex + 1];
+  const plot = plotFromFeatures(this.mapPanel.getCurrentFeatures());  // shared helper (design-fix 4)
+  const targetScene = getScene(plot, targetSceneId);
+  const temporal = this.sessions.getActiveSession()?.getState();
+
+  // ISO ↔ epoch conversion at the #215 boundary (arch-fix 4).
+  // TemporalSlice.timeRange is { start: number; end: number } (epoch ms).
+  // detectMissingDataForScene expects { start: string; end: string } (ISO-8601).
+  const plotTimeRange = temporal?.timeRange
+    ? {
+        start: new Date(temporal.timeRange.start).toISOString(),
+        end:   new Date(temporal.timeRange.end).toISOString(),
+      }
+    : { start: new Date(0).toISOString(), end: new Date(8.64e15).toISOString() };
+
+  const classification = detectMissingDataForScene(
+    targetScene!, plot.features, plotTimeRange,
+  );
+
+  if (classification.kind !== 'ok') {
+    await this.promptHardBlock(targetScene!, classification, 'forward', documentUri);
+    return;
+  }
+
+  await this.executeTransition(documentUri, state.currentSceneIndex + 1, 'forward');
+}
+```
+
+The `promptHardBlock` method:
+
+```ts
+private async promptHardBlock(
+  scene: SceneFeature,
+  classification: MissingDataClassification,
+  direction: 'forward' | 'backward',
+  documentUri: string,
+): Promise<void> {
+  const reason = this.toMissingDataReason(classification);
+  const body = this.formatHardBlockBody(scene, reason);
+
+  const choice = await vscode.window.showInformationMessage(
+    body,
+    { modal: true },
+    messages.jumpPastLabel,
+    messages.openForEditingLabel,
+  );
+
+  if (choice === messages.jumpPastLabel) {
+    await this.resolveHardBlockByJumpingPast(documentUri, scene.properties.id, direction);
+  } else if (choice === messages.openForEditingLabel) {
+    this.resolveHardBlockByOpeningForEditing(documentUri, scene.properties.id);
+  }
+  // Dismissed: leave transport state unchanged.
+}
+```
+
+---
+
+## 6. Error vocabulary
+
+The service itself throws no errors to the webview. All errors from
+#215's CRUD (`DuplicateStoryboardName`, `UnknownStoryboard`,
+`UnknownScene`) are caught and surfaced as
+`vscode.window.showErrorMessage(messages.crudError(err.code))`.
+
+An unknown `documentUri` in the per-plot map is a programmer error —
+methods log-and-return silently rather than throwing (the panel
+should not have sent a message for an unknown plot).
+
+---
+
+## 7. Non-API guarantees
+
+- **No domain logic in the service.** Scene ordering, missing-data
+  classification, and all invariant enforcement live in
+  `@debrief/components/storyboard`. The new
+  `getMostRecentlyModifiedStoryboard` query added by this slice also
+  lives in that module (not in the service).
+- **No direct Storyboard / Scene Feature writes.** All writes pass
+  through #215's async CRUD. Enforced by ESLint
+  `no-restricted-imports` on the extension's `src/services/` path.
+- **No network.** All calls are in-process.
+- **Single-flight.** Only one transition in flight per plot at a
+  time. CRUD ops (Create / Rename / Delete) are rejected during an
+  in-flight transition — same policy as transport-vs-transport (R9).
+- **validatePlot gate.** `onPlotOpened` runs `validatePlot(plot)`;
+  on throw, `plotValid = false` is recorded and all transport + CRUD
+  ops are no-ops for that plot until re-open.
+- **Context management.** Sets `debrief.storyboardActive` on
+  plot-opened (iff current index ≥ 0 AND plotValid) and clears it on
+  plot-closed.
+- **Lifecycle correctness.** On `dispose()`, calls
+  `setScrubbableRange(null, null)` for every plot with an active
+  override, clears context for every plot, and unsubscribes all
+  listeners.
+
+---
+
+## 8. Testability seams
+
+- `idOverride` on `createStoryboard` passes through to #215 (injected
+  ULID — already supported).
+- `now` on `createStoryboard` / `renameStoryboard` / `deleteStoryboard`
+  passes through to #215 (injected clock — already supported).
+- `TransitionController` is constructor-injectable for tests (stub
+  that resolves `durationMs` immediately without real RAF / `flyTo`).
+- `vscode.window.showInformationMessage` is abstracted behind a
+  `ModalPromptPort` interface for unit-test substitution.
+- `webviewView.onDidChangeVisibility` is abstracted behind a
+  `VisibilityPort` interface so visibility-cancel paths can be
+  driven deterministically from tests.
+
+## 9. Test requirements (from review)
+
+In addition to the core acceptance-scenario coverage, the service's
+test suite MUST include:
+
+| Test | Asserts |
+|---|---|
+| `onPlotOpened rejects corrupt plot via validatePlot` | fixture with orphan Scene → single `showErrorMessage` call; `plotValid = false`; all subsequent forward/backward/goToScene are no-ops (design-fix 2 / test-fix 3) |
+| `CRUD ops are rejected during in-flight transition` | inject a stub TransitionController that never completes; each of createStoryboard / renameStoryboard / deleteStoryboard returns void without calling the underlying CRUD (R9 / test-fix 1) |
+| `onDidChangeVisibility(false) clears transitionId` | start a transition; fire visibility false → transitionId === null; subsequent forward works (R8 / test-fix 2) |
+| `onFlyToComplete safety timer fires at durationMs+250ms` | stub MapPanel to never fire onFlyToComplete; advance vitest fake timers by durationMs+250ms → transitionId === null (R8 / test-fix 2) |
+| `plot-switch mid-transition cancels old plot's flight` | two documentUris with active transitions; close first mid-flight → first cleared; second unaffected (R8 / test-fix 2) |
+| `getMostRecentlyModifiedStoryboard drives default active` | plot with 3 Storyboards, each with distinct provenance[last].timestamp; onPlotOpened picks the max (R7 / test-fix 4) |
+| `ISO/epoch conversion rejects NaN timeRange` | Pass { start: NaN, end: NaN } from a malformed session → service substitutes full-extent defaults; detectMissingDataForScene receives valid ISO strings (arch-fix 4) |
+| `setScrubbableRange restored on service.dispose` | start active; spy on timeRangeView.setScrubbableRange; dispose → called with (null, null) for every plot (test-fix 4) |

--- a/specs/217-storyboarding-playback/contracts/scene-rectangle-layer.md
+++ b/specs/217-storyboarding-playback/contracts/scene-rectangle-layer.md
@@ -1,0 +1,184 @@
+# Contract: `SceneRectangleLayer` React component
+
+**Feature**: 217-storyboarding-playback
+**File**: `shared/components/src/MapView/SceneRectangleLayer.tsx`
+**Status**: Language-neutral contract. Drives implementation + test
+names in `shared/components/src/MapView/__tests__/SceneRectangleLayer.test.tsx`.
+
+A presentational React-Leaflet component that renders the active
+Storyboard's Scene viewport Polygons as faint rectangles on the map.
+Zero VS Code imports; works unchanged in Storybook, web-shell, and
+the VS Code webview host.
+
+---
+
+## 1. Public props
+
+```ts
+export interface SceneRectangleLayerProps {
+  /**
+   * Scene Features to render. The caller (the playback service, via
+   * MapPanel's `setSceneRectangles`) is responsible for pre-filtering
+   * to the active Storyboard's Scenes. Empty array renders nothing.
+   */
+  readonly scenes: ReadonlyArray<SceneFeature>;
+
+  /**
+   * Scopes rendering. If `null`, the layer renders nothing even if
+   * `scenes` is non-empty (defence-in-depth against render drift
+   * during dropdown transitions).
+   */
+  readonly activeStoryboardId: string | null;
+
+  /** The Scene whose rectangle should draw with the "current" visual
+   *  treatment (slightly bolder outline). `null` when the Storyboard
+   *  is empty. */
+  readonly currentSceneId: string | null;
+
+  /** Fires on rectangle click. */
+  onSceneRectangleClick(sceneId: string): void;
+}
+```
+
+---
+
+## 2. Rendering rules (FR-PLAY-015 / FR-PLAY-016 / FR-PLAY-018)
+
+### 2.1 Gating
+
+Renders nothing if any of:
+- `activeStoryboardId === null`
+- `scenes.length === 0`
+
+### 2.2 Per-Scene rendering
+
+For each `scene` in `scenes`, render a `<Polygon>` with:
+
+```ts
+<Polygon
+  key={scene.properties.id}
+  positions={geoJsonPolygonToLeafletCoords(scene.geometry.coordinates)}
+  pathOptions={{
+    color: tokens.sceneRectangleStroke,       // ThemeProvider token
+    fillColor: tokens.sceneRectangleFill,
+    fillOpacity: computeFillOpacity(scene, overlapRank, isCurrent),
+    weight: isCurrent ? 2 : 1,
+    opacity: isCurrent ? 0.9 : 0.5,
+    className: `debrief-scene-rect ${isCurrent ? 'debrief-scene-rect--current' : ''}`,
+  }}
+  eventHandlers={{
+    click: (event) => {
+      L.DomEvent.stopPropagation(event);
+      onSceneRectangleClick(scene.properties.id);
+    },
+  }}
+/>
+```
+
+**Geometry source**: `scene.geometry.coordinates` is the GeoJSON
+`Polygon` coordinates (outer ring + optional holes; in practice a
+single 4-corner outer ring with the closing point, written by
+#215's `viewportToPolygon` at capture time). **Not**
+`scene.properties.viewport.corners` — the `Viewport` interface in
+`@debrief/schemas` is `{center: [lon, lat], zoom: number, bearing: number}`
+only (Fix D).
+
+- `isCurrent = scene.properties.id === currentSceneId`
+- `overlapRank` is the 0-based index of this Scene among overlapping
+  rectangles at approximately the same centroid (stable sort by
+  `timestamp`). See §3.
+
+### 2.3 Opacity variation for overlap (FR-PLAY-018)
+
+```ts
+function computeFillOpacity(
+  scene: SceneFeature,
+  overlapRank: number,
+  isCurrent: boolean,
+): number {
+  const base = isCurrent ? 0.28 : 0.18;
+  const step = 0.04;
+  return Math.max(0.10, base - step * overlapRank);
+}
+```
+
+Overlap detection is approximate: two rectangles overlap if their
+viewport centres are within 10% of the smaller viewport's diagonal.
+Cheap O(n²) scan — fine for ≤ 50 Scenes per Storyboard.
+
+### 2.4 Topmost-click behaviour
+
+Rectangles are rendered in ascending `timestamp` order; Leaflet's
+default z-order puts later-rendered polygons on top. The stopPropagation
+call ensures only the topmost (most recent) rectangle fires
+`onSceneRectangleClick`.
+
+### 2.5 Antimeridian handling (R5)
+
+`viewportToLeafletCoords` passes the Polygon's corners through
+unchanged — Leaflet renders a visible best-effort polygon that wraps
+around the back of the globe in the default EPSG:3857 projection. No
+splitting into two polygons (R5).
+
+---
+
+## 3. Helper: `geoJsonPolygonToLeafletCoords`
+
+```ts
+function geoJsonPolygonToLeafletCoords(
+  coordinates: GeoJSON.Polygon['coordinates'],
+): LatLngTuple[] {
+  // GeoJSON.Polygon.coordinates: [[[lon, lat], ...]] — outer ring + optional holes.
+  // We only use the outer ring; storyboard viewports are always simple rectangles.
+  // The outer ring's first and last points are identical (GeoJSON closing rule) —
+  // Leaflet handles the duplicate gracefully, so no trim needed.
+  return coordinates[0].map(([lon, lat]) => [lat, lon] as LatLngTuple);
+}
+```
+
+---
+
+## 4. Theme tokens
+
+Added to `shared/components/src/ThemeProvider/tokens.ts`:
+
+```ts
+export interface ThemeTokens extends ExistingThemeTokens {
+  readonly sceneRectangleStroke: string;
+  readonly sceneRectangleFill: string;
+}
+```
+
+- **Light theme**: `stroke = #3b82f6` (blue-500), `fill = #93c5fd` (blue-300)
+- **Dark theme**: `stroke = #60a5fa` (blue-400), `fill = #1e40af` (blue-800)
+- **VS Code theme**: `stroke = var(--vscode-focusBorder)`, `fill = var(--vscode-selection-background)`
+
+---
+
+## 5. Test contract
+
+| Test | Asserts |
+|---|---|
+| `renders nothing when activeStoryboardId is null` | 0 Polygons; no click listeners attached |
+| `renders nothing when scenes is empty` | 0 Polygons |
+| `renders one Polygon per Scene` | exact count match |
+| `rectangles for non-active Storyboards never appear` | fixture with two Storyboards' Scenes merged into `scenes`; only the active-storyboard Scenes render (enforced by caller's filter; the layer trusts its prop but the test doubles as a contract smoke test) |
+| `current Scene rectangle has bolder stroke + className` | inspect path options |
+| `overlapping rectangles remain individually visible with opacity variation` | 3 Scenes at same centroid; 3 distinct fillOpacity values; all ≥ 0.10 |
+| `click on rectangle fires onSceneRectangleClick with correct sceneId` | click event simulation |
+| `topmost rectangle wins on overlapping click` | fires only for the most recent Scene at the click point |
+| `antimeridian-crossing viewport renders as single best-effort polygon` | fixture with corners `[[170, 10], [-170, 10], [-170, 0], [170, 0]]`; exactly one L.Polygon rendered |
+| `no memory leaks — re-render with fewer Scenes cleans up stale polygons` | 3 → 1 Scenes; inspect layer children count |
+
+---
+
+## 6. Non-API guarantees
+
+- **No VS Code imports.** The file imports only from `react`,
+  `react-leaflet`, `leaflet`, `@debrief/schemas`, and sibling
+  `shared/components/` modules.
+- **No side effects.** Pure render; event wiring cleaned up on
+  unmount via react-leaflet's built-in lifecycle.
+- **Strict types.** `any` / `unknown` prohibited on the public props.
+- **Theme-aware.** Colours route through `ThemeProvider` tokens — no
+  hardcoded hex in the component body.

--- a/specs/217-storyboarding-playback/contracts/storyboard-panel-messages.md
+++ b/specs/217-storyboarding-playback/contracts/storyboard-panel-messages.md
@@ -1,0 +1,148 @@
+# Contract: Storyboard panel `postMessage` discriminated union
+
+**Feature**: 217-storyboarding-playback
+**File**: `apps/vscode/src/types/storyboardPanelMessages.ts` (extend)
+**Status**: Language-neutral contract. All messages crossing the
+extension ↔ webview boundary are members of these two discriminated
+unions. No `any`, no `unknown`, no free-form payload.
+
+This contract **extends** the #216 message set with dropdown, overflow
+menu, transport, and active-state updates.
+
+---
+
+## 1. Outbound (extension → panel webview)
+
+```ts
+export type ExtensionToStoryboardPanelMessage =
+  | { type: 'scenes';
+      scenes: ReadonlyArray<SceneRowViewModel>;
+      activeStoryboardName: string | null;
+      activeStoryboardId: string | null; }                // existing from #216
+
+  | { type: 'captureInFlight';
+      inFlight: boolean; }                                // existing from #216
+
+  // ── NEW for #217 ───────────────────────────────────────────────────
+  | { type: 'snapshot';
+      storyboards: ReadonlyArray<StoryboardOptionViewModel>;
+      scenes: ReadonlyArray<SceneRowViewModel>;
+      activeStoryboardId: string | null;
+      currentSceneId: string | null;
+      activeStoryboardName: string | null;
+      transport: TransportViewModel; };
+```
+
+The new `snapshot` message replaces piece-meal updates — the service
+computes the full `StoryboardPlaybackSnapshot` and broadcasts it
+wholesale on every transport step, dropdown switch, CRUD op, or plot-
+features change. The webview diffs internally via React key stability.
+
+The existing `scenes` and `captureInFlight` messages are kept for
+backward compatibility with the #216 capture flow and are still used by
+`storyboardPanelView.ts`'s `refresh()` path. The service's outbound
+broadcasts use `snapshot` exclusively.
+
+### Invariants
+
+- `activeStoryboardId === null` ↔ `storyboards.length === 0` OR the
+  analyst has switched to "no storyboard" (not a currently exposed
+  action, but reserved).
+- `currentSceneId === null` ↔ `scenes.length === 0`.
+- `transport.sceneTotal === scenes.length`.
+- `transport.sceneNumber` is 1-based or 0 when `scenes.length === 0`.
+- `transport.canGoForward` → `!transport.transitionInFlight &&
+  transport.sceneNumber < transport.sceneTotal`.
+- `transport.canGoBackward` → `!transport.transitionInFlight &&
+  transport.sceneNumber > 1`.
+
+---
+
+## 2. Inbound (panel webview → extension)
+
+```ts
+export type StoryboardPanelMessage =
+  | { type: 'ready' }                                                // existing from #216
+  | { type: 'capture-clicked' }                                      // existing from #216
+  | { type: 'scene-row-clicked'; sceneId: string }                   // existing from #216 — behaviour CHANGED (now drives playback)
+  | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }  // existing from #216
+
+  // ── NEW for #217 ───────────────────────────────────────────────────
+  | { type: 'active-storyboard-changed'; storyboardId: string }
+  | { type: 'transport-forward-clicked' }
+  | { type: 'transport-backward-clicked' }
+  | { type: 'create-storyboard-requested' }
+  | { type: 'rename-storyboard-requested'; storyboardId: string }
+  | { type: 'delete-storyboard-requested'; storyboardId: string };
+```
+
+### Behaviour-change: `scene-row-clicked`
+
+- **Before (#216)**: extension logs only; no UI change.
+- **After (#217)**: extension calls
+  `storyboardPlaybackService.goToScene(documentUri, sceneId)`. The
+  service runs the hard-block check inside `goToScene` — if the
+  target Scene's `visible_feature_ids` no longer resolve or its
+  timestamp falls outside the plot's time range, the native VS Code
+  modal is surfaced. Rows themselves carry no pre-computed `blocked`
+  state (design-fix 1) — classification runs only at step-onto time.
+
+### Behaviour of management messages
+
+Each of `create-storyboard-requested`, `rename-storyboard-requested`,
+`delete-storyboard-requested` is handled by invoking the matching
+VS Code command (`debrief.storyboard.create`, `.rename`, `.delete`) via
+`vscode.commands.executeCommand`. This keeps the command palette and
+the panel overflow menu wired to the same handler — no duplication.
+
+### Behaviour of transport messages
+
+`transport-forward-clicked` / `transport-backward-clicked` invoke
+`debrief.storyboard.forward` / `.backward` via `executeCommand`.
+Rationale: keeps the panel's button clicks and the scoped arrow keys
+on the same code path (ensures in-flight gating + hard-block behaviour
+are identical regardless of entry point).
+
+### Behaviour of dropdown change
+
+`active-storyboard-changed` is handled **synchronously**:
+- Calls `service.setActiveStoryboard(documentUri, storyboardId)`.
+- No VS Code command dispatch — this is pure state.
+- The service emits a new snapshot within the same microtask, so
+  the webview's next render frame sees the updated Scene list +
+  rectangles (SC-003 — within the same user interaction).
+
+---
+
+## 3. Lifecycle
+
+- On panel `ready`, the view provider calls
+  `storyboardPlaybackService.getSnapshot(activePlotPath)` and posts
+  the initial `snapshot` message.
+- On `onSnapshotChange`, the view provider posts a new `snapshot`
+  message. Snapshot equality is NOT checked — the service caller is
+  responsible for only emitting on meaningful state changes.
+- On panel visibility change (hidden → visible), the view provider
+  re-posts the latest snapshot (React would re-mount with stale
+  props otherwise).
+
+---
+
+## 4. Map-side messages (extension ↔ MapPanel webview)
+
+Separate surface — see `contracts/map-view-flyto.md` for the
+Leaflet-webview messages; `scene-rectangle-clicked` flows from the
+MapPanel webview to the extension, which then calls
+`service.goToScene(documentUri, sceneId)` (same entry point as
+`scene-row-clicked`).
+
+---
+
+## 5. Testability
+
+Unit tests for the view provider mock the webview and assert the
+`postMessage` payload matches the discriminated-union variant exactly.
+A TypeScript type test (`expectType<...>`) asserts the unions are
+exhaustive — `default` cases in the handlers are `never`-typed and
+compile-fail if a new variant is added without a handler update
+(Article XV defence-in-depth).

--- a/specs/217-storyboarding-playback/contracts/vscode-commands.md
+++ b/specs/217-storyboarding-playback/contracts/vscode-commands.md
@@ -1,0 +1,256 @@
+# Contract: VS Code command + keybinding contributions
+
+**Feature**: 217-storyboarding-playback
+**File**: `apps/vscode/package.json` (contributes section)
+**Status**: Language-neutral contract. Each command has a 1:1 handler
+under `apps/vscode/src/commands/` with a matching unit test.
+
+> All strings shown here are displayed literals. User-facing strings
+> route through the extension's `messages.ts` pattern for
+> internationalisation (Article XI).
+
+---
+
+## 1. Command contributions
+
+Added to `contributes.commands[]`:
+
+| Command ID | Title | Handler file |
+|---|---|---|
+| `debrief.storyboard.forward` | `Storyboard: Forward` | `commands/storyboardTransport.ts#forward` |
+| `debrief.storyboard.backward` | `Storyboard: Backward` | `commands/storyboardTransport.ts#backward` |
+| `debrief.storyboard.clickScene` | *(hidden)* | `commands/storyboardTransport.ts#clickScene` |
+| `debrief.storyboard.jumpPast` | *(hidden)* | `commands/storyboardTransport.ts#jumpPast` |
+| `debrief.storyboard.editScene` | *(hidden)* | `commands/storyboardEditStub.ts#open` |
+| `debrief.storyboard.create` | `Storyboard: Create…` | `commands/storyboardManagement.ts#create` |
+| `debrief.storyboard.rename` | `Storyboard: Rename…` | `commands/storyboardManagement.ts#rename` |
+| `debrief.storyboard.delete` | `Storyboard: Delete…` | `commands/storyboardManagement.ts#delete` |
+| `debrief.storyboard.openPanel` | `Storyboard: Open Panel` | `views/storyboardPanelView.ts#reveal` |
+
+`*(hidden)*` commands omit `title` or use an internal-only title
+(VS Code hides them from the Command Palette via `command-palette`
+menu filter below).
+
+---
+
+## 2. `menus.commandPalette` filter
+
+```json
+{
+  "menus": {
+    "commandPalette": [
+      { "command": "debrief.storyboard.clickScene", "when": "false" },
+      { "command": "debrief.storyboard.jumpPast",   "when": "false" },
+      { "command": "debrief.storyboard.editScene",  "when": "false" },
+      { "command": "debrief.storyboard.forward",    "when": "debrief.storyboardActive" },
+      { "command": "debrief.storyboard.backward",   "when": "debrief.storyboardActive" }
+    ]
+  }
+}
+```
+
+`create` / `rename` / `delete` / `openPanel` are visible unconditionally
+in the palette (they are discoverable entry points).
+
+---
+
+## 3. Keybinding contributions
+
+Appended to `contributes.keybindings[]`:
+
+```json
+[
+  {
+    "command": "debrief.storyboard.forward",
+    "key": "right",
+    "when": "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"
+  },
+  {
+    "command": "debrief.storyboard.backward",
+    "key": "left",
+    "when": "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"
+  }
+]
+```
+
+No `mac` override — Left / Right arrows are the same key on all
+platforms, and the `when` clause guarantees scope.
+
+### `debrief.storyboardActive` context
+
+- Owner: `StoryboardPlaybackService`
+- Set `true` iff the service's current `TransportState` has
+  `sceneOrder.length > 0` (i.e. the active Storyboard contains at
+  least one Scene).
+- Cleared on plot-close, on dropdown-switch-to-null, on deletion of
+  the last Scene (empty active Storyboard), on deletion of the last
+  Storyboard, or on service dispose.
+- Set via `commands.executeCommand('setContext', 'debrief.storyboardActive', …)`.
+
+---
+
+## 4. Handler contracts
+
+### 4.1 `storyboardTransport.ts`
+
+```ts
+export function registerStoryboardTransportCommands(
+  context: vscode.ExtensionContext,
+  service: StoryboardPlaybackService,
+  sessionManager: SessionManager,
+): vscode.Disposable {
+  return vscode.Disposable.from(
+    vscode.commands.registerCommand('debrief.storyboard.forward', async () => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      await service.forward(documentUri);
+    }),
+
+    vscode.commands.registerCommand('debrief.storyboard.backward', async () => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      await service.backward(documentUri);
+    }),
+
+    vscode.commands.registerCommand('debrief.storyboard.clickScene', async (sceneId: string) => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri || typeof sceneId !== 'string') return;
+      await service.goToScene(documentUri, sceneId);
+    }),
+
+    vscode.commands.registerCommand('debrief.storyboard.jumpPast', async (payload: { blockedSceneId: string; direction: 'forward' | 'backward' }) => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      await service.resolveHardBlockByJumpingPast(documentUri, payload.blockedSceneId, payload.direction);
+    }),
+  );
+}
+```
+
+### 4.2 `storyboardManagement.ts`
+
+```ts
+export function registerStoryboardManagementCommands(
+  context: vscode.ExtensionContext,
+  service: StoryboardPlaybackService,
+  sessionManager: SessionManager,
+): vscode.Disposable {
+  return vscode.Disposable.from(
+    vscode.commands.registerCommand('debrief.storyboard.create', async () => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      const name = await vscode.window.showInputBox({
+        prompt: messages.createStoryboardPrompt,
+        validateInput: (value) => validateStoryboardName(value, service.getSnapshot(documentUri).storyboards),
+      });
+      if (!name) return;
+      await service.createStoryboard(documentUri, name);
+    }),
+
+    vscode.commands.registerCommand('debrief.storyboard.rename', async (targetId?: string) => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      const snapshot = service.getSnapshot(documentUri);
+      const storyboardId = targetId ?? snapshot.activeStoryboardId;
+      if (!storyboardId) return;
+      const current = snapshot.storyboards.find((s) => s.storyboardId === storyboardId);
+      if (!current) return;
+      const newName = await vscode.window.showInputBox({
+        prompt: messages.renameStoryboardPrompt,
+        value: current.name,
+        validateInput: (value) => validateStoryboardName(value, snapshot.storyboards, current.storyboardId),
+      });
+      if (!newName || newName === current.name) return;
+      await service.renameStoryboard(documentUri, storyboardId, newName);
+    }),
+
+    vscode.commands.registerCommand('debrief.storyboard.delete', async (targetId?: string) => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri) return;
+      const snapshot = service.getSnapshot(documentUri);
+      const storyboardId = targetId ?? snapshot.activeStoryboardId;
+      if (!storyboardId) return;
+      const target = snapshot.storyboards.find((s) => s.storyboardId === storyboardId);
+      if (!target) return;
+
+      if (target.sceneCount > 0) {
+        const choice = await vscode.window.showWarningMessage(
+          messages.deleteStoryboardConfirm(target.name, target.sceneCount),
+          { modal: true },
+          messages.deleteLabel,
+        );
+        if (choice !== messages.deleteLabel) return;
+      }
+      await service.deleteStoryboard(documentUri, storyboardId);
+    }),
+  );
+}
+```
+
+### 4.3 `storyboardEditStub.ts`
+
+```ts
+export function registerStoryboardEditStubCommand(
+  context: vscode.ExtensionContext,
+  sessionManager: SessionManager,
+  service: StoryboardPlaybackService,
+): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'debrief.storyboard.editScene',
+    (sceneId: string) => {
+      const documentUri = sessionManager.getActiveDocumentUri();
+      if (!documentUri || typeof sceneId !== 'string') return;
+      const snapshot = service.getSnapshot(documentUri);
+      const scene = snapshot.scenes.find((s) => s.sceneId === sceneId);
+      if (!scene) return;
+      void vscode.window.showInformationMessage(
+        messages.editSceneStub(scene.title, scene.timestampIso),
+      );
+    },
+  );
+}
+```
+
+Replaced by a full editor surface in #218.
+
+---
+
+## 5. `validateStoryboardName` helper
+
+```ts
+export function validateStoryboardName(
+  candidate: string,
+  existing: readonly StoryboardOptionViewModel[],
+  ignoreId?: string,
+): string | null {
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return messages.nameEmpty;
+  if (trimmed.length > 120)  return messages.nameTooLong;
+  const collision = existing.find(
+    (s) => s.name === trimmed && s.storyboardId !== ignoreId,
+  );
+  if (collision) return messages.nameInUse(trimmed);
+  return null;
+}
+```
+
+Inline-validation strings shown in VS Code's `showInputBox` — no modal
+rejection needed.
+
+---
+
+## 6. Testing contract
+
+| Test name | Asserts |
+|---|---|
+| `forward advances to next scene on happy path` | snapshot updates; `transitionId` briefly non-null; `timeFilter` clamped |
+| `forward is no-op at last scene` | snapshot unchanged; no `flyTo` call |
+| `forward is no-op during in-flight transition` | snapshot unchanged |
+| `forward surfaces hard-block modal when next scene has missing features` | `ModalPromptPort.showHardBlock` called; snapshot unchanged until resolution |
+| `backward mirrors forward` | same as forward, in reverse |
+| `clickScene triggers goToScene via command` | service.goToScene called with correct args |
+| `create → CRUD success → selection becomes the new Storyboard` | service.createStoryboard + snapshot change |
+| `rename → validateStoryboardName rejects duplicate` | showInputBox.validateInput returns the `messages.nameInUse` string; CRUD not invoked |
+| `delete empty Storyboard skips confirmation` | no showWarningMessage call; service.deleteStoryboard invoked |
+| `delete non-empty Storyboard requires confirmation` | showWarningMessage called; service invoked iff user clicks *Delete* |
+| `editScene stub surfaces details toast` | showInformationMessage called with title + DTG |

--- a/specs/217-storyboarding-playback/data-model.md
+++ b/specs/217-storyboarding-playback/data-model.md
@@ -1,0 +1,413 @@
+# Phase 1 — Data Model: Storyboarding — Panel + Playback
+
+**Feature**: 217-storyboarding-playback
+**Date**: 2026-04-21
+**Input**: `spec.md` (Key Entities section) + `plan.md` Technical Context + `research.md`
+
+> **Scope note.** This slice **adds no schema**. All persisted entities
+> (`Storyboard`, `Scene`, `Viewport`) are already defined in #215 via
+> LinkML and generated into `@debrief/schemas`. This document catalogues
+> the **transient, in-memory types** this slice introduces: transport
+> state, view-models crossing the webview boundary, and the
+> extension-service state machine.
+
+---
+
+## 1. Persisted entities (inherited — see #215)
+
+This slice **reads**:
+
+| Entity | Source | Consumed slots |
+|---|---|---|
+| `StoryboardFeature.properties` | `@debrief/schemas` | `id`, `name`, `description`, `provenance[last].timestamp` (= last_modified_at) |
+| `SceneFeature.properties` | `@debrief/schemas` | `id`, `storyboard_id`, `title`, `timestamp`, `viewport`, `visible_feature_ids`, `feature_set_hash`, `transition_duration_ms`, `thumbnail_asset_ref` |
+| `Viewport` | `@debrief/schemas` | `center`, `zoom`, `corners` (Polygon) — used by `flyTo` and `SceneRectangleLayer` |
+
+This slice **writes**, via the #215 CRUD module only:
+
+| Op | Entity | CRUD function |
+|---|---|---|
+| Create Storyboard | `StoryboardFeature` | `createStoryboard(plot, { name, description, actor })` |
+| Rename Storyboard | `StoryboardFeature` | `renameStoryboard(plot, { storyboardId, newName, actor })` |
+| Delete Storyboard (cascades to Scenes) | `StoryboardFeature` + all child `SceneFeature`s | `deleteStoryboard(plot, { storyboardId, actor })` |
+
+No Scene-level writes. No schema edits.
+
+---
+
+## 2. Transport state (in-extension, service-owned)
+
+Lives exclusively inside `StoryboardPlaybackService`. Never persisted,
+never serialised across the webview boundary in full — only the
+**view-model projection** (§3) crosses to the panel.
+
+```ts
+/**
+ * Per-plot transport state. The service holds one of these per
+ * plot currently open in a VS Code session, keyed by `documentUri`
+ * (the STAC URI string that `SessionManager` uses as its session key).
+ */
+export interface TransportState {
+  /** Document URI (STAC URI) — key for the per-plot map. */
+  readonly documentUri: string;
+
+  /** Current active Storyboard; `null` when plot has no Storyboards. */
+  readonly activeStoryboardId: string | null;
+
+  /** Ordered list of Scene ids for the active Storyboard (ascending timestamp). */
+  readonly sceneOrder: ReadonlyArray<string>;
+
+  /** Index into `sceneOrder`; `-1` when `sceneOrder` is empty. */
+  readonly currentSceneIndex: number;
+
+  /** Monotonically-increasing id of the in-flight transition; `null` when idle. */
+  readonly transitionId: number | null;
+
+  /**
+   * Whether the scrubbable range was narrowed by this service on activation.
+   * On deactivation, the service calls
+   * `TimeRangeViewProvider.setScrubbableRange(null, null)` to restore the
+   * default (full-extent) scrubbable range. No session-state field is
+   * overwritten — the override is purely view-provider-side state (see R2).
+   */
+  readonly scrubbableOverrideActive: boolean;
+
+  /** Whether the plot passed `validatePlot` on open. If false, transport
+   *  is disabled and the service surfaces a single error toast. */
+  readonly plotValid: boolean;
+}
+```
+
+### State-transition rules
+
+| Trigger | Precondition | Effect |
+|---|---|---|
+| Plot open | `documentUri` not in the per-plot map | Run `validatePlot(plot)`; if it throws, set `plotValid = false`, surface a single error toast, and skip the rest. Otherwise: seed `activeStoryboardId` from `getMostRecentlyModifiedStoryboard(plot)` (new #215 query); compute `sceneOrder = listScenesOrdered(plot, activeStoryboardId)`; `currentSceneIndex = sceneOrder.length > 0 ? 0 : -1`; call `timeRangeView.setScrubbableRange(...)` to apply the Scene-window clamp (sets `scrubbableOverrideActive = true`); set `debrief.storyboardActive` iff `currentSceneIndex >= 0`. |
+| Plot close | `documentUri` in the map | Call `timeRangeView.setScrubbableRange(null, null)` to restore default scrubbable range; clear `debrief.storyboardActive`; remove entry. |
+| Dropdown switch to storyboard X | `X` present in plot | `activeStoryboardId = X`; recompute `sceneOrder`; `currentSceneIndex = sceneOrder.length > 0 ? 0 : -1`; recompute scrub window via `setScrubbableRange`. |
+| Forward | `currentSceneIndex < sceneOrder.length - 1` AND `transitionId === null` AND hard-block check passes | `currentSceneIndex += 1`; `transitionId = next()`; recompute scrub window; fire animation. |
+| Backward | `currentSceneIndex > 0` AND `transitionId === null` AND hard-block check passes | `currentSceneIndex -= 1`; `transitionId = next()`; recompute scrub window; fire animation. |
+| Click Scene row / rectangle | target index differs from current AND `transitionId === null` AND hard-block check passes | `currentSceneIndex = target`; fire animation. |
+| Scrub starts while `transitionId !== null` | — | Cancel animation; `transitionId = null`. |
+| **Transition clear (any of three)** | `transitionId === T`; clear triggered by `moveend`, `onDidChangeVisibility(false)`, or `durationMs+250ms` safety timer | `transitionId = null`; emit snapshot with `transport.transitionInFlight = false`. Idempotent — later triggers with the same token are no-ops. |
+| **CRUD op (create/rename/delete)** during `transitionId !== null` | — | Reject with no side effect (same policy as transport-vs-transport). Panel's overflow buttons are disabled via `transport.transitionInFlight`. |
+| Hard-block resolved → Jump past | blocked Scene N, from direction D | `currentSceneIndex = N + 1` (if Forward) or `N - 1` (if Backward); skip the blocked Scene. |
+| Hard-block resolved → Open for editing (stubbed) | blocked Scene N | Surface read-only Scene details via `showInformationMessage`; leave `currentSceneIndex` unchanged. |
+| External plot refresh (features changed) | plot features mutated outside the service (via `MapPanel.onFeaturesChanged` — new event, arch-fix 2) | Recompute `sceneOrder` for current `activeStoryboardId`; if `activeStoryboardId` was deleted, fall back to `getMostRecentlyModifiedStoryboard(plot)`; if no Storyboards remain, `activeStoryboardId = null`, clear context + scrubbable override. |
+
+### Invariants
+
+- `-1 <= currentSceneIndex < sceneOrder.length`
+- `currentSceneIndex === -1` iff `sceneOrder.length === 0`
+- `transitionId !== null` implies an in-flight `flyTo` + slider tween
+- Scrubbable-range override is applied iff
+  `scrubbableOverrideActive === true`; cleared on plot-close /
+  dropdown-switch-to-null / empty-Storyboard / service.dispose.
+- `plotValid === false` implies transport + CRUD ops are all no-ops
+  for this plot until it is re-opened (validatePlot gate —
+  design-fix 2).
+
+### Concurrency model
+
+- Transport commands (Forward / Backward / click) are idempotent when
+  `transitionId !== null` (i.e. during a transition): the command is
+  dropped with no side effect, no error, no toast (matches spec
+  "transport buttons and arrow keys MUST be disabled during an in-
+  flight transition" — FR-PLAY-009).
+- **Storyboard CRUD ops (Create / Rename / Delete) are also rejected**
+  during an in-flight transition (same single-flight policy — R9).
+  Panel overflow buttons are disabled via
+  `transport.transitionInFlight`.
+- Scrub-cancel wins a race against the animation tick by clearing
+  `transitionId` under a service-side mutex; the animation's final
+  frame check sees `null` and exits without writing the target state.
+- **Three independent transition-clear triggers** keep `transitionId`
+  from getting stuck (R8):
+  1. Leaflet `moveend` via `MapPanel.onFlyToComplete` (primary).
+  2. `webviewView.onDidChangeVisibility(false)` on the Storyboard
+     panel (hidden / tab switched).
+  3. `setTimeout(durationMs + 250ms)` safety timer.
+  Whichever fires first clears; later triggers with the same token
+  are no-ops.
+
+---
+
+## 3. View-models (cross the webview boundary)
+
+These are the `postMessage` payload shapes. Every field is a
+transport-safe primitive (JSON-serialisable, no class instances, no
+functions). See `contracts/storyboard-panel-messages.md` for the
+discriminated union.
+
+```ts
+/**
+ * #216's `SceneRowViewModel` is unchanged by this slice. Missing-data
+ * classification happens only at step-onto time inside the service
+ * (design-fix 1) — rows do not carry a `blocked` state. Keeping the
+ * row shape stable means #216's existing tests compile unchanged.
+ */
+export interface SceneRowViewModel {
+  readonly sceneId: string;
+  readonly title: string;
+  readonly timestampIso: string;
+  readonly dtgLabel: string;          // formatted by #215's formatDtg
+  readonly thumbnailHref: string;     // webview URI
+  readonly state:
+    | { readonly kind: 'ok' }
+    | { readonly kind: 'pending' };
+}
+
+/**
+ * NEW. Header dropdown item.
+ */
+export interface StoryboardOptionViewModel {
+  readonly storyboardId: string;
+  readonly name: string;
+  readonly sceneCount: number;        // informational only; spec does not require it
+  readonly lastModifiedIso: string;   // used for default-selection ordering
+}
+
+/**
+ * NEW. Transport row state.
+ */
+export interface TransportViewModel {
+  readonly canGoBackward: boolean;    // false at first Scene or during transition
+  readonly canGoForward: boolean;     // false at last Scene or during transition
+  readonly sceneNumber: number;       // 1-based; 0 when empty Storyboard
+  readonly sceneTotal: number;        // total Scene count in active Storyboard
+  readonly transitionInFlight: boolean;
+}
+
+/**
+ * NEW. Missing-data reason surface (serialisable representation of
+ * #215's `MissingDataClassification`). Used by the hard-block modal's
+ * body (real VS Code `showInformationMessage` in the extension; mirrored
+ * by the Storybook-only `HardBlockModal` component for copy review).
+ *
+ * Not used as a row state — rows stay in `ok` / `pending` only; the
+ * classification runs at step-onto time inside the service, not at
+ * snapshot-emit time (design-fix 1).
+ */
+export type MissingDataReason =
+  | { readonly kind: 'missing-features'; readonly missingIds: ReadonlyArray<string> }
+  | { readonly kind: 'out-of-range' };
+```
+
+### Parent panel props
+
+All new fields are **optional** with sensible defaults, so every
+existing `StoryboardPanelProps` test from #216 compiles and passes
+unchanged (design-fix 3). When the new fields are omitted, the panel
+renders in its #216 shape — dropdown / overflow / transport controls
+are simply not shown.
+
+```ts
+export interface StoryboardPanelProps {
+  // ── Inherited from #216 (required, unchanged) ─────────────────────
+
+  /** Ordered by `timestampIso` ascending. Empty when no active Storyboard has Scenes. */
+  readonly scenes: readonly SceneRowViewModel[];
+
+  /** Header label — null signals the "no Storyboards yet" empty state. */
+  readonly activeStoryboardName: string | null;
+
+  /** Drives the pending row. */
+  readonly captureInFlight: boolean;
+
+  /** Capture button click. */
+  onCaptureClick(): void;
+
+  /** Scene row click; this slice wires it to the playback service. */
+  onSceneRowClick(sceneId: string): void;
+
+  // ── NEW for #217 — all optional with defaults ─────────────────────
+
+  /** Populates the dropdown. Default: `[]` — dropdown hidden. */
+  readonly storyboards?: readonly StoryboardOptionViewModel[];
+
+  /** Drives dropdown selection. Default: `null` — dropdown hidden. */
+  readonly activeStoryboardId?: string | null;
+
+  /** Drives the current-Scene highlight. Default: `null` — no highlight. */
+  readonly currentSceneId?: string | null;
+
+  /** Drives the transport row. Default: `undefined` — transport row hidden. */
+  readonly transport?: TransportViewModel;
+
+  /** Dropdown change. Default: no-op — dropdown still renders disabled if provided without a callback. */
+  onActiveStoryboardChange?(storyboardId: string): void;
+
+  /** Overflow menu actions (service delegates to #215 CRUD).
+   *  Any omitted callback hides the corresponding menu item. */
+  onCreateStoryboard?(): void;
+  onRenameStoryboard?(storyboardId: string): void;
+  onDeleteStoryboard?(storyboardId: string): void;
+
+  /** Transport buttons. Omitted callbacks render the buttons disabled. */
+  onTransportForward?(): void;
+  onTransportBackward?(): void;
+}
+```
+
+**Rendering rules for optional props**:
+- If `storyboards` is missing or empty → no dropdown renders; the
+  header shows only `activeStoryboardName` as a static label
+  (matches #216).
+- If `transport` is missing → transport row not rendered.
+- If `currentSceneId` is missing or null → no row gets the highlight
+  style.
+- If any overflow-menu callback is omitted → that menu item is hidden.
+  This lets Storybook stories and reduced hosts surface only a
+  subset of controls.
+
+### HardBlockModal presentational component (Storybook only)
+
+```ts
+export interface HardBlockModalProps {
+  readonly sceneTitle: string;
+  readonly reason: MissingDataReason;
+
+  /** Labels kept on the props for translation. */
+  readonly jumpPastLabel: string;
+  readonly openForEditingLabel: string;
+
+  onJumpPast(): void;
+  onOpenForEditing(): void;
+  onDismiss(): void;
+}
+```
+
+> The real modal uses `vscode.window.showInformationMessage` (R3).
+> The presentational `HardBlockModal` exists for Storybook demos +
+> visual / copy review only.
+
+---
+
+## 4. SceneRectangleLayer — render-only entity
+
+A presentational React component rendered inside `MapView`. Carries no
+persisted state.
+
+```ts
+export interface SceneRectangleLayerProps {
+  /**
+   * All Scene Features for the active Storyboard. The layer renders
+   * one `<Polygon>` per Scene using `scene.properties.viewport` (the
+   * 4-corner ViewportPolygon).
+   */
+  readonly scenes: ReadonlyArray<SceneFeature>;
+
+  /**
+   * Scopes rendering. Caller passes only the active Storyboard's
+   * Scenes; if this is `null`, the layer renders nothing.
+   * Defence-in-depth: enforces FR-PLAY-016 at the prop boundary.
+   */
+  readonly activeStoryboardId: string | null;
+
+  /** Currently-highlighted Scene id. The layer draws a slightly stronger
+   *  outline on this rectangle if provided. */
+  readonly currentSceneId: string | null;
+
+  /**
+   * Invoked on rectangle click with the clicked Scene's id (which
+   * always matches one of the Scenes in `scenes`). The caller (the
+   * playback service via `MapPanel`) decides the transport action.
+   */
+  onSceneRectangleClick(sceneId: string): void;
+}
+```
+
+### Rendering rules (FR-PLAY-015 / FR-PLAY-016 / FR-PLAY-018)
+
+- If `activeStoryboardId === null` OR `scenes.length === 0`: render
+  nothing.
+- Otherwise render one `<Polygon>` per Scene with:
+  - `positions` derived from `scene.geometry.coordinates` (the
+    GeoJSON Polygon written by #215's `viewportToPolygon` at capture
+    time; best-effort on antimeridian — see R5). **Not**
+    `scene.properties.viewport.corners` — `Viewport` is
+    `{center, zoom, bearing}` only (Fix D).
+  - `pathOptions.weight = scene.properties.id === currentSceneId ? 2 : 1`
+  - `pathOptions.opacity = 0.6 - 0.1 * overlapRank` (clamped ≥ 0.3)
+    where `overlapRank` is the 0-based index of this Scene among
+    overlapping rectangles at the same centroid (stable sort by
+    `timestamp`).
+  - Click handler fires `onSceneRectangleClick(scene.properties.id)`;
+    topmost (last-rendered) polygon captures the click.
+- The parent Storyboard Feature is **never** rendered as a rectangle
+  (FR-PLAY-015 — panel-only entity).
+
+### Interaction with the main GeoJSON layer
+
+- The main `MapView` GeoJSON layer already renders `StoryboardFeature`
+  and `SceneFeature` if left un-filtered. The MapView's GeoJSON
+  `filter` prop is extended in this slice to **exclude** both kinds
+  (Storyboard never renders; Scenes render via `SceneRectangleLayer`).
+  This keeps the "no Scene rectangles for non-active Storyboards"
+  invariant at the only render surface.
+
+---
+
+## 5. Playback service — public state projection
+
+The service exposes a small observable surface for the panel and the
+map to subscribe to. It does **not** expose `TransportState` directly;
+consumers get pre-projected view-models.
+
+```ts
+export interface StoryboardPlaybackSnapshot {
+  readonly documentUri: string;
+  readonly storyboards: readonly StoryboardOptionViewModel[];
+  readonly scenes: readonly SceneRowViewModel[];
+  readonly activeStoryboardId: string | null;
+  readonly currentSceneId: string | null;
+  readonly transport: TransportViewModel;
+}
+
+export interface StoryboardPlaybackService {
+  getSnapshot(documentUri: string): StoryboardPlaybackSnapshot;
+
+  onSnapshotChange(listener: (snap: StoryboardPlaybackSnapshot) => void): Disposable;
+
+  /** Called by the panel webview's postMessage bridge. */
+  forward(documentUri: string): Promise<void>;
+  backward(documentUri: string): Promise<void>;
+  goToScene(documentUri: string, sceneId: string): Promise<void>;
+  setActiveStoryboard(documentUri: string, storyboardId: string): void;
+
+  /** Storyboard CRUD — delegates to #215. Rejected with no side effect
+   *  if a transition is in flight for this documentUri (R9). */
+  createStoryboard(documentUri: string, name: string, description?: string): Promise<void>;
+  renameStoryboard(documentUri: string, storyboardId: string, newName: string): Promise<void>;
+  deleteStoryboard(documentUri: string, storyboardId: string): Promise<void>;
+
+  /** Lifecycle. */
+  onPlotOpened(documentUri: string): void;          // runs validatePlot, seeds active
+  onPlotClosed(documentUri: string): void;          // clears scrub override + context
+  onPlotFeaturesChanged(documentUri: string): void; // recomputes sceneOrder; falls back if active deleted
+
+  dispose(): void;
+}
+```
+
+Full signatures + error vocabulary in
+`contracts/playback-service.md`.
+
+---
+
+## 6. Type catalogue summary
+
+| Type | File | Persisted? | Crosses webview? |
+|---|---|---|---|
+| `TransportState` | `apps/vscode/src/services/storyboardPlayback.ts` | No | No |
+| `SceneRowViewModel` | `shared/components/src/panels/StoryboardPanel/types.ts` (edit) | No | Yes |
+| `StoryboardOptionViewModel` | same file (new) | No | Yes |
+| `TransportViewModel` | same file (new) | No | Yes |
+| `MissingDataReason` | same file (new) | No | Yes |
+| `StoryboardPanelProps` | same file (edit) | No | Via message projection |
+| `HardBlockModalProps` | `shared/components/src/panels/StoryboardPanel/HardBlockModal.tsx` (new) | No | Storybook only |
+| `SceneRectangleLayerProps` | `shared/components/src/MapView/SceneRectangleLayer.tsx` (new) | No | No |
+| `StoryboardPlaybackSnapshot` | `apps/vscode/src/services/storyboardPlayback.ts` | No | Via message projection |
+
+**No LinkML edits. No `@debrief/schemas` regeneration. No fixtures
+added.**

--- a/specs/217-storyboarding-playback/media/linkedin-planning.md
+++ b/specs/217-storyboarding-playback/media/linkedin-planning.md
@@ -1,0 +1,11 @@
+An analyst has twelve Scenes captured from a three-week exercise, walks into a briefing room, opens the plot, and presses Forward. The map flies to the first viewport while the time slider tweens to the right instant. The stakeholder watches the story; the analyst isn't scrubbing and zooming in front of them.
+
+That's the shape of the next Future Debrief slice (#217): the Storyboard panel, transport controls, scoped Left/Right keys, on-map Scene rectangles, and a native modal that hard-blocks playback if a Scene's underlying feature no longer exists.
+
+What makes the planning interesting is how much of it is orchestration. The CRUD core came with #215. Capture came with #216. #217 adds no new schema, no new runtime dependencies, no Python. Two animations — Leaflet `flyTo` and an RAF tween on the time slider — share a `transitionId` so a mid-flight scrub cancels both cleanly. The scrub window reuses the existing `timeFilter` slot instead of adding a new one.
+
+Three questions we'd value outside perspectives on — scrub-window lock vs snap-back, whether flyTo stays welcome at the twelfth transition, and how busy Scene rectangles should get — are in the post:
+
+{{POST_URL}}
+
+#FutureDebrief #MaritimeAnalysis #OpenSource

--- a/specs/217-storyboarding-playback/media/planning-post.md
+++ b/specs/217-storyboarding-playback/media/planning-post.md
@@ -1,0 +1,52 @@
+---
+layout: future-post
+title: "Planning: Storyboarding — Panel + Playback"
+date: 2026-04-21
+track: [momentum]
+author: Ian
+reading_time: 5
+tags: [tracer-bullet, storyboarding, vscode-extension, playback]
+excerpt: "The slice that turns captured Scenes into a stakeholder briefing — Forward, Backward, and the plot walking itself through the story."
+---
+
+## What We're Building
+
+Imagine an analyst walks into a room to brief a senior stakeholder on an exercise that ran for three weeks. The interesting moments are already captured — back at their desk, they watched the tracks develop and pressed `Ctrl/Cmd+Alt+C` every time something mattered. A dozen Scenes, each one a frozen viewport, time, and set of visible tracks, all attached to the plot.
+
+What #217 adds is the part where the plot walks itself through those Scenes.
+
+They open the plot in the Map Viewer. The Storyboard panel shows "Commander's view — 12 Scenes". They press Forward. The map flies to Scene 1's viewport while the time slider tweens to Scene 1's instant. The stakeholder is watching the transition, not waiting for the analyst to zoom and scrub. Forward again. Forward again. Halfway through, a question — the analyst drags the time slider to look at what happened between Scene 5 and Scene 6, then hits Forward and they're back on the rails.
+
+That's the shape of this slice. A header dropdown for picking among the plot's Storyboards. A transport row with Forward / Backward / "Scene N of M". Scoped Left / Right arrow keys that only fire when the analyst's focus is somewhere sensible. Faint rectangles on the map showing the captured viewports. And, underneath, enough machinery to make the transitions look like a briefing tool rather than a debugger.
+
+## How It Fits
+
+Storyboarding (#024) is a four-slice epic. #215 landed the headless schema and CRUD core — shapes, ordering, canonicalisation, missing-data detection. #216 landed capture — one keystroke to freeze a moment as a Scene. #217 (this one) is the delivery flow: the part an analyst actually shows to an audience. #218, which comes after, handles Scene editing, rename, delete, undo, thumbnail refresh, and full Analysis Log integration.
+
+The scope boundary matters. You cannot rename a Scene in this slice. You cannot reorder them. You cannot refresh a stale thumbnail. The *Open for editing* button in the missing-data hard-block modal is wired to a stub that acknowledges the click and does nothing else — #218 will pick it up. Pulling any of that forward would blur the briefing-delivery story that this slice has to tell cleanly.
+
+## Key Decisions
+
+**No new schema. No new runtime dependencies. No Python additions.** Everything in #217 rides on pieces already shipped — the CRUD module from #215, the capture flow and panel shell from #216, session-state, MapView, react-leaflet, the VS Code extension API. The whole slice is orchestration. If it feels like there's less engineering here than there should be, that's the payoff from landing #215 and #216 in the right order.
+
+**Two independent animations, one imperative entrypoint.** On Forward, the service calls `advanceTo(scene, durationMs)`, which fans out to Leaflet's `flyTo` for the map and a `requestAnimationFrame` tween on the time slider's `currentTime`. A shared `transitionId` correlates the pair so that if the analyst starts scrubbing mid-flight, both animations cancel at the frame they're on. 500 ms default, per-Scene overrideable. No animation library — the browser already has two.
+
+**The scrub window reuses the existing `timeFilter` slot.** While positioned on Scene N, the time slider is clamped to `[Scene[N].t, Scene[N+1].t]`. No new slice on `TemporalSlice`, no new widget — the service captures the pre-activation `timeFilter`, applies the clamp during playback, and restores the original on deactivation. Last Scene has no upper bound, so scrubbing past its timestamp is simply disabled.
+
+**The missing-data check hard-blocks.** Before advancing onto a Scene, the service calls `detectMissingDataForScene` from #215. If a feature the Scene references has been deleted, or the Scene's timestamp is now outside the plot's time range, transport stops and a native VS Code modal offers *Jump past this scene* / *Open for editing*. No partial animation, no silent fallback. A half-rendered Scene in front of an audience is worse than a visible interruption.
+
+**Scoped keys, not global keys.** `Left` and `Right` only bind when `debrief.storyboardActive` is true AND focus is on either the Storyboard panel or the Map Viewer. The service manages the `when`-context flag. No arrow-key leakage into the editor, the terminal, or any other panel — something we've seen bite other extensions.
+
+**Active Storyboard selection is ephemeral.** A plot can carry several Storyboards — a commander's view, an ASW evidence thread, a training debrief. The active selection per plot lives in extension memory, keyed by the STAC `documentUri` that `SessionManager` already uses. On plot open, it defaults to the most-recently-modified Storyboard via a new `getMostRecentlyModifiedStoryboard` query we're adding to the #215 CRUD module. Nothing writes to disk. Nothing for #218 to migrate.
+
+## What We'd Love Feedback On
+
+Three open questions where we'd genuinely benefit from perspectives outside the team:
+
+- **Scrub-window lock behaviour.** When the analyst is on Scene 5 and drags the slider to Scene 6's timestamp, should the slider hard-clamp at Scene 6 and require a Forward press, or snap back to Scene 5's window on release? The hard-clamp is more predictable; the snap-back preserves the "one scene at a time" mental model more loudly. We've picked hard-clamp for now, but we're not sure.
+
+- **flyTo animation for briefing audiences.** 500 ms of smooth map motion looks polished in a demo. Does it also look polished at the twelfth transition of a twenty-Scene briefing, or does the audience start wanting an instant cut? Is there a regime — maybe transitions under a certain map-distance — where the fly should be swapped for a direct jump?
+
+- **Overlapping Scene rectangles.** We're rendering viewport rectangles for the active Storyboard, with opacity variation where they overlap. For a Storyboard that revisits the same area across many Scenes, the overlay can get busy. Is the right default "always show rectangles", "show on hover/focus", or "toggle in the panel header"?
+
+→ [Join the discussion]({{DISCUSSION_URL}})

--- a/specs/217-storyboarding-playback/plan.md
+++ b/specs/217-storyboarding-playback/plan.md
@@ -1,0 +1,485 @@
+# Implementation Plan: Storyboarding — Panel + Playback
+
+**Branch**: `217-storyboarding-playback` | **Date**: 2026-04-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/217-storyboarding-playback/spec.md`
+
+## Summary
+
+Ship the **briefing-delivery flow** for the Storyboarding epic (#024) as a
+VS Code extension slice that turns the minimal Scene list shipped by
+#216 into a full **Storyboard panel + playback transport**. Three new
+pieces of UI surface + two existing modules carry the load:
+
+1. **Storyboard panel upgrade** (`shared/components/src/panels/StoryboardPanel/`) —
+   add a **header dropdown** listing all Storyboards, an **overflow
+   menu** (Create / Rename / Delete), a **transport row** (Forward /
+   Backward buttons, current-Scene counter), and **on-row transport
+   highlight**. The existing presentational props model is extended
+   with `storyboards[]`, `activeStoryboardId`, `currentSceneId`, and
+   transport callbacks — no VS Code imports enter the headless path.
+2. **Map flyTo + Scene rectangle layer** (`shared/components/src/MapView/`) —
+   extend `MapView` with an imperative `flyTo(target, durationMs)`
+   (wraps Leaflet `L.Map.flyTo`) and a new presentational
+   `SceneRectangleLayer` that renders the active Storyboard's Scene
+   viewport Polygons as faint rectangles. The layer is scoped by a
+   new `activeStoryboardId` prop; non-active Storyboards' rectangles
+   never render.
+3. **Playback orchestration** (`apps/vscode/src/services/storyboardPlayback.ts`) —
+   a new extension-side service that owns the transport state
+   machine: which Scene is current, whether a transition is in
+   flight, and the scrub window bounds. It coordinates three existing
+   surfaces: `@debrief/components/storyboard` (queries + missing-data
+   detection), the session-state `TemporalSlice` (currentTime tween +
+   timeFilter-based scrub lock), and the `MapPanel` (`flyTo` on the
+   map, `setSceneRectangles` for the overlay). Transport is driven by
+   new VS Code commands (`debrief.storyboard.forward`, `.backward`,
+   `.clickScene`) bound to scoped `Left` / `Right` keybindings with
+   `when: "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"`.
+4. **Missing-data hard-block** is implemented at the orchestration
+   layer: before every advance, the service calls #215's
+   `detectMissingDataForScene`; on any non-`ok` classification the
+   service surfaces a modal with **Jump past this scene** /
+   **Open for editing** actions. The latter action is wired to a
+   stub command (`debrief.storyboard.editScene`) that #218 will
+   replace; until then the action opens a read-only details toast.
+5. **Ephemeral active-Storyboard selection** lives in extension
+   memory only (per-session map from `documentUri` →
+   `activeStoryboardId`); on plot open the service calls a new
+   `getMostRecentlyModifiedStoryboard(plot)` query — added to #215's
+   `shared/components/src/storyboard/queries.ts` by this slice — which
+   scans each Storyboard's `provenance[last].timestamp` and returns
+   the maximum. The existing `getActiveStoryboardDefault` (first by
+   name ascending) is kept for other consumers. No schema additions.
+
+After this slice merges, an analyst with Scenes captured via #216 can
+walk a stakeholder through a briefing end-to-end inside the Map
+Viewer — forward/backward by button or scoped arrow key, scrub inside
+the current segment, click rectangles to jump, switch between multiple
+Storyboards on the same plot, and have unresolved Scenes hard-block
+with clear remediation options.
+
+Scene editing (rename, description, delete+undo, update-to-current,
+duplicate, copy-to-other) remains deferred to #218. This slice
+creates & deletes **Storyboards** (via the overflow menu) but does
+not create / update / delete **Scenes**.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode) for the VS Code
+extension path, the webview (React 18.x), and the `shared/components`
+library additions. No Python additions in this slice — all Pydantic /
+LinkML work landed in #215.
+
+**Primary Dependencies** (all already in the monorepo — **no new
+runtime dependencies**):
+
+- `@debrief/components/storyboard` — `listScenesOrdered`,
+  `getStoryboard`, `getScene`, `detectMissingDataForScene`,
+  `validatePlot`, `createStoryboard`, `renameStoryboard`,
+  `deleteStoryboard`, `formatDtg` (all shipped by #215), plus the
+  **new** `getMostRecentlyModifiedStoryboard` query added to #215's
+  queries module by this slice (~10 LOC).
+- `@debrief/components` — the existing `StoryboardPanel` (#216),
+  `MapView` (extended here with `flyTo` + `SceneRectangleLayer`), the
+  `ThemeProvider` tokens, `vscrui` icons used by every panel.
+- `@debrief/session-state` — `SessionStoreApi.getState()`,
+  `setCurrentTime`, `onActiveSessionChange`. **Note**: the scrub-
+  window lock is **not** implemented via `setTimeFilter` (that slot
+  drives STAC-catalog browsing, not the time scrubber) — it is
+  implemented at the view-provider layer by narrowing the scrubbable
+  `start`/`end` pair while preserving `dataStart`/`dataEnd` (see
+  research.md R2). Playback state slice (`playbackState`,
+  `displayMode`) introduced by #205 is **not touched** here.
+- `@debrief/schemas` — generated `StoryboardFeature`, `SceneFeature`,
+  `Viewport`, `ViewportPolygon` types.
+- `leaflet` / `react-leaflet` (already a peer in `shared/components`) —
+  `L.Map.flyTo`, `L.GeoJSON` / `Polygon` for Scene rectangles.
+  `SceneRectangleLayer` renders each Scene's `scene.geometry.coordinates`
+  (a GeoJSON Polygon populated by #215's `viewportToPolygon` at
+  capture time); the `Viewport` record itself (`{center, zoom,
+  bearing}`) is **not** the rectangle geometry source.
+- VS Code Extension API ^1.85.0 — `commands.registerCommand`,
+  `commands.executeCommand('setContext', …)`,
+  `window.showInformationMessage(…, { modal: true })`,
+  `WebviewView.onDidChangeVisibility`,
+  `window.showInputBox` (Create / Rename).
+
+**Storage**: No new persisted surfaces. Storyboard + Scene Features
+still round-trip as plain GeoJSON Features inside the plot
+FeatureCollection (schema shipped by #215). The **active-Storyboard
+selection is ephemeral** — held in extension memory (keyed by
+`documentUri`, the same key `SessionManager` uses) and recomputed on
+plot-open via the new `getMostRecentlyModifiedStoryboard(plot)` query
+added to #215. Scene rectangles are rendered at draw time from the
+plot FeatureCollection; they are **not** stored as a derived layer.
+
+**Testing**:
+
+- `shared/components/src/panels/StoryboardPanel/__tests__/*.test.tsx` —
+  extend existing suite with dropdown, overflow menu, transport row,
+  current-Scene highlight (vitest + @testing-library/react).
+- `shared/components/src/panels/StoryboardPanel/*.stories.tsx` —
+  extend with `WithMultipleStoryboards`, `Transport`, `HardBlockModal`
+  stories (Storybook, exercised by Playwright under light / dark /
+  vscode themes).
+- `shared/components/src/MapView/__tests__/SceneRectangleLayer.test.tsx` —
+  **NEW**; verifies rectangles render only for active Storyboard,
+  opacity variation on overlap, click-to-select fires `onSceneClick`,
+  antimeridian-crossing viewport rendered as best-effort Polygon.
+- `shared/components/src/MapView/__tests__/flyTo.test.tsx` — **NEW**;
+  verifies the imperative `flyTo` triggers `L.Map.flyTo` with the
+  correct duration + ease-in-out, and that starting a scrub during
+  flight cancels the animation at its current frame.
+- `apps/vscode/src/services/__tests__/storyboardPlayback.test.ts` —
+  **NEW**; unit tests for the transport state machine — forward /
+  backward at boundaries, scrub-window recompute on step + dropdown
+  switch, hard-block on missing data (features + out-of-range),
+  click-to-select via map rectangle, multi-Storyboard switching,
+  external deletion fallback. **Plus** (from review):
+  - `validatePlot` gate on plot-open — corrupt fixture (orphan scene
+    or duplicate timestamp) surfaces a single error toast and disables
+    transport for that plot.
+  - CRUD-during-flight guard — Delete/Rename/Create ops during a
+    non-null `transitionId` either cancel the transition first, or
+    are rejected with no side effect (pick one; test both branches
+    of the chosen policy).
+  - Visibility cancel — service listens to
+    `webviewView.onDidChangeVisibility`; when hidden, any in-flight
+    `transitionId` is cleared.
+  - `onFlyToComplete` timeout fallback — if Leaflet's `moveend` does
+    not fire within `durationMs + 250ms`, the safety timer clears
+    `transitionId` and emits completion.
+  - Plot-switch mid-transition — switching VS Code tab during flight
+    cancels the departing plot's transition; new plot starts fresh.
+  - ISO/epoch conversion at the `detectMissingDataForScene` boundary
+    — service receives `timeRange: { start: number; end: number }`
+    (epoch ms) from `TemporalSlice` and converts to
+    `{ start: string; end: string }` (ISO-8601) before calling #215.
+    Test with `NaN`-bearing input to ensure graceful handling.
+  - `setScrubbableRange` restoration — on `service.dispose()`, the
+    service calls `TimeRangeViewProvider.setScrubbableRange(null)`
+    restoring the default (full-extent) scrubber range.
+- `apps/vscode/src/commands/__tests__/storyboardCommands.test.ts` —
+  **NEW**; unit tests for the new command handlers (forward,
+  backward, clickScene, createStoryboard, renameStoryboard,
+  deleteStoryboard, jumpPast, editScene stub).
+- `shared/components/src/storyboard/__tests__/queries.test.ts` —
+  **EDIT** to cover the new `getMostRecentlyModifiedStoryboard`
+  query: single Storyboard, multiple Storyboards with differing
+  `provenance[last].timestamp`, empty plot returns `null`, ties
+  broken by ULID (deterministic fallback).
+- `tests/e2e/test-storyboard-playback.spec.ts` — **NEW**; Playwright
+  E2E driving the code-server preview app through the full forward-
+  through-a-storyboard loop (open plot → open panel → switch
+  dropdown → press Forward × N → scrub → hard-block modal → jump
+  past → reach last Scene → press Backward × N). Follows the
+  existing webview-E2E patterns (`docs/e2e-testing-guide.md`).
+
+**Target Platform**: VS Code extension host (Node 20+) for the
+orchestration + command handlers; evergreen Chromium (the VS Code
+webview runtime) for the Storyboard panel React component and the
+`MapView` extensions. Code-server as a first-class host for E2E
+verification. **Offline** — Article I applies; no network calls in
+the playback path.
+
+**Project Type**: Single-project monorepo extension. Code lands in
+existing workspaces — `apps/vscode/` (new service + commands +
+mapPanel extensions), `shared/components/` (panel upgrade + new
+SceneRectangleLayer + MapView flyTo), plus the existing
+`services/session-state/` consumer surface.
+
+**Performance Goals**:
+
+- **SC-001** — visible map transition between Scenes completes within
+  `transition_duration_ms + 150 ms` tolerance; time slider lands on
+  the target timestamp at transition end with no perceptible
+  overshoot.
+- **SC-003** — dropdown switch (Scene list + rectangles update)
+  completes within one paint frame (≤ 17 ms on the reference
+  runner) — no stale state visible after the dropdown closes.
+- Panel rendering at typical sizes (≤ 5 Storyboards × ≤ 50 Scenes
+  per plot) needs no virtualisation — straight list renders.
+
+**Constraints**:
+
+- **Offline** — every path (transport, scrub, rectangle render,
+  hard-block) uses Node / browser built-ins and already-bundled
+  packages; no network (Article I).
+- **No silent failures** — missing-data cases surface the hard-block
+  modal; disabled transport at list boundaries signals state visually
+  (Article I.3).
+- **No bypass of #215** — every read of Storyboard / Scene state goes
+  through `@debrief/components/storyboard` queries; every write
+  (Storyboard create/rename/delete) goes through the CRUD module.
+  No direct `plot.features.filter(isStoryboardFeature)` in extension
+  code; no direct mutation (SC-008). The new
+  `getMostRecentlyModifiedStoryboard` query is added to #215's
+  module in this slice, keeping single-source-of-truth (Article II).
+  Enforced by ESLint `no-restricted-imports` rule targeting the
+  internal module files.
+- **Plot invariant gate at open** — service calls `validatePlot(plot)`
+  on plot-open; if it throws (orphan Scene, duplicate timestamp,
+  duplicate Storyboard name, reserved-slot violation), the service
+  disables transport for that plot and surfaces a single
+  `vscode.window.showErrorMessage` — no partial transport on a
+  structurally-invalid plot (Article I.3).
+- **Scoped keybindings** — `Left` / `Right` bound with
+  `when: "debrief.storyboardActive && (debrief.mapFocused ||
+  focusedView == 'debrief.storyboardPanel')"`; the
+  `debrief.storyboardActive` context is set / cleared by the playback
+  service on plot open / close / empty-Storyboard-set. Global key
+  leakage verified by SC-007 test harness.
+- **Single-flight transport** — concurrent Forward / Backward
+  presses during an in-flight transition are rejected; starting a
+  scrub cancels the flight at its current frame and yields (Assumption
+  "Scrub-cancel during transition"). Storyboard CRUD ops (Create /
+  Rename / Delete) during an in-flight transition are also rejected
+  (consistent with the transport-vs-transport guard). Panel-hide via
+  `webviewView.onDidChangeVisibility` cancels any in-flight
+  transition immediately; an `onFlyToComplete` safety timer fires
+  after `durationMs + 250ms` if Leaflet's `moveend` does not.
+- **Strict types** — `any` / `unknown` prohibited on every new public
+  API (Article XV). The webview `postMessage` contract from the
+  Storyboard panel is extended via a discriminated union in
+  `apps/vscode/src/types/storyboardPanelMessages.ts` (already
+  established by #216).
+- **No UI imports on the headless core** — `@debrief/components/storyboard`
+  is not extended in this slice; all UI wiring lives in
+  `shared/components/src/panels/StoryboardPanel/` and
+  `shared/components/src/MapView/` (the latter already carries
+  `leaflet` imports — pre-existing boundary).
+
+**Scale/Scope**:
+
+- Expected working plot: ≤ 5 Storyboards × ≤ 50 Scenes (per #215's
+  performance bound).
+- Transport state: one integer index per active plot; negligible.
+- `SceneRectangleLayer`: renders ≤ 50 Polygons per plot; trivial for
+  Leaflet.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Decision | Status |
+|---------|----------|--------|
+| **I. Defence-grade reliability — offline by default** | Every branch of the playback path (state read, transport tick, `flyTo` animation, `timeFilter` write, Scene-rectangle render, hard-block prompt) uses Node/browser built-ins + already-bundled packages. No network call introduced. | ✅ Pass |
+| **I.3 No silent failures** | Missing-data cases hard-block with a modal naming the specific unresolved features or out-of-range condition. Transport disabled at list boundaries is visually signalled. External Storyboard deletion refreshes the dropdown with silent fallback (not an error condition per spec). | ✅ Pass |
+| **I.4 Reproducibility** | Transport is deterministic — given an ordered Scene list and a start index, Forward / Backward produce identical traversals. `flyTo` animation is visually non-deterministic (frame timing) but the final state is deterministic (target viewport + timestamp). Tests assert final state, not intermediate frames. | ✅ Pass |
+| **II. Schema integrity** | No schema edits. All Storyboard / Scene reads + writes go through #215's CRUD module; Scene Features stay conformant to the LinkML-derived types. | ✅ Pass |
+| **III.1 Provenance always** | Storyboard create / rename / delete ops pass through #215's CRUD module, which appends the `LogEntry` to the inherited `provenance[]`. The playback transport is a pure read op on Features — no mutation, no provenance append needed (playback is ephemeral UI state). | ✅ Pass |
+| **III.2 Source preservation** | No source files touched. Transport is read-only against the plot; only Storyboard Feature rows (created / renamed / deleted via the overflow menu) ever change, and those pass through #215. | ✅ Pass |
+| **III.3 Audit trail immutable** | Same as #216 — provenance flows through #215's append-only write path; playback service never reaches into existing `LogEntry` records. | ✅ Pass |
+| **IV. Architectural boundaries** | Playback orchestration lives in the VS Code extension (Node runtime + VS Code APIs). It reads session state, calls #215's CRUD module, and pushes to the webview via typed `postMessage`. The **domain logic** (Scene ordering, missing-data classification, CRUD invariants) stays inside `@debrief/components/storyboard`. The extension is orchestration only — no ordering / hashing / validation re-implemented here. Headless panel + MapView extensions carry zero VS Code imports. | ✅ Pass |
+| **V. Extensibility** | The playback service is a first-party extension singleton; contrib extensions could later register a competing `WebviewViewProvider` for a different narrative renderer without touching this code. The `StoryboardPanel` remains presentational; consumers in web-shell or Storybook can render it standalone. | ✅ Pass |
+| **VI. Testing** | Positive + negative test for every edge case enumerated in spec (arrow-key scope, `transition_duration_ms = 0` snap, `10000`-ms cancellation, boundary-disabled transport, hard-block on mid-sequence, empty Storyboard, external deletion fallback, antimeridian rectangle, overlapping rectangles, scrub-during-transition cancel). E2E covers the end-to-end briefing loop (SC-002). | ✅ Pass |
+| **VII. Test-driven AI collaboration** | Acceptance Scenarios from spec.md map 1:1 to the playback-service unit test names; the spec-quality checklist at `checklists/requirements.md` (to be refreshed in Phase 1) captures "what good looks like" per user story. | ✅ Pass |
+| **VIII. Documentation** | spec.md (shipped), research.md (Phase 0 below), data-model.md (Phase 1 below — view-model-only, no schema), contracts/ (Phase 1 below — playback service, new VS Code commands, panel postMessage delta), quickstart.md (Phase 1 below). All precede implementation. | ✅ Pass |
+| **IX. Dependencies** | Zero new runtime dependencies. One zero-impact edit to `apps/vscode/package.json` adding new command contributions + scoped keybinding contributions. | ✅ Pass |
+| **X. Security** | No secrets. No network. Scene rectangles render from already-loaded plot data; no classified-data exfiltration vector. | ✅ Pass |
+| **XI. Internationalisation** | All user-visible strings (dropdown placeholder, overflow menu labels, transport tooltips, hard-block modal body + buttons) route through the extension's `messages.ts` pattern, keeping them externalisable. DTG formatter is locale-invariant by defence convention. | ✅ Pass |
+| **XII. Community engagement** | Planning post (Phase 2 below) announces the slice; preview-app screenshot + GIF of the forward-through-a-storyboard flow will ship with the shipped post after implementation. | ✅ Pass |
+| **XIII. Contribution standards** | Atomic commits per section. PR review required. CI gates: lint + typecheck + unit + Storybook-E2E + webview-E2E all green. | ✅ Pass |
+| **XIV. Pre-release freedom** | No backwards-compatibility shims. Schema (from #215) is v1 only. No deprecation periods. | ✅ Pass |
+| **XV. Strict type safety** | `any` / `unknown` prohibited on every new API — playback service public methods, command handler return types, new webview `postMessage` variants, `MapView.flyTo` signature, `SceneRectangleLayer` props. Modal prompt return values are narrowed to a literal-union at the VS Code API boundary. | ✅ Pass |
+
+**Result**: All 15 articles pass. **No Complexity Tracking entries required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/217-storyboarding-playback/
+├── plan.md              # This file
+├── spec.md              # Feature spec (already complete)
+├── research.md          # Phase 0 — six research questions resolved
+├── data-model.md        # Phase 1 — view-model + transport-state types (no schema deltas)
+├── quickstart.md        # Phase 1 — end-to-end walk-through for #218's authors
+├── contracts/
+│   ├── playback-service.md          # StoryboardPlaybackService public API
+│   ├── vscode-commands.md           # New command + keybinding contributions
+│   ├── storyboard-panel-messages.md # Extended postMessage discriminated union delta
+│   ├── map-view-flyto.md            # MapView.flyTo + onSceneRectangleClick additions
+│   └── scene-rectangle-layer.md     # SceneRectangleLayer props + rendering rules
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist (already complete)
+├── media/
+│   ├── planning-post.md    # Phase 2 output
+│   └── linkedin-planning.md
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+apps/vscode/
+├── package.json                                ← EDIT: +6 command contributions, +Left/Right scoped keybindings
+└── src/
+    ├── extension.ts                            ← EDIT: instantiate StoryboardPlaybackService; register storyboard commands; wire mapPanel.onSceneRectangleClick + mapPanel.onFeaturesChanged → service; maintain `debrief.storyboardActive` context
+    ├── services/
+    │   ├── storyboardPlayback.ts               ← NEW: transport state machine (active Storyboard, current Scene, transition in-flight, scrub-window recompute, hard-block flow, validatePlot gate, visibility + timeout cancel, CRUD-during-flight guard)
+    │   ├── plotFromFeatures.ts                 ← NEW: shared helper — wraps DebriefFeature[] into a throwaway FeatureCollection for the #215 module API. Used by BOTH storyboardPanelView.refresh() and StoryboardPlaybackService (design-fix 4; extracts duplicated code)
+    │   └── __tests__/
+    │       └── storyboardPlayback.test.ts      ← NEW
+    ├── commands/
+    │   ├── storyboardTransport.ts              ← NEW: forward / backward / clickScene / jumpPast command handlers
+    │   ├── storyboardManagement.ts             ← NEW: createStoryboard / renameStoryboard / deleteStoryboard command handlers (delegates to #215 CRUD via the service)
+    │   ├── storyboardEditStub.ts               ← NEW: stub for `debrief.storyboard.editScene` — opens read-only detail toast; replaced by #218
+    │   └── __tests__/
+    │       └── storyboardCommands.test.ts      ← NEW
+    ├── webview/
+    │   └── mapPanel.ts                         ← EDIT: add `flyToViewport(viewport, durationMs): number`, `setSceneRectangles(scenes, activeId, currentId)`, `onSceneRectangleClick`, `onFlyToComplete`, and **new** `onFeaturesChanged: vscode.Event<DebriefFeature[]>` fired from `setFeatures` (arch-fix 2)
+    ├── views/
+    │   ├── storyboardPanelView.ts              ← EDIT: extend postMessage handling for dropdown change, overflow menu actions, transport clicks, current-scene highlight; accept `activeStoryboardId` + `currentSceneId` from the playback service; rewrite the `#217 will replace` comment to describe current behaviour (design-fix 4); reuse `plotFromFeatures` helper
+    │   └── timeRangeView.ts                    ← EDIT: add `setScrubbableRange(start: number | null, end: number | null)` — overrides the `start/end` pair in outbound `updateTimeExtent` messages while leaving `dataStart/dataEnd` driven by `state.timeRange` (arch-fix 1)
+    └── types/
+        └── storyboardPanelMessages.ts          ← EDIT: extend discriminated union with dropdown-changed, overflow-menu-clicked, transport-clicked, scene-row-clicked (upgrade from log-only), and inbound state updates
+
+shared/components/
+├── src/
+│   ├── storyboard/
+│   │   ├── queries.ts                          ← EDIT: +getMostRecentlyModifiedStoryboard(plot): StoryboardFeature | null — scans provenance[last].timestamp per Storyboard, returns max (Fix B; ~10 LOC)
+│   │   ├── index.ts                            ← EDIT: re-export the new query
+│   │   └── __tests__/
+│   │       └── queries.test.ts                 ← EDIT: +unit tests for the new query (empty plot, single Storyboard, multiple, tie-break on equal timestamps)
+│   ├── panels/
+│   │   └── StoryboardPanel/
+│   │       ├── StoryboardPanel.tsx             ← EDIT: add dropdown, overflow menu, transport row, current-Scene highlight, hard-block modal surface
+│   │       ├── StoryboardHeader.tsx            ← NEW: dropdown + overflow menu
+│   │       ├── TransportRow.tsx                ← NEW: Forward / Backward buttons + Scene N of M counter
+│   │       ├── HardBlockModal.tsx              ← NEW: presentational — renders missing-data info + two actions (Storybook only; real modal is VS Code-native)
+│   │       ├── StoryboardPanel.stories.tsx     ← EDIT: add WithMultipleStoryboards, Transport, HardBlockModal stories
+│   │       ├── types.ts                        ← EDIT: extend StoryboardPanelProps with **optional+defaulted** storyboards[], activeStoryboardId, currentSceneId, transport/overflow callbacks (design-fix 3 — keeps #216 tests compiling unchanged). NOTE: SceneRowViewModel keeps only `ok` + `pending` states — no `blocked` variant (design-fix 1)
+│   │       └── __tests__/
+│   │           └── StoryboardPanel.test.tsx    ← EDIT: add dropdown, overflow, transport, highlight, hard-block cases
+│   └── MapView/
+│       ├── MapView.tsx                         ← EDIT: add `flyToTarget` prop + `onFlyToComplete` callback + `onSceneRectangleClick`; integrate `SceneRectangleLayer`; base-layer GeoJSON filter excludes STORYBOARD / STORYBOARD_SCENE
+│       ├── SceneRectangleLayer.tsx             ← NEW: renders `scene.geometry.coordinates` (GeoJSON Polygon) for Scenes of the active Storyboard only; scoped by activeStoryboardId prop; best-effort antimeridian render; click forwards sceneId (Fix D — reads geometry, not viewport.corners)
+│       └── __tests__/
+│           ├── SceneRectangleLayer.test.tsx    ← NEW
+│           └── flyTo.test.tsx                  ← NEW
+
+tests/e2e/
+└── test-storyboard-playback.spec.ts            ← NEW: Playwright E2E through code-server (open plot → panel → transport × N → scrub → hard-block → jump past → backward → dropdown switch)
+
+.specify/ / CLAUDE.md
+└── <no agent-context delta — shared/components + VS Code extension stack already listed>
+```
+
+**Structure Decision**: Single-project monorepo extension. The slice
+follows the established `WebviewViewProvider` + shared-React-component
+pattern (#176 LogPanel / #216 StoryboardPanel minimal). New code
+splits cleanly into:
+
+- **Extension-only** (Node runtime, VS Code API): the
+  `StoryboardPlaybackService`, the command handlers, and the
+  `mapPanel.ts` surface extensions. These own all orchestration,
+  state, and VS Code command registration.
+- **Shared / reusable** (browser runtime, zero VS Code imports): the
+  extended `StoryboardPanel`, the new `SceneRectangleLayer`, and the
+  `MapView.flyTo` extension. These render the same in Storybook,
+  web-shell, and VS Code host — no VS Code context required.
+
+## Media Components
+
+| Component | Story Source | Bundle Name | Purpose |
+|-----------|--------------|-------------|---------|
+| `StoryboardPanel` — with multiple Storyboards | `shared/components/src/panels/StoryboardPanel/StoryboardPanel.stories.tsx` | `storyboard-panel-multi.js` | Shows the new header dropdown + Scene list populated from one of several Storyboards on the plot (core dropdown-UX demo). |
+| `StoryboardPanel` — transport row | same file, `Transport` story | `storyboard-panel-transport.js` | Demonstrates the Forward / Backward buttons + Scene counter + current-Scene highlight; the headline new affordance of the slice. |
+| `StoryboardPanel` — hard-block modal | same file, `HardBlockModal` story | `storyboard-panel-hardblock.js` | Demonstrates the missing-data prompt with *Jump past* / *Open for editing* actions (the safety surface of the slice). |
+
+**Inclusion Criteria Applied**:
+- [x] New visual component — `StoryboardHeader`, `TransportRow`,
+      `HardBlockModal` are new sub-components; `SceneRectangleLayer`
+      is new but not a Storybook story (requires Leaflet host — demo
+      via preview-app screenshots instead).
+- [x] Significant visual change — the Storyboard panel shell itself
+      is materially enriched vs. the #216 minimal version.
+- [x] Interactive demo adds narrative value — dropdown switching,
+      transport stepping, and the hard-block modal all tell the epic's
+      core story better in Storybook than in prose.
+
+**Bundleability Verified**:
+- [x] Stories will exist in Storybook — written alongside the
+      component extensions.
+- [x] Components render standalone — each sub-component receives its
+      data via props; no VS Code postMessage or session-state context
+      required in Storybook.
+- [x] Reasonable bundle size expected — the panel depends only on
+      vscrui icons + inline styles; estimated total bundle across
+      the three stories < 120 KB.
+
+**Storybook Link**: `https://debrief.github.io/debrief-future/storybook/?path=/story/panels-storyboardpanel--transport` (published after PR merge).
+
+## Storybook E2E Testing
+
+| Story | Test Coverage | Theme Variants | Interactions |
+|-------|--------------|----------------|--------------|
+| `StoryboardPanel.stories.tsx — WithMultipleStoryboards` | Rendering, dropdown renders all Storyboards, overflow menu opens, accessibility (`aria-expanded`, `role="menu"`) | light, dark, vscode | open dropdown, select a different Storyboard, open overflow menu |
+| `StoryboardPanel.stories.tsx — Transport` | Rendering, Forward / Backward enabled/disabled at boundaries, current-Scene highlight, Scene N of M counter, accessibility (`aria-label` per button) | light, dark, vscode | click Forward, click Backward, press `Right` (verify `onTransportForward` fires) |
+| `StoryboardPanel.stories.tsx — HardBlockModal` | Rendering, two action buttons visible, body names missing feature IDs or out-of-range condition, focus trap, accessibility (`role="dialog"`, `aria-modal`) | light, dark, vscode | click *Jump past this scene*, click *Open for editing*, press `Escape` |
+
+**Testing Strategy**:
+- [x] Component renders correctly in all theme variants
+- [x] Interactive elements respond to user input (dropdown, transport buttons, modal actions)
+- [x] Accessibility attributes present (`data-testid` + `aria-label` /
+      `role` / `aria-modal`)
+- [x] Screenshots captured for evidence (lives under
+      `specs/217-storyboarding-playback/evidence/storybook/`)
+
+**Test File Location**: `shared/components/e2e/StoryboardPanel.spec.ts` (extends existing file from #216).
+
+**Theme Variant URLs** (for Storybook):
+```
+/iframe.html?id=panels-storyboardpanel--with-multiple-storyboards&globals=theme:light
+/iframe.html?id=panels-storyboardpanel--with-multiple-storyboards&globals=theme:dark
+/iframe.html?id=panels-storyboardpanel--with-multiple-storyboards&globals=theme:vscode
+/iframe.html?id=panels-storyboardpanel--transport&globals=theme:light
+/iframe.html?id=panels-storyboardpanel--transport&globals=theme:dark
+/iframe.html?id=panels-storyboardpanel--transport&globals=theme:vscode
+/iframe.html?id=panels-storyboardpanel--hard-block-modal&globals=theme:light
+/iframe.html?id=panels-storyboardpanel--hard-block-modal&globals=theme:dark
+/iframe.html?id=panels-storyboardpanel--hard-block-modal&globals=theme:vscode
+```
+
+## VS Code Webview E2E Testing
+
+| Workflow | Panels Involved | Key Selectors | Interactions |
+|----------|----------------|---------------|--------------|
+| **Forward through a populated Storyboard** | Map Panel, Storyboard Panel | `.leaflet-container`, `[data-testid="storyboard-panel"]`, `[data-testid="transport-forward"]`, `[data-testid="scene-row"][data-active="true"]`, `.leaflet-interactive.debrief-scene-rect` | open plot with ≥ 3 Scenes, open Storyboard panel, press Forward × 3, verify map `flyTo` + time slider advance + current-Scene highlight update each step |
+| **Scoped Right-arrow transport (SC-007)** | Map Panel, Storyboard Panel, Log Panel | same as above plus `.log-panel` | focus Map Panel (Storyboard active), press `Right`, verify Forward fired; focus Log Panel, press `Right`, verify no transport change |
+| **Scrub-window lock (SC-004)** | Map Panel, Time-range View, Storyboard Panel | `[data-testid="time-range-scrubber"]`, `.debrief-time-scrubber__thumb`, `[data-testid="scene-row"][data-active="true"]` | position on Scene N, drag scrubber beyond `Scene[N+1].timestamp`, verify clamp at boundary |
+| **Click Scene rectangle on map (FR-PLAY-017)** | Map Panel, Storyboard Panel | `.leaflet-interactive.debrief-scene-rect`, `[data-testid="scene-row"][data-active="true"]` | click a non-current Scene's rectangle on the map, verify panel highlight jumps + map animates to that Scene's viewport |
+| **Dropdown switch refreshes rectangles (SC-006)** | Map Panel, Storyboard Panel | `[data-testid="storyboard-dropdown"]`, `.leaflet-interactive.debrief-scene-rect` | switch dropdown, verify previous Storyboard's rectangles are gone and new Storyboard's rectangles render — within the same interaction |
+| **Hard-block modal — Jump past (FR-PLAY-020)** | Map Panel, Storyboard Panel, modal prompt | `.notification-toast-container` or `showInformationMessage` modal, `[data-testid="scene-row"][data-active="true"]` | step onto a Scene with a deleted `visible_feature_id`, verify modal surfaces, click *Jump past this scene*, verify transport advanced **past** the blocked Scene without animating through it |
+| **Create → Rename → Delete a Storyboard** | Storyboard Panel | `[data-testid="storyboard-overflow"]`, `[data-testid="storyboard-overflow-create"]`, input box, confirm modal | create, rename, delete a Storyboard; verify dropdown reflects each change and cascade-delete confirmation names Scene count |
+| **External Storyboard deletion (edge)** | Storyboard Panel | same as above | simulate external delete (via test hook), verify dropdown refreshes and active selection falls back silently to the most-recently-modified remaining Storyboard |
+
+**Testing Strategy**:
+- [x] Extension workflow works end-to-end in code-server
+- [x] Webview content accessible via `frameLocator` chaining (Map
+      Panel iframe → Leaflet container + Scene rectangles; Storyboard
+      Panel iframe → dropdown + transport + scene rows)
+- [x] Page objects updated for new selectors
+      (`storyboard-dropdown`, `storyboard-overflow`,
+      `transport-forward`, `transport-backward`, `scene-row[data-active]`,
+      `scene-rect[data-scene-id]`)
+- [x] Screenshots captured for evidence (lives under
+      `specs/217-storyboarding-playback/evidence/e2e/`)
+
+**Test File Location**: `tests/e2e/test-storyboard-playback.spec.ts`
+
+**Infrastructure**:
+- Patches applied by existing `tests/e2e/scripts/patch-webview.sh`
+- Content injection via existing `tests/e2e/helpers/webview-injector.ts`
+- Headed Chromium via the project's `@sparticuz/chromium` runner
+
+## Complexity Tracking
+
+**Nothing to justify.** Constitution Check passes all 15 articles with
+zero narrow departures. No new runtime dependencies. No new schema
+modules. No Python additions. The slice is orchestration + presentation
+only, reusing the #215 CRUD module, the #216 minimal panel shell, the
+`MapView` + `react-leaflet` stack, the session-state `TemporalSlice`,
+and the existing `WebviewViewProvider` pattern.

--- a/specs/217-storyboarding-playback/quickstart.md
+++ b/specs/217-storyboarding-playback/quickstart.md
@@ -1,0 +1,231 @@
+# Quickstart — Storyboarding Panel + Playback
+
+**Feature**: 217-storyboarding-playback
+**Audience**: Implementers of this slice; authors of sibling #218
+(edit suite); QA running the manual verification script; reviewers
+preparing stakeholder demos.
+
+This quickstart walks a developer through standing up the feature
+from a clean clone, verifying the acceptance scenarios end-to-end,
+and onto the review-app preview where stakeholders will exercise it.
+
+---
+
+## 1. Prerequisites
+
+- Node 20+, pnpm 9+, Python 3.11 + uv, VS Code 1.85+.
+- Clone includes `main` merged up to the #216 **Storyboarding
+  Capture** slice (`StoryboardPanel` minimal version present;
+  `@debrief/components/storyboard` CRUD module present).
+- Preview-app sample data: `preview/workspace/samples/local-store/`
+  carries at least one `.rep` plot that parses cleanly into
+  `DebriefFeature[]`.
+
+---
+
+## 2. Clean-build from scratch
+
+```bash
+cd ~/dev/debrief-future
+git switch 217-storyboarding-playback           # this feature's branch
+pnpm install
+uv sync
+pnpm -r build --filter '@debrief/schemas'       # regen types (no-op for this slice)
+pnpm -r build                                   # builds shared/components + apps/vscode
+```
+
+Expect:
+
+- `shared/components/dist/` contains the extended `StoryboardPanel`
+  exports plus the new `SceneRectangleLayer`.
+- `apps/vscode/dist/extension.js` contains the new
+  `StoryboardPlaybackService` and the transport / management
+  commands.
+
+---
+
+## 3. Run the unit tests
+
+```bash
+# TypeScript tests (fast — hot path for day-to-day work)
+pnpm --filter @debrief/components test
+pnpm --filter @debrief/vscode-extension test
+
+# Python tests (no-op for this slice, but CI runs them)
+uv run pytest
+```
+
+Tests added by this slice:
+
+| Suite | Notes |
+|---|---|
+| `shared/components/src/panels/StoryboardPanel/__tests__/StoryboardPanel.test.tsx` | Dropdown + overflow + transport + highlight + hard-block |
+| `shared/components/src/MapView/__tests__/SceneRectangleLayer.test.tsx` | New layer — 10 test cases |
+| `shared/components/src/MapView/__tests__/flyTo.test.tsx` | `flyTo` prop transitions, zero-duration, cancellation |
+| `apps/vscode/src/services/__tests__/storyboardPlayback.test.ts` | Transport state machine |
+| `apps/vscode/src/commands/__tests__/storyboardCommands.test.ts` | Command handlers |
+
+All must pass before the E2E suite runs.
+
+---
+
+## 4. Run the Storybook E2E
+
+```bash
+pnpm --filter @debrief/components storybook:build
+node apps/web-shell/run-playwright.mjs   # the shared runner (@sparticuz/chromium)
+```
+
+Three new stories are exercised under light / dark / vscode themes:
+
+- `panels-storyboardpanel--with-multiple-storyboards`
+- `panels-storyboardpanel--transport`
+- `panels-storyboardpanel--hard-block-modal`
+
+Screenshots land under `specs/217-storyboarding-playback/evidence/storybook/`.
+
+---
+
+## 5. Run the VS Code webview E2E
+
+```bash
+pnpm --filter @debrief/vscode-extension build
+cd tests/e2e
+pnpm exec playwright test test-storyboard-playback.spec.ts
+```
+
+The suite covers all acceptance scenarios from `spec.md` plus the
+edge cases in §6 below. Screenshots land under
+`specs/217-storyboarding-playback/evidence/e2e/`.
+
+---
+
+## 6. Manual verification script
+
+Stakeholder demo + final sanity check. Assumes you have a plot with
+≥ 3 Scenes captured via #216 (or the included test fixture
+`preview/workspace/samples/storyboarding/three-scenes.rep`).
+
+### 6.1 Happy-path forward traversal
+
+1. Open the plot in the code-server preview (or a local VS Code).
+2. Open the Storyboard panel (Command Palette → "Storyboard: Open Panel").
+3. Expect: dropdown populated; Scene list populated; one Scene
+   highlighted (Scene 1 of N); transport shows *N-1* forward steps
+   possible.
+4. Press **Forward** (button). Expect: map animates via `flyTo` to
+   Scene 2's viewport; time slider tweens; panel highlight jumps to
+   row 2; counter reads *2 of N*.
+5. Press **Forward** again until you hit Scene N. Expect: Forward
+   button greyed out; pressing it has no effect.
+6. Press **Backward** to reverse. Expect: mirror of the above.
+
+### 6.2 Scoped arrow keys (SC-007)
+
+1. Position on Scene 1.
+2. Click into the map (`debrief.mapFocused === true`). Press `Right`.
+   Expect: Forward fires (Scene 2 highlighted).
+3. Press `Right` again. Expect: Scene 3 highlighted.
+4. Focus the Log Panel (another webview). Press `Right`. Expect:
+   **no transport change** — the scoped binding did not fire.
+5. Focus the file explorer. Press `Right`. Expect: **no transport
+   change**.
+
+### 6.3 Scrub-window lock (SC-004)
+
+1. Position on Scene 1. Note the time slider's extent.
+2. Attempt to drag the slider past Scene 2's timestamp. Expect:
+   clamp at Scene 2's boundary.
+3. Position on Scene N (last). Attempt to drag past its timestamp.
+   Expect: clamp at Scene N's timestamp.
+
+### 6.4 On-map Scene rectangles (FR-PLAY-016 / -017 / -018)
+
+1. With the active Storyboard selected, the map shows faint
+   rectangles at each Scene's viewport.
+2. Switch the dropdown to another Storyboard. Expect: previous
+   rectangles disappear; new Storyboard's rectangles render
+   (SC-006) — within the same user interaction.
+3. Click a non-current Scene rectangle. Expect: transport jumps to
+   that Scene; map animates to its viewport.
+
+### 6.5 Hard-block on missing data (FR-PLAY-019 / -020 / -021)
+
+1. Deliberately delete a feature referenced in some Scene's
+   `visible_feature_ids` (use the VS Code Features view to remove
+   a track's line feature).
+2. Step forward onto that Scene. Expect: modal prompt naming the
+   missing feature ID and offering *Jump past this scene* / *Open
+   for editing*.
+3. Click *Jump past this scene*. Expect: transport advances past
+   the blocked Scene; no animation into the blocked Scene occurred.
+4. Click *Open for editing* on a repeat. Expect: read-only detail
+   toast (full editor is #218).
+
+### 6.6 Multi-Storyboard CRUD (FR-PLAY-001 / -002 / -003 / -004)
+
+1. From the panel overflow menu, choose **Create**. Enter a new
+   Storyboard name. Expect: dropdown includes the new Storyboard;
+   panel switches to it; Scene list is empty.
+2. Use capture (`Ctrl/Cmd+Alt+C`) to add a Scene to the new
+   Storyboard. Expect: Scene list populates.
+3. Choose **Rename**. Change the name. Expect: dropdown updates.
+4. Choose **Delete**. Expect: confirmation modal naming the Scene
+   count. Confirm. Expect: Storyboard gone from dropdown; active
+   selection falls back to most-recently-modified.
+
+### 6.7 Offline check (SC-009)
+
+1. Disconnect from the network.
+2. Repeat §6.1 – §6.6 end-to-end. Expect: everything works
+   identically.
+
+---
+
+## 7. Preview-app deployment
+
+Per-PR preview apps are provisioned by Heroku Review Apps
+(`app.json` / `heroku.yml` / `Dockerfile.preview`). When the PR for
+this feature opens, the GitHub Actions bot posts a "🚀 Preview
+Deployments" comment with:
+
+- **Code Server** — exercise §6 end-to-end inside a browser.
+- **Web Shell** — render the `StoryboardPanel` in isolation.
+- **Storybook** — exercise the three new stories under each theme.
+
+The GIF captured for the shipped blog post (§8 below) lives under
+`specs/217-storyboarding-playback/evidence/media/`.
+
+---
+
+## 8. Evidence checklist (for the PR)
+
+- [ ] `specs/217-storyboarding-playback/evidence/storybook/` — 9
+      screenshots (3 stories × 3 themes).
+- [ ] `specs/217-storyboarding-playback/evidence/e2e/` — screenshots
+      per acceptance scenario from `spec.md`.
+- [ ] `specs/217-storyboarding-playback/evidence/media/forward-traversal.gif` —
+      1-minute GIF of the forward-through-a-storyboard flow.
+- [ ] Test summary at
+      `specs/217-storyboarding-playback/evidence/test-summary.md`
+      using `.specify/templates/evidence/test-summary-template.md`
+      (include YAML front matter with `git_sha` + `captured_at`).
+
+---
+
+## 9. Downstream hand-off to #218
+
+#218 (edit suite) consumes:
+
+- `StoryboardPlaybackService.resolveHardBlockByOpeningForEditing` —
+  currently a stub (`showInformationMessage` with read-only details);
+  #218 replaces with a full editor surface.
+- `StoryboardPanel`'s new overflow menu per-Scene slots — #218 adds
+  rename / delete+undo / update-to-current / duplicate / copy-to-
+  other-storyboard.
+- `StoryboardPlaybackService.onSnapshotChange` — #218's edit ops must
+  trigger a snapshot refresh (via the existing
+  `onPlotFeaturesChanged` lifecycle).
+
+No breaking changes to this slice's surface are expected from #218 —
+only additive extensions.

--- a/specs/217-storyboarding-playback/research.md
+++ b/specs/217-storyboarding-playback/research.md
@@ -1,0 +1,526 @@
+# Phase 0 — Research: Storyboarding — Panel + Playback
+
+**Feature**: 217-storyboarding-playback
+**Date**: 2026-04-21
+**Input**: Technical Context in `plan.md`
+
+The Technical Context in `plan.md` has **zero `NEEDS CLARIFICATION`
+markers** — every decision bar the six below was either inherited
+from #215 / #216 or is mechanical (re-use existing patterns). This
+document records the six non-trivial decisions specific to this slice.
+
+---
+
+## R1. `flyTo` + time-slider tween — one mechanism or two?
+
+### Decision
+
+**Two independent animations driven from a single imperative entrypoint
+on the playback service.** The service holds a single `advanceTo(scene,
+durationMs)` method which fans out to:
+
+1. `MapPanel.flyToViewport(viewport, durationMs)` → webview
+   `postMessage` → Leaflet `L.Map.flyTo([lat, lon], zoom, { duration:
+   durationMs / 1000, easeLinearity: 0.25 })`.
+2. `SessionStoreApi.setCurrentTime(startEpoch + ((targetEpoch -
+   startEpoch) * t))` on a browser-`requestAnimationFrame` loop inside
+   the webview (the time slider already animates on `setCurrentTime`
+   changes; Leaflet does the map tween internally).
+
+A shared `transitionId: number` is used to correlate the two so a
+scrub mid-flight can cancel both; the service also holds a single
+`isTransitionInFlight` flag.
+
+### Rationale
+
+- Leaflet's `L.Map.flyTo` is already the idiomatic API and respects
+  the browser's native animation frame cadence; re-implementing it
+  via `requestAnimationFrame` + `setView` would be strictly worse.
+- The time-slider tween is a single-slot write (`currentTime` as
+  `number | null` on the `TemporalSlice`), so a simple RAF loop over
+  the delta is adequate — no library needed.
+- A single imperative entrypoint keeps all transport state in the
+  service; the webview does not hold transport state, only renders
+  what it receives.
+
+### Alternatives considered
+
+- **Single unified animation library (`framer-motion`, `gsap`)** —
+  rejected. Adds a runtime dependency that replaces primitives we
+  already have. Both Leaflet and the time-slider webview already
+  animate natively.
+- **Do the tween inside `L.Map.flyTo`'s frame callback** —
+  rejected. `flyTo` doesn't expose a per-frame callback in a way
+  that survives version upgrades; correlating two animations in the
+  service is more robust.
+- **Let the webview own transport state** — rejected. The service
+  needs to gate Forward / Backward on `detectMissingDataForScene`,
+  which needs the full plot FeatureCollection. That lives in the
+  extension, not the webview.
+
+---
+
+## R2. Scrub-window enforcement — where does the clamp live?
+
+### Decision
+
+**Narrow the scrubbable `start`/`end` pair in `TimeRangeViewProvider`
+while leaving `dataStart`/`dataEnd` unchanged.** When transport moves
+to Scene N, the playback service calls:
+
+```ts
+timeRangeView.setScrubbableRange(
+  epoch(scenes[N].timestamp),
+  N < scenes.length - 1
+    ? epoch(scenes[N + 1].timestamp)
+    : epoch(scenes[N].timestamp),   // locked at last
+);
+```
+
+`TimeRangeViewProvider`'s existing `updateTimeExtent` message already
+carries both pairs:
+
+```ts
+{
+  type: 'updateTimeExtent',
+  start: number,        // scrubbable lower bound
+  end: number,          // scrubbable upper bound
+  dataStart: number,    // visible data extent — stays at plot's timeRange
+  dataEnd: number,
+}
+```
+
+The view provider overrides `start`/`end` with the Scene-window values
+while still sending `dataStart`/`dataEnd` from `state.timeRange`. The
+`TimeScrubber` component reads both — the thumb drag is constrained
+to `[start, end]`; the visual track shows the full `[dataStart, dataEnd]`
+extent for context. On `setScrubbableRange(null, null)` the override
+is cleared and both pairs go back to `state.timeRange`.
+
+### Rationale (refined after code survey)
+
+- **`timeFilter` is the wrong lever.** It exists on `TemporalSlice`
+  but is consumed only by `StacBrowser` for catalog browsing — it
+  does not constrain `TimeScrubber`. Using it would produce a silent
+  failure (FR-PLAY-012 would not fire). Verified at
+  `shared/components/src/StacBrowser/useBrowserFilter.ts` and at
+  `apps/vscode/src/webview/web/timeController.tsx` where the scrubber
+  consumes `timeExtent` only.
+- **The scrubbable vs data-context split is already in the wire
+  format.** The `updateTimeExtent` message's four-field shape was
+  designed for exactly this case. Using it for the Scene window is
+  idiomatic and zero-impact on existing paths.
+- **"Clamp" (rather than "reject a drag") matches spec wording** —
+  "scrub is constrained to `[Scene[N].t, Scene[N+1].t]`" — and is
+  the idiomatic slider behaviour.
+- **Visual preservation**: keeping `dataStart/dataEnd` intact means
+  the analyst sees the full time range in the scrubber track with
+  the thumb clamped to a sub-range. Stakeholders can see the overall
+  extent as well as the current segment — better than collapsing the
+  whole scrubber to the Scene window.
+- **Last-Scene lock**: setting `start === end` collapses the thumb
+  to a single instant, which the existing scrubber already treats as
+  "locked at timestamp." No special-case code needed.
+
+### Alternatives considered
+
+- **`setTimeFilter({start, end})` on `TemporalSlice`** — rejected
+  after code survey. `timeFilter` does not feed the scrubber; would
+  silently fail the FR without a visible test failure.
+- **Add a new `scrubWindow` prop to the `TimeScrubber` component** —
+  rejected. Adds a third time-range concept to a component that
+  already takes two. The `updateTimeExtent` message is the cleaner
+  extension point.
+- **Clamp `setCurrentTime` writes in the service** — rejected. The
+  scrubber thumb would still drag outside the window visually; the
+  analyst would see the thumb jump back, not hit a wall. That is a
+  silent-UX failure (Article I.3).
+- **Let the analyst scrub anywhere but snap back to the window** —
+  rejected. Contradicts the spec ("locked at or before the
+  boundaries") and creates frustrating UX in front of a stakeholder.
+
+### Downstream impact
+
+- The service **must** call `setScrubbableRange(null, null)` on
+  `service.dispose()`, on plot-close, on dropdown-switch-to-null,
+  and on emptying the active Storyboard. Tested.
+- `TimeRangeViewProvider` retains a `scrubbableOverride: { start:
+  number | null; end: number | null }` field; when either endpoint
+  is non-null the override wins. This is purely extension-side state
+  (no session-state slice changes; no persistence).
+- Existing scrubber consumers outside storyboard playback are
+  unaffected — they never call `setScrubbableRange`.
+
+---
+
+## R3. Where does the hard-block modal live — webview or extension host?
+
+### Decision
+
+**Extension host via `window.showInformationMessage(…, { modal: true },
+"Jump past this scene", "Open for editing")`.** The presentational
+`HardBlockModal.tsx` sub-component in the panel is only used by
+Storybook demos; the real prompt is a VS Code-native modal.
+
+### Rationale
+
+- VS Code-native modals live above the webview and cannot be
+  obscured by it; they are keyboard-trappable and dismissable via
+  `Escape` (which the analyst will expect).
+- The two action labels are stable strings — no need for webview
+  round-trip to render them.
+- The missing-data payload (list of unresolved feature IDs or
+  "out-of-range") is short; fitting it in the modal body is trivial.
+- VS Code's modal button labels render exactly as passed, so
+  Internationalisation routes cleanly through the extension's
+  `messages.ts`.
+
+### Alternatives considered
+
+- **Custom webview modal overlay** — rejected. Would require CSP
+  changes, focus-trap logic, `aria-modal` plumbing, and would not
+  block map interactions behind it.
+- **Mixed (modal in the panel webview, plain toast in the extension
+  host depending on focus)** — rejected. Unpredictable UX; also
+  creates two code paths for the same concern.
+
+### Why keep the Storybook `HardBlockModal.tsx` component?
+
+- To document the copy + layout in a reviewable medium (stakeholder
+  review, shipped blog post screenshot).
+- To have a pure presentational surface so the *copy* can be proof-
+  read without a live VS Code host.
+- It is not loaded in the real extension path.
+
+---
+
+## R4. Scoped arrow-key binding — `when` clause shape?
+
+### Decision
+
+```json
+{
+  "command": "debrief.storyboard.forward",
+  "key": "right",
+  "when": "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"
+},
+{
+  "command": "debrief.storyboard.backward",
+  "key": "left",
+  "when": "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"
+}
+```
+
+- **`debrief.storyboardActive`** — a new context managed by the
+  playback service. Set `true` when an active Storyboard exists
+  **and** has at least one Scene; cleared on plot close, on deletion
+  of the last Storyboard, on emptying the active Storyboard's Scenes,
+  or when the user deactivates the panel.
+- **`debrief.mapFocused`** — existing context maintained by
+  `apps/vscode/src/webview/mapPanel.ts`.
+- **`focusedView == 'debrief.storyboardPanel'`** — built-in VS Code
+  context for `WebviewView` focus.
+
+### Rationale
+
+- Matches the spec: keys are bound only when (a) a Storyboard is
+  ready to play back, **and** (b) focus is on one of the two
+  surfaces that conceptually own the transport (the panel or the
+  map).
+- VS Code evaluates `when` clauses per keypress, so the guard is
+  enforced by the platform — no service-side re-check needed.
+- Adding a **single** new context (`debrief.storyboardActive`)
+  keeps the `when` surface small and easy to reason about.
+
+### Alternatives considered
+
+- **Bind `Left` / `Right` globally when a Storyboard is active** —
+  rejected. Breaks SC-007 (no global key leakage) — e.g. arrow
+  navigation inside a QuickPick or the file explorer would step the
+  transport.
+- **Bind only when the panel is focused** — rejected. Analysts will
+  want to drive the transport from the map (the canonical briefing
+  surface).
+- **Use a single broad context `debrief.storyboardTransportActive`
+  that combines both guards** — rejected. Harder to re-use (#218
+  would want the *active-storyboard* part without the *focus* part
+  for rename / delete commands).
+
+### Test harness
+
+- SC-007 requires a Playwright test that focuses an unrelated view
+  (e.g. Log Panel webview or the built-in file explorer) and
+  presses `Right`. The service `storyboardPlayback.test.ts` is a
+  unit test; the `tests/e2e/test-storyboard-playback.spec.ts` is the
+  integration enforcement for SC-007.
+
+---
+
+## R5. Antimeridian-crossing rectangle rendering
+
+### Decision
+
+**Render as a single best-effort `L.Polygon` with the raw four-corner
+coordinates as provided by the Scene's `viewport` slot.** No splitting
+into two halves.
+
+### Rationale
+
+- #215 already flags antimeridian-crossing viewports as a "best-effort"
+  render — the spec notes "Rendered as a best-effort Polygon (warned by
+  #215)."
+- Leaflet's own `L.Polygon` handles the crossing with a visible-but-
+  correct render (the polygon wraps around the back of the globe in
+  the default projection). The rectangle's *click* still targets the
+  correct lat/lon pair, and that is the enforcement surface
+  (FR-PLAY-017).
+- Splitting into two polygons would require cross-product geometry
+  logic in the render path — a disproportionate cost for an edge
+  case that defence analysts handle rarely (most plots are in a
+  single ocean basin; few cross 180°).
+
+### Alternatives considered
+
+- **Split into two L.Polygons at ±180°** — rejected for complexity
+  (see above); also would double-fire click handlers at the seam.
+- **Skip rendering antimeridian-crossers entirely with a toast** —
+  rejected; breaks SC-006 ("only the active Storyboard's Scene
+  rectangles are visible" — silently hiding a rectangle violates
+  the spirit of the invariant).
+
+### Testing
+
+- `SceneRectangleLayer.test.tsx` includes a fixture with a viewport
+  `[170, 10], [-170, 10], [-170, 0], [170, 0]` — the test asserts
+  that exactly one `L.Polygon` is rendered and that clicking at the
+  centroid fires `onSceneClick` with the correct scene ID.
+
+---
+
+## R6. Multi-Storyboard ephemeral-selection storage
+
+### Decision
+
+**In-memory `Map<documentUri, storyboardId>` inside
+`StoryboardPlaybackService`.** No persistence to disk, no session-state
+slice addition. Keyed by `documentUri` — the same STAC URI string
+`SessionManager` uses as its session key.
+
+- On plot **open**: if the map has no entry for this `documentUri`,
+  seed it from `getMostRecentlyModifiedStoryboard(plot)` (the new
+  #215 query added by this slice — see R7).
+- On **dropdown switch**: update the entry.
+- On plot **close**: drop the entry.
+- On **session reload** (VS Code restart / window reload): the map is
+  empty; next open re-seeds from `getMostRecentlyModifiedStoryboard`.
+
+### Rationale
+
+- The spec explicitly says active selection is ephemeral (FR-PLAY-002)
+  and on re-open defaults to most-recently-modified (FR-PLAY-002,
+  SC-002 implicit).
+- Keeping it in the service means no new session-state slice to
+  design / persist / migrate, and no risk of stale selection after
+  a Storyboard is deleted by another tab.
+- Keyed by `documentUri` (the STAC URI string `SessionManager` uses as
+  its session key — `apps/vscode/src/services/sessionManager.ts:101`)
+  so multi-plot hosts work correctly.
+
+### Alternatives considered
+
+- **Add a `uiPreferences.activeStoryboardId` slice to session-state** —
+  rejected. Violates the spec's ephemerality clause; also creates
+  a migration surface for #218 to inherit.
+- **Store on `window` / extension `Memento`** — rejected for the same
+  ephemerality reason; also persists across VS Code restarts when the
+  spec says it should not.
+- **Recompute every render from `getActiveStoryboardDefault`** —
+  rejected. That would prevent the analyst from switching Storyboards
+  at all.
+
+### Edge cases handled
+
+- **External deletion** (another tab deletes the active Storyboard):
+  service detects via `MapPanel.onFeaturesChanged` (new event —
+  arch-fix 2) → re-invokes `getMostRecentlyModifiedStoryboard` (new
+  #215 query — R7) on the refreshed plot, updates the map, and
+  broadcasts the new selection to the panel. If no Storyboards
+  remain, clears `debrief.storyboardActive` context and the panel
+  switches to its empty state.
+- **Rename of the active Storyboard**: the `storyboardId` is stable;
+  the map entry is unaffected. Panel re-renders the new name from
+  the refreshed plot.
+
+---
+
+## R7. "Most-recently-modified" default — where does the query live?
+
+### Decision
+
+**Add a new pure query `getMostRecentlyModifiedStoryboard(plot)` to
+`shared/components/src/storyboard/queries.ts`** (in #215's module),
+alongside the existing `getActiveStoryboardDefault` (which returns
+"first by name ascending"). Both functions stay — they answer
+different questions.
+
+```ts
+/**
+ * Return the plot's most-recently-modified Storyboard, measured as
+ * `provenance[last].timestamp` (appended by every CRUD op per #215).
+ * Ties broken by Storyboard id ascending (deterministic). Null if
+ * the plot contains no Storyboards.
+ */
+export function getMostRecentlyModifiedStoryboard(
+  plot: Plot,
+): StoryboardFeature | null;
+```
+
+~10 LOC. Covered by tests added to
+`shared/components/src/storyboard/__tests__/queries.test.ts`.
+
+### Rationale
+
+- The original plan cited `getActiveStoryboardDefault(plot)` as the
+  most-recently-modified resolver, but code survey showed it returns
+  "first by name ascending" (`shared/components/src/storyboard/queries.ts:41`).
+  Using it would produce silently-wrong behaviour against FR-PLAY-002.
+- Adding the new query to #215 keeps Article II single-source-of-
+  truth: #217's consumer does not re-implement the scan. Replaces
+  what would otherwise be a minor Article IV departure (domain
+  logic in the VS Code extension).
+- #215's `provenance[last].timestamp` is the authoritative "last
+  modified" signal — every CRUD op appends. No separate
+  `last_modified_at` slot needs introducing.
+
+### Alternatives considered
+
+- **Compute in the playback service** — rejected. The scan logic
+  fits the "pure query over a Plot" shape that #215's queries module
+  already owns; duplicating it in the extension would fork the
+  "last modified" concept across two call sites.
+- **Change spec FR-PLAY-002 to accept #215's `getActiveStoryboardDefault`** —
+  rejected. The product intent is that the analyst returns to the
+  Storyboard they were last working on; name-alphabetical is
+  unrelated to that intent.
+
+---
+
+## R8. In-flight transition safety — panel hide + `moveend` no-fire
+
+### Decision
+
+**The service holds a single `transitionId: number | null` per plot
+and clears it on three independent triggers:**
+
+1. **`moveend` event** from Leaflet's `L.Map.flyTo` (primary path).
+2. **`webviewView.onDidChangeVisibility(false)`** on the Storyboard
+   panel (panel hidden / tab switched).
+3. **Safety timer** — `setTimeout(durationMs + 250)` scheduled at
+   transition start; whichever of these three fires first clears
+   the transitionId and emits the snapshot.
+
+```ts
+private startTransition(documentUri: string, durationMs: number): number {
+  const token = this.nextTransitionId++;
+  this.transitions.set(documentUri, { token, startedAt: Date.now() });
+
+  const timer = setTimeout(() => this.clearTransition(documentUri, token),
+                           durationMs + 250);
+  const disposable = this.panelView.onDidChangeVisibility((visible) => {
+    if (!visible) this.clearTransition(documentUri, token);
+  });
+
+  this.mapPanel.onFlyToComplete(({ token: completedToken }) => {
+    if (completedToken === token) this.clearTransition(documentUri, token);
+  });
+
+  // On clear:
+  // - cancel RAF tween
+  // - clear timer
+  // - dispose visibility listener
+  // - emit snapshot with transport.transitionInFlight = false
+}
+```
+
+### Rationale
+
+- Leaflet's `L.Map.flyTo` on a hidden webview has no defined
+  behaviour — `moveend` may fire late, never, or at an unexpected
+  time after the panel re-shows. The safety timer caps this.
+- Panel-hide-during-flight is a real user flow (the analyst switches
+  VS Code tabs, comes back a minute later); leaving `transitionId`
+  non-null blocks all subsequent transport until a manual refresh.
+- Three independent clears are idempotent — the first one wins;
+  the other two are no-ops on a stale token.
+
+### Alternatives considered
+
+- **Rely on `moveend` only** — rejected. Hidden-webview case leaves
+  the service locked.
+- **Poll for completion every 100ms** — rejected. Three events +
+  one timeout is cheaper and more deterministic than polling.
+- **Fire-and-forget the transition** — rejected. The snapshot
+  needs `transport.transitionInFlight = false` to re-enable the
+  transport buttons.
+
+---
+
+## R9. Transport-vs-CRUD race
+
+### Decision
+
+**Reject Storyboard CRUD ops (Create / Rename / Delete) during an
+in-flight transition** — same single-flight policy as transport.
+Commands return immediately with no side effect; the panel's
+overflow menu buttons are disabled (via `transport.transitionInFlight`
+on the view-model).
+
+On a Delete-the-active-Storyboard op after the transition clears, the
+service first clears `transitionId`, then runs the CRUD call, then
+re-seeds active selection via
+`getMostRecentlyModifiedStoryboard(plot)`.
+
+### Rationale
+
+- A Delete-during-flight would mutate the plot while the transition
+  is animating toward a Scene that may no longer exist. On
+  completion, the service would try to emit a snapshot for removed
+  features. Worst case: a stale thumbnail flashing up before the
+  panel refreshes.
+- Consistent with the existing transport-vs-transport guard — no
+  new policy to reason about.
+- Rename-during-flight is comparatively benign (just a name change),
+  but it's cheaper to use one uniform rule than to model per-op
+  safety.
+
+### Alternatives considered
+
+- **Cancel the transition, then run CRUD** — rejected as the
+  default. A partial fly-to followed by a delete is jarring visually;
+  the analyst may not have realised a transition was in flight.
+  *Available as a design option if user testing shows rejection is
+  too strict.*
+- **Queue CRUD ops for post-transition execution** — rejected.
+  Adds a queue surface for a race that completes in 500ms. Delay +
+  retry is simpler.
+- **Allow CRUD during flight** — rejected per first bullet.
+
+---
+
+## Consolidated Decisions Summary
+
+| # | Topic | Decision | Key Rationale |
+|---|-------|----------|---------------|
+| R1 | Map + slider tween mechanism | Two independent animations driven from a single imperative `advanceTo` on the service | Re-use native Leaflet `flyTo` + existing `setCurrentTime` writes |
+| R2 | Scrub-window enforcement | Narrow `start`/`end` via new `TimeRangeViewProvider.setScrubbableRange`; leave `dataStart`/`dataEnd` at full data extent; restore on deactivation | Re-uses existing `updateTimeExtent` wire format; `timeFilter` doesn't feed the scrubber |
+| R3 | Hard-block modal surface | VS Code-native `showInformationMessage({ modal: true })` in the extension host | Above-webview, keyboard-trappable, platform-idiomatic |
+| R4 | Scoped arrow-key `when` clause | `debrief.storyboardActive && (debrief.mapFocused \|\| focusedView == 'debrief.storyboardPanel')` | Adds one context; enforced by VS Code per-keypress |
+| R5 | Antimeridian rectangle | Single best-effort `L.Polygon` from `scene.geometry.coordinates` | Rare edge case; Leaflet renders correctly; click still works |
+| R6 | Active-Storyboard ephemeral store | In-memory `Map<documentUri, storyboardId>` in the service, keyed by `SessionManager`'s `documentUri` | Matches spec's explicit ephemerality; no new slice / migration |
+| R7 | Most-recently-modified default | New `getMostRecentlyModifiedStoryboard(plot)` query added to #215's queries module | Single source of truth (Article II); existing helper returns "first by name ascending" — wrong for FR-PLAY-002 |
+| R8 | In-flight transition safety | Three clear triggers on `transitionId`: `moveend`, `onDidChangeVisibility`, `durationMs+250ms` safety timer | Handles hidden-webview + `moveend`-no-fire without polling |
+| R9 | Transport-vs-CRUD race | CRUD ops rejected during in-flight transition (same policy as transport) | One uniform single-flight rule; prevents stale-snapshot emission |
+
+All nine decisions resolve cleanly within the existing monorepo
+technology stack. **No NEEDS CLARIFICATION remains.** Proceed to
+Phase 1.

--- a/specs/217-storyboarding-playback/spec.md
+++ b/specs/217-storyboarding-playback/spec.md
@@ -161,8 +161,11 @@ Storyboard is chosen on re-open.
 - **FR-PLAY-002**: The active Storyboard selection MUST be ephemeral
   (not persisted to disk). On plot open, System MUST default the
   active selection to the Storyboard with the most recent
-  `last_modified_at` (via #215's `getActiveStoryboardDefault`); if no
-  Storyboards exist, the panel MUST show an empty state.
+  `last_modified_at` (via `getMostRecentlyModifiedStoryboard` — a
+  new pure query added to #215's queries module by this slice; the
+  existing `getActiveStoryboardDefault` returns "first by name
+  ascending" and is NOT the correct helper); if no Storyboards
+  exist, the panel MUST show an empty state.
 - **FR-PLAY-003**: Changing the dropdown selection MUST update the
   Scene list, the playback transport state, and the on-map Scene
   rectangles within the same user interaction (no visible stale state
@@ -393,9 +396,11 @@ and #218 (edit suite).
 
 ## Dependencies
 
-- **#215 (Schema + CRUD core)** (hard) — Scene ordering,
-  `getActiveStoryboardDefault`, cascading `deleteStoryboard`,
-  `detectMissingDataForScene`.
+- **#215 (Schema + CRUD core)** (hard) — Scene ordering, cascading
+  `deleteStoryboard`, `detectMissingDataForScene`, `validatePlot`.
+  This slice also adds a new `getMostRecentlyModifiedStoryboard`
+  query to #215's queries module (for FR-PLAY-002's default active
+  selection — see plan.md R7).
 - **#216 (Capture)** (hard in practice) — without capture, no Scenes
   exist to play back. Playback can still be tested against fixture
   data without #216 present.

--- a/specs/217-storyboarding-playback/tasks.md
+++ b/specs/217-storyboarding-playback/tasks.md
@@ -1,0 +1,469 @@
+# Tasks: Storyboarding — Panel + Playback
+
+**Feature Branch**: `217-storyboarding-playback`
+**Spec**: [spec.md](spec.md) · **Plan**: [plan.md](plan.md) · **Research**: [research.md](research.md)
+
+> **⚠️ PLAYWRIGHT WORKS IN CLOUD SESSIONS** — Do NOT skip or omit Playwright E2E tasks because you think browsers can't be installed. The project uses `@sparticuz/chromium` which bundles a Linux Chromium binary via npm. Standard browser CDN downloads are blocked (403), but this bundled binary works fully. Run `node apps/web-shell/run-playwright.mjs` to extract and configure. Full details: `docs/project_notes/playwright-installation-research.md`
+
+## Evidence Requirements
+
+**Evidence Directory**: `specs/217-storyboarding-playback/evidence/`
+**Media Directory**: `specs/217-storyboarding-playback/media/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| `test-summary.md` | Aggregated vitest + Playwright results (YAML front matter: feature, captured_at, git_sha, tests_passed, tests_failed, tests_skipped, coverage_pct) | After all tests pass |
+| `usage-example.md` | Walk-through of opening a plot, stepping through a Storyboard, hitting a hard-block, switching Storyboards | After US1 + US2 complete |
+| `screenshots/storyboard-panel-transport-light.png` | TransportRow story in light theme (Storybook capture) | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-transport-dark.png` | TransportRow story in dark theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-transport-vscode.png` | TransportRow story in vscode theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-multi-light.png` | WithMultipleStoryboards story in light theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-multi-dark.png` | WithMultipleStoryboards story in dark theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-multi-vscode.png` | WithMultipleStoryboards story in vscode theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-hardblock-light.png` | HardBlockModal story in light theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-hardblock-dark.png` | HardBlockModal story in dark theme | After T330 Storybook E2E |
+| `screenshots/storyboard-panel-hardblock-vscode.png` | HardBlockModal story in vscode theme | After T330 Storybook E2E |
+| `screenshots/interaction.gif` | 3-5 s GIF of forward-through-storyboard in code-server: Forward click → map flyTo → time slider advance → rectangle highlight update | Captured during webview E2E run, converted from Playwright video |
+| `screenshots/e2e-hardblock.png` | Code-server screenshot of the native VS Code modal surfaced by a missing-feature hard-block | After T340 webview E2E |
+| `screenshots/e2e-dropdown-switch.png` | Code-server screenshot of dropdown switch with Scene rectangles updating | After T340 webview E2E |
+| `feature-integration.md` | Integration diagram + brief — shows how `StoryboardPlaybackService` composes with `#215 CRUD`, `MapPanel`, `TimeRangeViewProvider`, `SessionManager` | After US1 + US2 complete |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| `media/planning-post.md` | Blog post announcing the feature | ✅ Already created during `/speckit.plan` |
+| `media/linkedin-planning.md` | LinkedIn summary for planning | ✅ Already created during `/speckit.plan` |
+| `media/shipped-post.md` | Blog post celebrating completion (What We Built, Screenshots, Lessons Learned, What's Next) | During Polish phase |
+| `media/linkedin-shipped.md` | LinkedIn shipped summary (150–200 words, hook + link to full post) | During Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in `debrief/debrief-future` with evidence attached | Final task in Polish phase |
+| Blog PR | PR in `debrief/debrief.github.io` with shipped post | Triggered by `/speckit.pr` |
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Scaffolding that unblocks implementation — evidence directories, media directory, and a preflight check that #216 is merged to main.
+
+- [ ] T001 Create evidence directory tree `specs/217-storyboarding-playback/evidence/screenshots/.gitkeep`
+- [ ] T002 [P] Preflight: verify `@debrief/components/storyboard` exports `isSceneFeature`, `isStoryboardFeature`, `listScenesOrdered`, `getScene`, `getStoryboard`, `detectMissingDataForScene`, `validatePlot`, `createStoryboard`, `renameStoryboard`, `deleteStoryboard`, `formatDtg` (fails fast if #215 is not on the branch — read-only check) `shared/components/src/storyboard/index.ts`
+- [ ] T003 [P] Preflight: verify `StoryboardPanel` (#216) is present with its current 6-prop shape (`scenes`, `activeStoryboardName`, `captureInFlight`, `onCaptureClick`, `onSceneRowClick` — see `shared/components/src/panels/StoryboardPanel/types.ts`) so design-fix 3 (optional+defaulted new props) can proceed without breaking #216 tests `shared/components/src/panels/StoryboardPanel/types.ts`
+- [ ] T004 [P] Preflight: verify `TimeScrubber` props accept `dataStart`/`dataEnd` + `start`/`end` as separate pairs (required for R2 `setScrubbableRange` approach — if the component has drifted, escalate before starting Foundation) `shared/components/src/TimeController/TimeScrubber.tsx`
+
+**Parallel opportunity**: T002 / T003 / T004 are pure read checks on independent files — run them in parallel with T001.
+
+## Phase 2: Foundation
+
+**Goal**: Ship the shared primitives that both user stories consume — the new #215 query, the `MapPanel` / `TimeRangeView` extensions, the `MapView` additions, the shared helper, the view-model type extensions, the webview message types, and the VS Code command contribution skeleton. No user-visible behaviour yet; every extension point is verified by a unit test before US1 lands its integration.
+
+**Independent test criteria for this phase**: every unit test added below passes in isolation; `pnpm -r typecheck` passes; no user flow exists yet (merely the primitives).
+
+### 2.1 #215 query addition (Fix B / R7)
+
+- [ ] T101 [test] Add unit tests for new `getMostRecentlyModifiedStoryboard` query — empty plot → null, single Storyboard, multiple Storyboards with distinct `provenance[last].timestamp`, tie-break on equal timestamps → ULID ascending `shared/components/src/storyboard/__tests__/queries.test.ts`
+- [ ] T102 Implement `getMostRecentlyModifiedStoryboard(plot: Plot): StoryboardFeature | null` — scans `provenance[last].timestamp` per Storyboard; ties broken by `storyboard.properties.id` ascending `shared/components/src/storyboard/queries.ts`
+- [ ] T103 [P] Re-export `getMostRecentlyModifiedStoryboard` from the package entrypoint `shared/components/src/storyboard/index.ts`
+
+### 2.2 Shared extension helper (design-fix 4)
+
+- [ ] T110 [P][test] Add unit tests for `plotFromFeatures(features: DebriefFeature[]): StoryboardPlot` — wraps a feature array as a throwaway `FeatureCollection`; identity on empty; preserves references (no deep copy) `apps/vscode/src/services/__tests__/plotFromFeatures.test.ts`
+- [ ] T111 Implement `plotFromFeatures` helper — returns `{ type: 'FeatureCollection', features }`; the single source of truth for the boundary between `DebriefFeature[]` and #215's `Plot` type `apps/vscode/src/services/plotFromFeatures.ts`
+
+### 2.3 View-model type extensions (design-fix 3)
+
+- [ ] T120 Extend `StoryboardPanelProps` with **optional+defaulted** fields: `storyboards?: readonly StoryboardOptionViewModel[]`, `activeStoryboardId?: string | null`, `currentSceneId?: string | null`, `transport?: TransportViewModel`, `onActiveStoryboardChange?`, `onCreateStoryboard?`, `onRenameStoryboard?`, `onDeleteStoryboard?`, `onTransportForward?`, `onTransportBackward?`. `SceneRowViewModel` stays at `ok` / `pending` only (no `blocked` variant — design-fix 1). `shared/components/src/panels/StoryboardPanel/types.ts`
+- [ ] T121 [P] Define new view-model types `StoryboardOptionViewModel` (storyboardId, name, sceneCount, lastModifiedIso), `TransportViewModel` (canGoBackward, canGoForward, sceneNumber, sceneTotal, transitionInFlight), `MissingDataReason` (discriminated union) in `shared/components/src/panels/StoryboardPanel/types.ts`
+- [ ] T122 [P] Confirm existing `StoryboardPanel.test.tsx` still compiles (design-fix 3 check — every optional+defaulted field must be usable without explicit value) `shared/components/src/panels/StoryboardPanel/__tests__/StoryboardPanel.test.tsx`
+
+### 2.4 MapPanel API extensions (arch-fix 2 + contracts/map-view-flyto.md)
+
+- [ ] T130 [test] Unit tests for MapPanel additions — `flyToViewport` returns fresh monotonic token, posts `flyTo` webview message with correct args; `flyToViewport(..., 0)` posts `animate: false` equivalent; `setSceneRectangles(null, ...)` posts a clear message; `onFlyToComplete` fires with correct token; `onSceneRectangleClick` fires with sceneId; `onFeaturesChanged` fires on every `setFeatures` call `apps/vscode/src/webview/__tests__/mapPanel.test.ts`
+- [ ] T131 Implement `MapPanel.flyToViewport(viewport, durationMs): number` — allocates fresh token, posts `flyTo` webview message with `{ token, center, zoom, durationMs }` `apps/vscode/src/webview/mapPanel.ts`
+- [ ] T132 Implement `MapPanel.setSceneRectangles(scenes, activeStoryboardId, currentSceneId)` — posts `setSceneRectangles` webview message; serialises Scene features to `{ sceneId, viewport, timestamp }` view-model (no geometry duplication; webview uses `scene.geometry.coordinates`, see T142) `apps/vscode/src/webview/mapPanel.ts`
+- [ ] T133 Implement `MapPanel.onSceneRectangleClick: vscode.Event<string>` — forwards inbound `sceneRectangleClicked` webview message; uses `vscode.EventEmitter<string>` following the existing pattern `apps/vscode/src/webview/mapPanel.ts`
+- [ ] T134 Implement `MapPanel.onFlyToComplete: vscode.Event<number>` — forwards inbound `flyToComplete` webview message `apps/vscode/src/webview/mapPanel.ts`
+- [ ] T135 Implement `MapPanel.onFeaturesChanged: vscode.Event<DebriefFeature[]>` — fired from `setFeatures` after the internal feature-list mutation and the `loadPlot` repost; mirrors the `logPanelView` `_onFeaturesChanged` pattern (`apps/vscode/src/views/logPanelView.ts:123`) `apps/vscode/src/webview/mapPanel.ts`
+- [ ] T136 Extend `MapPanelMessage` + `MapPanelToExtensionMessage` discriminated unions with the new variants (`flyTo`, `setSceneRectangles`, `flyToComplete`, `sceneRectangleClicked`) `apps/vscode/src/webview/messages.ts`
+
+### 2.5 MapView extensions (shared/components)
+
+- [ ] T140 [P][test] Add unit tests for `MapView.flyToTarget` — `durationMs > 0` triggers `L.Map.flyTo` with duration + easeLinearity; `durationMs === 0` triggers `L.Map.setView` with `animate: false`; new token during in-flight supersedes previous; `onFlyToComplete` callback invoked on `moveend` with correct token `shared/components/src/MapView/__tests__/flyTo.test.tsx`
+- [ ] T141 Extend `MapView` with `flyToTarget?: FlyToTarget | null` prop + `onFlyToComplete?(token: number)` callback; integrate into existing `MapController` child (the effect fires on `flyToTarget.token` change); passes `{ duration: durationMs / 1000, easeLinearity: 0.25 }` to Leaflet `shared/components/src/MapView/MapView.tsx`
+- [ ] T142 [P][test] Add unit tests for `SceneRectangleLayer` — renders nothing when `activeStoryboardId === null` or `scenes.length === 0`; renders one `<Polygon>` per Scene; positions derived from `scene.geometry.coordinates` (Fix D — NOT `viewport.corners`); opacity variation on overlapping rectangles; current Scene has bolder stroke; click fires `onSceneRectangleClick(sceneId)`; topmost wins on overlap click; antimeridian viewport renders as single best-effort polygon `shared/components/src/MapView/__tests__/SceneRectangleLayer.test.tsx`
+- [ ] T143 Implement `SceneRectangleLayer.tsx` — react-leaflet `<Polygon>` per Scene from `scene.geometry.coordinates`; `geoJsonPolygonToLeafletCoords` helper (lon,lat → lat,lon); opacity computed via overlap-rank helper; `L.DomEvent.stopPropagation` on click `shared/components/src/MapView/SceneRectangleLayer.tsx`
+- [ ] T144 Extend `MapView` to accept `sceneRectangles?: SceneRectangleLayerProps` and render `<SceneRectangleLayer {...sceneRectangles} />` inside the `<MapContainer>`; add base-layer GeoJSON `filter` that excludes `STORYBOARD` and `STORYBOARD_SCENE` features so rectangles only come from the scoped layer `shared/components/src/MapView/MapView.tsx`
+- [ ] T145 [P] Add theme tokens — `sceneRectangleStroke`, `sceneRectangleFill` — for light / dark / vscode themes `shared/components/src/ThemeProvider/tokens.ts`
+
+### 2.6 TimeRangeView scrubbable-range override (arch-fix 1 / R2)
+
+- [ ] T150 [test] Unit tests for `TimeRangeViewProvider.setScrubbableRange(start, end)` — posting `updateTimeExtent` overrides `start`/`end` but leaves `dataStart`/`dataEnd` at `state.timeRange`; `setScrubbableRange(null, null)` restores; override survives session-state `timeRange` updates (new extent still applies override); cleared on plot switch `apps/vscode/src/views/__tests__/timeRangeView.test.ts`
+- [ ] T151 Implement `TimeRangeViewProvider.setScrubbableRange(start: number | null, end: number | null): void` — stores `scrubbableOverride: { start, end }` field; repost `updateTimeExtent` with `start`/`end` replaced while `dataStart`/`dataEnd` stay from `state.timeRange`; called by `StoryboardPlaybackService` on each transport step / dropdown switch / deactivation `apps/vscode/src/views/timeRangeView.ts`
+
+### 2.7 Webview message types (panel-side)
+
+- [ ] T160 Extend `StoryboardPanelMessage` (webview → extension) discriminated union with `active-storyboard-changed`, `transport-forward-clicked`, `transport-backward-clicked`, `create-storyboard-requested`, `rename-storyboard-requested`, `delete-storyboard-requested` `apps/vscode/src/types/storyboardPanelMessages.ts`
+- [ ] T161 Extend `ExtensionToStoryboardPanelMessage` (extension → webview) with `snapshot` variant (full `StoryboardPlaybackSnapshot` projection); keep `scenes` + `captureInFlight` + `theme` for #216 backward compatibility `apps/vscode/src/types/storyboardPanelMessages.ts`
+
+### 2.8 VS Code command + keybinding contributions (skeleton)
+
+- [ ] T170 Add command contributions to `contributes.commands[]`: `debrief.storyboard.forward`, `.backward`, `.clickScene`, `.jumpPast`, `.editScene`, `.create`, `.rename`, `.delete`, `.openPanel` (latter reveals existing panel) `apps/vscode/package.json`
+- [ ] T171 Add `menus.commandPalette` filter — hide `.clickScene`, `.jumpPast`, `.editScene` via `when: "false"`; gate `.forward`, `.backward` by `debrief.storyboardActive` `apps/vscode/package.json`
+- [ ] T172 Add scoped keybinding contributions — `Left` / `Right` for `.backward` / `.forward` with `when: "debrief.storyboardActive && (debrief.mapFocused || focusedView == 'debrief.storyboardPanel')"` `apps/vscode/package.json`
+
+### Parallel execution examples (Phase 2)
+
+```
+# Batch 2a — T101/T110/T120/T130/T140/T142/T150/T160 can all run in parallel (different files, no cross-deps)
+[P] T101 queries.test.ts
+[P] T110 plotFromFeatures.test.ts
+[P] T120 types.ts (presentational)
+[P] T130 mapPanel.test.ts
+[P] T140 flyTo.test.tsx
+[P] T142 SceneRectangleLayer.test.tsx
+[P] T150 timeRangeView.test.ts
+[P] T160 storyboardPanelMessages.ts
+
+# Batch 2b — implementations (some serial within a file, but batches can run in parallel with other files)
+T102 → T103          (queries.ts then re-export)
+T111                 (plotFromFeatures.ts)
+T131 → T132 → T133 → T134 → T135 → T136   (mapPanel.ts + messages.ts serial — all touch files)
+T141                 (MapView.tsx)
+T143 → T144          (SceneRectangleLayer.tsx then MapView integration)
+T145                 (theme tokens)
+T151                 (timeRangeView.ts)
+T170 → T171 → T172   (package.json — same file, serial)
+```
+
+## Phase 3: US1 — Step through a storyboard to deliver a briefing (P1)
+
+**Story goal**: An analyst with Scenes already captured (via #216) opens the Storyboard panel, picks a Storyboard from the header, and steps Forward and Backward through its Scenes using on-screen transport or scoped arrow keys. The map animates between Scenes; the time slider tweens; scrub is constrained to the current Scene segment. Scene viewport rectangles render on the map for the active Storyboard only. A Scene with unresolved feature IDs or out-of-range timestamp hard-blocks with a native modal offering *Jump past this scene* / *Open for editing*.
+
+**Independent test**: Load a plot with a fixture Storyboard of at least three Scenes (no #216 capture run needed). Confirm (a) Forward button and scoped `Right`-arrow advance to the next Scene, (b) map performs animated `flyTo` + time slider tweens over `transition_duration_ms`, (c) scrub clamped to `[scene[N].t, scene[N+1].t]`, (d) Scene rectangles render only for active Storyboard, (e) stepping onto a deliberately-broken Scene hard-blocks with the modal, (f) *Jump past this scene* advances past the blocked Scene without animating into it.
+
+### 3.1 Presentational components — TransportRow + HardBlockModal (tests first)
+
+- [ ] T301 [P][test] Unit tests for `TransportRow` — renders Forward / Backward buttons and "Scene N of M" counter; buttons disabled at boundaries (N=1 Backward, N=M Forward); transitionInFlight disables both; aria-labels present; click fires corresponding callbacks `shared/components/src/panels/StoryboardPanel/__tests__/TransportRow.test.tsx`
+- [ ] T302 [P][test] Unit tests for `HardBlockModal` (Storybook-only presentational) — renders body describing the scene + reason kind; two action buttons with labels; focus trap on dialog; `Escape` fires `onDismiss`; `role="dialog"` + `aria-modal="true"` present `shared/components/src/panels/StoryboardPanel/__tests__/HardBlockModal.test.tsx`
+- [ ] T303 Implement `TransportRow.tsx` — consumes `TransportViewModel` + two click callbacks; renders Forward / Backward `<button>`s with vscrui icons; disabled state from `canGoForward` / `canGoBackward` / `transitionInFlight`; counter renders "Scene N of M" or empty when `sceneTotal === 0` `shared/components/src/panels/StoryboardPanel/TransportRow.tsx`
+- [ ] T304 Implement `HardBlockModal.tsx` (presentational, Storybook-only) — consumes `sceneTitle`, `reason`, `jumpPastLabel`, `openForEditingLabel`; `<div role="dialog" aria-modal="true">`; body renders the missing-features list or "out-of-range" copy; two action `<button>`s wired to callbacks; `useEffect` for `Escape` key handler `shared/components/src/panels/StoryboardPanel/HardBlockModal.tsx`
+
+### 3.2 Integrate TransportRow into StoryboardPanel
+
+- [ ] T310 [test] Extend existing `StoryboardPanel.test.tsx` — TransportRow renders when `transport` prop provided; TransportRow hidden when `transport` undefined (design-fix 3); current-scene highlight applied to matching row via `currentSceneId` prop; `[data-active="true"]` attribute present on current row `shared/components/src/panels/StoryboardPanel/__tests__/StoryboardPanel.test.tsx`
+- [ ] T311 Update `StoryboardPanel.tsx` to render `<TransportRow>` below the Scene list when `transport` prop is provided; apply `data-active="true"` to the Scene row matching `currentSceneId` (used by E2E + CSS highlight); retain #216 empty-state paths unchanged `shared/components/src/panels/StoryboardPanel/StoryboardPanel.tsx`
+- [ ] T312 [P] Add `Transport` and `HardBlockModal` stories to Storybook — Transport story shows 3-Scene panel with transport enabled; HardBlockModal story shows missing-features variant with labels populated `shared/components/src/panels/StoryboardPanel/StoryboardPanel.stories.tsx`
+
+### 3.3 StoryboardPlaybackService — transport state machine (tests first)
+
+- [ ] T320 [test] Unit tests for `StoryboardPlaybackService` — state machine core (`apps/vscode/src/services/__tests__/storyboardPlayback.test.ts`):
+  - `onPlotOpened` runs `validatePlot`; on throw, `plotValid = false`, single `showErrorMessage`, all subsequent forward/backward/goToScene are no-ops (design-fix 2)
+  - `onPlotOpened` seeds `activeStoryboardId` from `getMostRecentlyModifiedStoryboard(plot)` (R7)
+  - `onPlotOpened` calls `timeRangeView.setScrubbableRange(start, end)` for the Scene window
+  - `onPlotClosed` calls `timeRangeView.setScrubbableRange(null, null)`
+  - `forward` advances when `transitionId === null` AND not at last AND hard-block check passes
+  - `forward` is no-op during in-flight transition (FR-PLAY-009)
+  - `forward` is no-op at last scene (FR-PLAY-010)
+  - `backward` mirrors forward at first scene
+  - `goToScene(sceneId)` treats as transport — runs hard-block check; no-op during flight
+  - `setActiveStoryboard` recomputes `sceneOrder`, `currentSceneIndex = 0`, calls `setScrubbableRange` for new window (FR-PLAY-003)
+  - Scrub during in-flight cancels `transitionId`
+  - `onDidChangeVisibility(false)` cancels `transitionId` (R8)
+  - `durationMs + 250ms` safety timer fires when `moveend` never arrives (R8)
+  - Plot-switch cancels old plot's `transitionId` (R8)
+  - CRUD ops (Create / Rename / Delete) are rejected during in-flight transition (R9)
+  - `detectMissingDataForScene` boundary receives ISO strings converted from `TemporalSlice.timeRange` epoch ms (arch-fix 4); `NaN` inputs handled gracefully
+  - `resolveHardBlockByJumpingPast` advances past blocked Scene in requested direction
+  - `resolveHardBlockByOpeningForEditing` surfaces `showInformationMessage` with read-only Scene details; transport unchanged
+  - `onPlotFeaturesChanged` recomputes `sceneOrder`; if active Storyboard was deleted, falls back via `getMostRecentlyModifiedStoryboard`; if none remain, `activeStoryboardId = null`, clear context
+  - `dispose` calls `setScrubbableRange(null, null)` for every plot with an active override (test-fix 4)
+
+- [ ] T321 Implement `StoryboardPlaybackService` class skeleton — constructor accepts `{ sessionManager, mapPanel, panelView, timeRangeView, storyboardModule, modalPromptPort, visibilityPort, transitionController }`; per-plot `Map<documentUri, TransportState>`; `onSnapshotChange` event emitter; `getSnapshot(documentUri)` projection `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T322 Implement lifecycle methods — `onPlotOpened` (validatePlot gate + seed active + setScrubbableRange + set `debrief.storyboardActive` context); `onPlotClosed` (restore scrubbable range + clear context + remove entry); `onPlotFeaturesChanged` (recompute sceneOrder + fallback via getMostRecentlyModifiedStoryboard) `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T323 Implement transport methods — `forward`, `backward`, `goToScene`; each runs in-flight guard → boundary guard → hard-block check (ISO conversion) → `executeTransition` `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T324 Implement `executeTransition(documentUri, targetIndex, direction)` — sets `transitionId`; calls `mapPanel.flyToViewport(viewport, durationMs)`; starts RAF tween writing `session.setCurrentTime(lerp)` over `durationMs`; calls `timeRangeView.setScrubbableRange(sceneN.t, sceneN+1.t)`; wires three clear triggers (`onFlyToComplete`, `onDidChangeVisibility`, `durationMs+250ms` timer); idempotent — first trigger wins `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T325 Implement hard-block flow — `promptHardBlock(scene, classification, direction, documentUri)` calls `modalPromptPort.showInformationMessage({ modal: true }, jumpPastLabel, openForEditingLabel)`; route to `resolveHardBlockByJumpingPast` / `resolveHardBlockByOpeningForEditing` (showInformationMessage inline — no separate command registration) `apps/vscode/src/services/storyboardPlayback.ts`
+
+### 3.4 Command handlers + package.json (US1 subset)
+
+- [ ] T330 [test] Unit tests for US1 command handlers — forward/backward/clickScene/jumpPast dispatch to service with `documentUri = sessionManager.getActiveDocumentUri()`; return early when `documentUri === null` `apps/vscode/src/commands/__tests__/storyboardCommands.test.ts`
+- [ ] T331 Implement `registerStoryboardTransportCommands(context, service, sessionManager)` — registers `debrief.storyboard.forward`, `.backward`, `.clickScene`, `.jumpPast` `apps/vscode/src/commands/storyboardTransport.ts`
+- [ ] T332 [P] Note: `debrief.storyboard.editScene` is NOT registered as a command for this slice — the "Open for editing" modal action calls `showInformationMessage` inline from the service. This task is a documentation marker only (no code change) — confirm `resolveHardBlockByOpeningForEditing` surfaces a read-only `showInformationMessage` with Scene title + DTG `apps/vscode/src/services/storyboardPlayback.ts`
+
+### 3.5 Extension host wiring (US1)
+
+- [ ] T340 Wire `StoryboardPlaybackService` in `extension.ts` — instantiate after `SessionManager` + `MapPanel` + `StoryboardPanelViewProvider` + `TimeRangeViewProvider`; subscribe to `sessionManager.onActiveSessionChange` → `service.onPlotOpened / onPlotClosed`; subscribe to `mapPanel.onFeaturesChanged` → `service.onPlotFeaturesChanged`; subscribe to `mapPanel.onSceneRectangleClick` → `service.goToScene`; subscribe to `mapPanel.onFlyToComplete` → service's transition-clear path; register US1 transport commands; maintain `debrief.storyboardActive` context `apps/vscode/src/extension.ts`
+- [ ] T341 Extend `StoryboardPanelViewProvider` to accept a `StoryboardPlaybackSnapshot` via a new `applySnapshot(snap)` method that posts a `snapshot` webview message; subscribe to `service.onSnapshotChange`; rewrite the stale `"#217 will replace with flyTo behaviour"` comment (design-fix 4) — the handler now delegates `scene-row-clicked` to `debrief.storyboard.clickScene`; use the new `plotFromFeatures` helper for any plot-reconstruction paths `apps/vscode/src/views/storyboardPanelView.ts`
+- [ ] T342 Update `storyboardPanelView.ts` message handler to forward new inbound messages (`transport-forward-clicked`, `transport-backward-clicked`) via `vscode.commands.executeCommand('debrief.storyboard.forward' / '.backward')` — ensures button clicks and scoped arrow keys share the same code path `apps/vscode/src/views/storyboardPanelView.ts`
+- [ ] T343 Update `storyboardPanel.tsx` webview entry — subscribe to the new `snapshot` inbound message and pass `storyboards`, `activeStoryboardId`, `currentSceneId`, `transport` to `StoryboardPanel`; wire `onTransportForward` / `onTransportBackward` / `onSceneRowClick` to `postMessage` variants `apps/vscode/src/webview/web/storyboardPanel.tsx`
+- [ ] T344 [P] Update `mapView.tsx` webview — subscribe to inbound `flyTo` + `setSceneRectangles` messages; pass `flyToTarget` + `sceneRectangles` props to `<MapView>`; post outbound `flyToComplete` (on `onFlyToComplete`) + `sceneRectangleClicked` (on `onSceneRectangleClick`) `apps/vscode/src/webview/web/mapView.tsx`
+
+### 3.6 E2E coverage (US1)
+
+- [ ] T350 [test] Playwright E2E — forward through a populated Storyboard (SC-002 + FR-PLAY-005 / -007): open plot fixture with ≥ 3 Scenes → open Storyboard panel → press Forward × (N-1) → verify `flyTo` call count + time slider advances + current-Scene highlight (`[data-testid="scene-row"][data-active="true"]`) + transport counter advances `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T351 [test] Playwright E2E — scoped `Right` arrow (SC-007 + FR-PLAY-006): focus Map Panel (storyboard active), press `Right` → verify Forward fires; focus Log Panel, press `Right` → verify no transport change `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T352 [test] Playwright E2E — scrub-window lock (SC-004 + FR-PLAY-012/-013): position on Scene N, drag scrubber thumb past `scene[N+1].timestamp` → verify clamp at boundary; position on last Scene, verify scrub past its timestamp is disabled `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T353 [test] Playwright E2E — click Scene rectangle on map (FR-PLAY-017): click a non-current rectangle → verify panel selection jumps + map animates to that Scene's viewport `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T354 [test] Playwright E2E — hard-block on missing-feature (FR-PLAY-019/-020/-021): step onto a Scene whose `visible_feature_ids` has been deleted → verify native modal surfaces → click *Jump past this scene* → verify transport advanced past blocked Scene without animating into it `tests/e2e/test-storyboard-playback.spec.ts`
+
+**Checkpoint**: US1 complete. An analyst can walk forward and backward through a single Storyboard end-to-end inside the Map Viewer. Scene rectangles render on the map for the active Storyboard. Hard-block surfaces on missing data with Jump past / Open for editing. This is the epic's stated core value — shippable independently of US2.
+
+### Parallel execution examples (Phase 3)
+
+```
+# Batch 3a — tests can run in parallel
+[P] T301 TransportRow.test.tsx
+[P] T302 HardBlockModal.test.tsx
+[P] T310 StoryboardPanel.test.tsx extensions
+[P] T320 storyboardPlayback.test.ts
+[P] T330 storyboardCommands.test.ts
+[P] T350–T354 E2E — independent test files, same suite
+
+# Batch 3b — presentational implementations (different files)
+[P] T303 TransportRow.tsx
+[P] T304 HardBlockModal.tsx
+(T311 StoryboardPanel.tsx — depends on T303)
+[P] T312 Stories file
+
+# Batch 3c — service implementation (same file — serial)
+T321 → T322 → T323 → T324 → T325
+
+# Batch 3d — extension wiring (mostly same file — serial within file)
+T340 (extension.ts) → T341 → T342 (storyboardPanelView.ts serial)
+[P] T343 storyboardPanel.tsx
+[P] T344 mapView.tsx
+```
+
+## Phase 4: US2 — Maintain multiple storyboards per plot (P2)
+
+**Story goal**: A plot can carry several narratives — "commander's view", "ASW evidence", "training debrief". The analyst switches between them from the panel header dropdown; the Scene list, transport, and on-map rectangles all follow. The analyst can create a new Storyboard from the overflow menu, rename the active one, or delete a Storyboard (with cascade-delete confirmation). On plot re-open, the active selection defaults to the most-recently-modified Storyboard.
+
+**Independent test**: With two Storyboards on a plot, switch between them via the header dropdown and confirm (a) Scene list updates to the selected Storyboard, (b) Scene viewport rectangles update to only those of the active Storyboard, (c) selection is not persisted across plot close/open — the most-recently-modified Storyboard is chosen on re-open. Create a new Storyboard from the overflow menu — confirm it appears in the dropdown and becomes the active selection. Delete a Storyboard with Scenes — confirm confirmation modal names Scene count; on confirm, Storyboard + Scenes removed via #215's cascade; dropdown refreshes; active selection falls back.
+
+### 4.1 Presentational component — StoryboardHeader (tests first)
+
+- [ ] T401 [P][test] Unit tests for `StoryboardHeader` — renders dropdown with all `storyboards` option; marks `activeStoryboardId` as selected; overflow menu opens on icon click; menu items present: Create, Rename, Delete; Rename / Delete hidden when no `activeStoryboardId`; `aria-expanded` / `role="menu"` accessibility attributes; empty `storyboards` hides dropdown (design-fix 3) `shared/components/src/panels/StoryboardPanel/__tests__/StoryboardHeader.test.tsx`
+- [ ] T402 Implement `StoryboardHeader.tsx` — `<select>` dropdown populated from `storyboards[]` + overflow `<button>` that toggles a menu with Create / Rename / Delete items; vscrui icons; each menu item fires a prop callback or hides if callback is undefined `shared/components/src/panels/StoryboardPanel/StoryboardHeader.tsx`
+
+### 4.2 Integrate StoryboardHeader into StoryboardPanel
+
+- [ ] T410 [test] Extend `StoryboardPanel.test.tsx` — StoryboardHeader renders when `storyboards` prop provided and non-empty; hidden when `storyboards` undefined or empty (design-fix 3 — #216 tests still pass unchanged); dropdown change fires `onActiveStoryboardChange` with target `storyboardId` `shared/components/src/panels/StoryboardPanel/__tests__/StoryboardPanel.test.tsx`
+- [ ] T411 Update `StoryboardPanel.tsx` to render `<StoryboardHeader>` above the Scene list when `storyboards` prop non-empty; pass through dropdown + overflow callbacks; keep the #216 static header fallback when `storyboards` empty `shared/components/src/panels/StoryboardPanel/StoryboardPanel.tsx`
+- [ ] T412 [P] Add `WithMultipleStoryboards` story — 3 Storyboards, 5 Scenes on active, dropdown populated; play function opens overflow menu `shared/components/src/panels/StoryboardPanel/StoryboardPanel.stories.tsx`
+
+### 4.3 StoryboardPlaybackService — management methods (tests extend T320 suite)
+
+- [ ] T420 [test] Extend `storyboardPlayback.test.ts` with management tests — `setActiveStoryboard` switches within same microtask (SC-003); `createStoryboard` delegates to #215 CRUD, new Storyboard becomes active; `renameStoryboard` delegates; `deleteStoryboard` delegates (cascading delete handled by #215); external deletion via `onPlotFeaturesChanged` falls back to `getMostRecentlyModifiedStoryboard`; all three CRUD ops reject during in-flight transition (R9 / test-fix 1) `apps/vscode/src/services/__tests__/storyboardPlayback.test.ts`
+- [ ] T421 Implement `setActiveStoryboard(documentUri, storyboardId | null)` — synchronous; updates per-plot map, recomputes `sceneOrder`, `currentSceneIndex = 0`, calls `setScrubbableRange` for new window, emits snapshot `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T422 Implement `createStoryboard(documentUri, name, description?)` — in-flight guard (reject with no side effect); calls `createStoryboard` from `@debrief/components/storyboard`; pushes new feature set back via `MapPanel.setFeatures`; sets new Storyboard as active; catches `DuplicateStoryboardName` → `showErrorMessage` `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T423 Implement `renameStoryboard(documentUri, storyboardId, newName)` — in-flight guard; calls `renameStoryboard` from `@debrief/components/storyboard`; pushes new features via `MapPanel.setFeatures`; catches `DuplicateStoryboardName` / `UnknownStoryboard` → `showErrorMessage` `apps/vscode/src/services/storyboardPlayback.ts`
+- [ ] T424 Implement `deleteStoryboard(documentUri, storyboardId)` — in-flight guard; calls `deleteStoryboard` from `@debrief/components/storyboard` (cascade); pushes new features via `MapPanel.setFeatures`; if deleted Storyboard was active, re-seed via `getMostRecentlyModifiedStoryboard`; if no Storyboards remain, clear `debrief.storyboardActive` context + scrubbable override `apps/vscode/src/services/storyboardPlayback.ts`
+
+### 4.4 Command handlers + package.json (US2 subset)
+
+- [ ] T430 [test] Extend `storyboardCommands.test.ts` — Create command: `showInputBox` with `validateStoryboardName`; CRUD only invoked with non-empty trimmed name; Rename: pre-populates current name, validates uniqueness excluding self, no-op on unchanged name; Delete: non-empty Storyboard prompts `showWarningMessage` modal with Scene count; empty Storyboard skips confirmation; *Delete* confirmation fires CRUD; any other choice leaves state unchanged `apps/vscode/src/commands/__tests__/storyboardCommands.test.ts`
+- [ ] T431 Implement `registerStoryboardManagementCommands` — registers `debrief.storyboard.create`, `.rename`, `.delete` with input-box + confirmation modals per contract §4.2 `apps/vscode/src/commands/storyboardManagement.ts`
+- [ ] T432 [P] Implement `validateStoryboardName(candidate, existing, ignoreId?)` helper — trim + non-empty + ≤ 120 chars + no collision against `existing` (excluding `ignoreId`); returns the error string for `showInputBox.validateInput` or `null` for OK `apps/vscode/src/commands/storyboardManagement.ts`
+
+### 4.5 Extension host wiring (US2)
+
+- [ ] T440 Register management commands in `extension.ts` — call `registerStoryboardManagementCommands(context, service, sessionManager)` after `registerStoryboardTransportCommands` `apps/vscode/src/extension.ts`
+- [ ] T441 Update `storyboardPanelView.ts` message handler — forward `active-storyboard-changed` → `service.setActiveStoryboard(documentUri, storyboardId)` synchronously; forward `create-storyboard-requested` → `vscode.commands.executeCommand('debrief.storyboard.create')`; same pattern for rename / delete `apps/vscode/src/views/storyboardPanelView.ts`
+- [ ] T442 Update `storyboardPanel.tsx` webview entry — wire `onActiveStoryboardChange`, `onCreateStoryboard`, `onRenameStoryboard`, `onDeleteStoryboard` to their `postMessage` variants `apps/vscode/src/webview/web/storyboardPanel.tsx`
+
+### 4.6 E2E coverage (US2)
+
+- [ ] T450 [test] Playwright E2E — dropdown switch refreshes Scene list + rectangles (SC-003 + SC-006 + FR-PLAY-003): open plot with 2 Storyboards → switch dropdown → verify previous Storyboard's rectangles gone, new Storyboard's rectangles render; Scene list updated; all within the same user interaction (no visible stale state after dropdown closes) `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T451 [test] Playwright E2E — Create → new Storyboard becomes active (FR-PLAY-001 Create): open overflow menu → Create → enter name → confirm → verify dropdown includes new Storyboard and selection is the new one; panel shows empty Scene list `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T452 [test] Playwright E2E — Rename via overflow menu: open overflow → Rename → enter new name → verify dropdown updates with new name `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T453 [test] Playwright E2E — Delete non-empty Storyboard prompts confirmation with Scene count (FR-PLAY-004): open overflow → Delete → verify `showWarningMessage` modal body names Scene count → confirm → verify Storyboard gone from dropdown, Scenes removed, active selection falls back to most-recently-modified remaining `tests/e2e/test-storyboard-playback.spec.ts`
+- [ ] T454 [test] Playwright E2E — External deletion refreshes silently: simulate external delete via test hook (directly calls `service.deleteStoryboard`) → verify dropdown refreshes, active selection falls back silently, no error toast `tests/e2e/test-storyboard-playback.spec.ts`
+
+**Checkpoint**: US2 complete. An analyst can manage multiple Storyboards per plot. Combined with US1, this closes all functional requirements in the spec.
+
+### Parallel execution examples (Phase 4)
+
+```
+# Batch 4a — tests first
+[P] T401 StoryboardHeader.test.tsx
+[P] T410 StoryboardPanel.test.tsx extensions
+[P] T420 storyboardPlayback.test.ts extensions
+[P] T430 storyboardCommands.test.ts extensions
+[P] T450–T454 E2E — can be written in parallel
+
+# Batch 4b — presentational
+[P] T402 StoryboardHeader.tsx
+(T411 depends on T402)
+[P] T412 Stories
+
+# Batch 4c — service (same file — serial)
+T421 → T422 → T423 → T424
+
+# Batch 4d — commands (same file — serial)
+T431 → T432 (storyboardManagement.ts)
+
+# Batch 4e — wiring (different files)
+T440 (extension.ts)
+[P] T441 storyboardPanelView.ts
+[P] T442 storyboardPanel.tsx
+```
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Goal**: Collect evidence, close out the schema-adherence / offline / strict-type gates, produce the shipped-post media, and open the PR. No new feature work.
+
+### 5.1 Pre-PR CI gates
+
+- [ ] T501 Run `task verify` (or fallback: `uv run ruff check . && pnpm lint && uv run pyright && pnpm -r typecheck && uv run pytest && pnpm --filter '!@debrief/web-shell' test`) — every step MUST pass before opening the PR (CLAUDE.md "Before Pushing")
+- [ ] T502 Run web-shell Playwright suite — `cd apps/web-shell && node run-playwright.mjs && cd ../..` (bundled Chromium via `@sparticuz/chromium`)
+- [ ] T503 Run VS Code webview E2E — `pnpm --filter @debrief/vscode-extension build && cd tests/e2e && pnpm exec playwright test test-storyboard-playback.spec.ts` — all nine T350–T354 + T450–T454 scenarios pass
+
+### 5.2 Storybook E2E (theme capture)
+
+- [ ] T510 [test] Storybook E2E — verify 3 stories × 3 theme variants × basic render + accessibility assertions `shared/components/e2e/StoryboardPanel.spec.ts` (extend existing file from #216)
+- [ ] T511 [P] Run the Storybook build + E2E run (`pnpm --filter @debrief/components storybook:build && node apps/web-shell/run-playwright.mjs`); archive the nine PNGs into the evidence directory `specs/217-storyboarding-playback/evidence/screenshots/`
+
+### 5.3 Interaction GIF capture
+
+- [ ] T520 Record interaction GIF via Playwright — enable `recordVideo` in the webview E2E config for T350 (forward-through-storyboard); convert the WebM to ≤ 2MB / ≤ 5s GIF using `ffmpeg` with `scale=800:-1`; save to `specs/217-storyboarding-playback/evidence/screenshots/interaction.gif`
+
+### 5.4 Evidence collection
+
+- [ ] T530 Capture test results using the template (`.specify/templates/evidence/test-summary-template.md`) with YAML front matter (feature, captured_at, git_sha, tests_passed, tests_failed, tests_skipped, coverage_pct) — include counts for vitest unit tests + Playwright E2E + Storybook E2E `specs/217-storyboarding-playback/evidence/test-summary.md`
+- [ ] T531 Create usage demonstration — walk-through of: open plot, open Storyboard panel, Forward through 3 Scenes, scrub within a segment, switch Storyboard via dropdown, hit a hard-block, jump past. Include screenshots at key steps `specs/217-storyboarding-playback/evidence/usage-example.md`
+- [ ] T532 [P] Capture E2E screenshot — native VS Code hard-block modal in code-server (output from T354) `specs/217-storyboarding-playback/evidence/screenshots/e2e-hardblock.png`
+- [ ] T533 [P] Capture E2E screenshot — dropdown switch with Scene rectangles updating (output from T450) `specs/217-storyboarding-playback/evidence/screenshots/e2e-dropdown-switch.png`
+- [ ] T534 [P] Produce integration diagram + brief — Mermaid sequence diagram showing `StoryboardPanel` click → `storyboardPanelView` postMessage → `vscode.commands.executeCommand('debrief.storyboard.forward')` → `StoryboardPlaybackService.forward` → `#215 detectMissingDataForScene` → `MapPanel.flyToViewport` → `TimeRangeViewProvider.setScrubbableRange`; narrative explaining each hop `specs/217-storyboarding-playback/evidence/feature-integration.md`
+
+### 5.5 Media content (shipped post + LinkedIn)
+
+- [ ] T540 Create shipped blog post using the Content Specialist agent (`.claude/agents/media/content.md`) — sections: What We Built (delivery flow landed), Screenshots (embedded from T511 + T520 + T532 + T533), By the Numbers (metrics from T530's YAML front matter), Lessons Learned (R2 discovery about `timeFilter` vs `timeExtent`; the three-trigger transition-clear; the design-fix-1 "don't pre-compute row state" decision), What's Next (#218 edit suite) — front matter per agent spec: `layout: future-post`, `track: [credibility]`, `author: Ian`, `reading_time` calculated, `excerpt` under 150 chars `specs/217-storyboarding-playback/media/shipped-post.md`
+- [ ] T541 [P] Create LinkedIn shipped summary (150–200 words) — strong hook (analyst walking into a briefing), one concrete implementation insight (three-trigger transition-clear or the `timeFilter` trap), link placeholder `{{POST_URL}}`, tags `#FutureDebrief #MaritimeAnalysis #OpenSource` `specs/217-storyboarding-playback/media/linkedin-shipped.md`
+
+### 5.6 Documentation hygiene
+
+- [ ] T550 Update `CHANGELOG.md` — add the #217 entry under "Unreleased" describing the Storyboard panel + playback transport landing (brief — links to the PR) `CHANGELOG.md`
+- [ ] T551 [P] Log in `docs/project_notes/issues.md` with ticket #217 URL and evidence-dir reference `docs/project_notes/issues.md`
+- [ ] T552 [P] Log the R2 research finding (`timeFilter` vs `timeExtent` — the scrubber doesn't consume `timeFilter`) in `docs/project_notes/bugs.md` so a future PR doesn't repeat the mistake `docs/project_notes/bugs.md`
+
+### 5.7 PR creation
+
+- [ ] T560 Create PR and publish blog: run `/speckit.pr`
+
+**Task T560 must run last. It depends on T501–T552 being complete.** It will:
+- Open the feature PR in `debrief/debrief-future` with the generated description + evidence links
+- Open a companion PR in `debrief/debrief.github.io` publishing the shipped post
+- Return both URLs for review
+
+### Parallel execution examples (Phase 5)
+
+```
+# Batch 5a — verify gates (strictly serial — each catches the next)
+T501 → T502 → T503 → T510
+
+# Batch 5b — parallel evidence
+[P] T511 archive Storybook PNGs
+[P] T520 GIF capture
+[P] T530 test-summary.md
+[P] T531 usage-example.md
+[P] T532 e2e-hardblock.png
+[P] T533 e2e-dropdown-switch.png
+[P] T534 feature-integration.md
+
+# Batch 5c — media
+T540 → T541 (content specialist delivers post first, then LinkedIn summary)
+
+# Batch 5d — docs hygiene (different files — parallel)
+[P] T550 CHANGELOG.md
+[P] T551 issues.md
+[P] T552 bugs.md
+
+# Final
+T560 /speckit.pr
+```
+
+## Dependencies
+
+### Story completion order
+
+1. **Phase 1 Setup** (T001–T004) must complete before any other work — evidence scaffolding + #216 / #215 / TimeScrubber preflight checks. Any preflight failure escalates before Foundation starts.
+2. **Phase 2 Foundation** (T101–T172) must complete before US1 integration (§3.3 onwards) — US1 relies on:
+   - `getMostRecentlyModifiedStoryboard` (T102) for onPlotOpened seeding
+   - `plotFromFeatures` helper (T111) for the #215 module boundary
+   - `MapPanel.flyToViewport / onFlyToComplete / onFeaturesChanged / onSceneRectangleClick` (T131–T135) for transition + rectangle + external-change plumbing
+   - `MapView.flyToTarget` + `SceneRectangleLayer` (T141 / T143 / T144) for the render path
+   - `TimeRangeViewProvider.setScrubbableRange` (T151) for scrub-window enforcement (R2)
+   - Webview message-type extensions (T160 / T161) for the new `snapshot` + transport / management messages
+   - Command + keybinding contributions (T170 / T171 / T172) — without these the commands don't appear in VS Code
+3. **Phase 3 US1** (T301–T354) MUST complete as a standalone slice — it passes the P1 independent test without any US2 work. Within Phase 3:
+   - Presentational (T301–T312) independent of service work — can land in parallel
+   - Service (T320–T325) must land before extension wiring (T340–T344)
+   - E2E (T350–T354) can be scripted after commands register but requires the service + wiring to pass
+4. **Phase 4 US2** (T401–T454) depends on Phase 3 being **interaction-complete** — specifically on:
+   - `StoryboardPanel.tsx` (T311) already rendering new optional props so `StoryboardHeader` can be layered on
+   - `StoryboardPlaybackService` transitions working so T424's cascade-delete fallback has meaning
+   - `storyboardPanelView.ts` postMessage handler wired (T342) — US2 message variants extend the same dispatch
+   - Within Phase 4: service management ops (T421–T424) before command handlers (T431–T432) before extension wiring (T440–T442) before E2E (T450–T454).
+5. **Phase 5 Polish** (T501–T560) depends on **both** stories being complete — every test must pass; every artefact must exist; PR is the terminal task.
+
+### Cross-phase dependencies at a glance
+
+```
+Setup ──► Foundation ──► US1 ──► US2 ──► Polish ──► PR
+ (4)       (~23)        (~17)   (~17)    (~18)     (1)
+```
+
+Total: ~80 tasks. See §5.7 for PR-creation gating.
+
+## Implementation Strategy
+
+### Incremental delivery
+
+#217 is explicitly shippable in two tranches that correspond to the two user stories:
+
+1. **Tranche 1 — US1 (P1 "Step through a storyboard")**: Phases 1 + 2 + 3. After this lands, an analyst with a single Storyboard captured via #216 can walk a stakeholder through it end-to-end: on-screen Forward / Backward transport, scoped arrow keys, `flyTo` + time-slider tween, scrub clamp per segment, on-map Scene rectangles, hard-block on missing data with *Jump past* / *Open for editing*. Delivers the epic's stated core value.
+2. **Tranche 2 — US2 (P2 "Multiple storyboards")**: Phase 4. After this lands, the analyst can manage multiple Storyboards per plot via the dropdown + overflow (Create / Rename / Delete).
+
+Either tranche can ship as its own PR if the programme manager prefers smaller review units. The default is a single PR covering both + Phase 5.
+
+### MVP boundary
+
+**MVP = Tranche 1**. A plot opened in VS Code with a captured Storyboard (from #216) becomes walkable on the map, with clean interaction semantics and a safety net for missing data. That is the minimum deliverable for the epic's "guided walk-through" goal.
+
+Tranche 2 makes the capability *sustainable* across realistic analyst workflows (multiple narratives per plot), but is not required for the briefing-delivery flow itself.
+
+### Test-first discipline (constitution VII)
+
+Each phase's tests are authored before the corresponding implementation. For Phase 3:
+
+- T301 / T302 before T303 / T304 (presentational tests before components)
+- T310 before T311 (integration tests before panel integration)
+- T320 before T321–T325 (service tests before service)
+- T330 before T331 (command tests before commands)
+- T350–T354 are scripted last (they require the end-to-end wiring to be in place)
+
+Phase 4 follows the same pattern: T401 before T402, T410 before T411, T420 before T421–T424, T430 before T431–T432, T450–T454 after all wiring.
+
+### Risk markers + mitigations (from /speckit.review)
+
+| Risk | Mitigation | Task |
+|---|---|---|
+| `timeFilter` does not constrain the scrubber (R2) | `TimeRangeViewProvider.setScrubbableRange` overrides `start`/`end` at the view-provider layer — never touches session-state `timeFilter` | T151 |
+| `getActiveStoryboardDefault` is "first by name ascending", not most-recently-modified (R7) | New `getMostRecentlyModifiedStoryboard` pure query added to #215 | T102 |
+| `SessionManager` keys by `documentUri` (STAC URI), not `plotPath` (Fix C) | All service / command signatures use `documentUri` throughout | T321 + all command handlers |
+| `SceneFeature.geometry.coordinates` holds the rectangle geometry, NOT `viewport.corners` (Fix D) | `SceneRectangleLayer.tsx` reads `scene.geometry.coordinates` via `geoJsonPolygonToLeafletCoords` | T143 |
+| Leaflet `moveend` may not fire when webview is hidden (R8) | Three-trigger clear on `transitionId`: `onFlyToComplete` + `onDidChangeVisibility(false)` + `durationMs+250ms` safety timer | T324 |
+| CRUD-during-flight could emit stale snapshot (R9) | Create / Rename / Delete reject during in-flight transition; panel overflow buttons disabled via `transport.transitionInFlight` | T422 / T423 / T424 |
+| Corrupt plot (orphan Scene etc.) could crash mid-transport (design-fix 2) | `validatePlot` gate in `onPlotOpened`; on throw, disable transport + single error toast; `plotValid === false` makes all subsequent ops no-ops | T322 |
+| ISO vs epoch mismatch at `detectMissingDataForScene` (arch-fix 4) | Service converts `TemporalSlice.timeRange` epoch ms → ISO-8601 at the #215 boundary; handles `NaN` gracefully | T323 (inside hard-block flow) |
+| Existing #216 tests break when new optional props are added (design-fix 3) | All new `StoryboardPanelProps` fields are optional with sensible defaults; T122 confirms the existing suite still compiles | T120 + T122 |
+
+### What's out of scope (recap from spec)
+
+Deferred to #218: Scene editing (rename, description, delete+undo, update-to-current, duplicate, copy-to-other-storyboard); stale-thumbnail detection + refresh; Analysis Log (#176) integration. This slice does not create / update / delete Scenes — that is #216 (capture) and #218 (edit). It does create / delete Storyboards (FR-PLAY-001 / FR-PLAY-004).


### PR DESCRIPTION
## Summary

- Planning artefacts for **[E024 3/4] Storyboarding: panel + playback** (#217) — the slice that turns Scenes captured via #216 into a stakeholder briefing flow. Forward / Backward transport, scoped arrow keys, `flyTo` + time-slider tween, scrub-window lock, on-map Scene rectangles, missing-data hard-block, multi-Storyboard management.
- No implementation. The branch holds spec corrections + plan.md + research.md + data-model.md + 5 contracts + quickstart.md + tasks.md + media (planning-post + LinkedIn). Full breakdown: 96 tasks across 5 phases.
- Research gaps caught by `/speckit.review` (before any code) are folded in: scrub-window via `TimeRangeViewProvider.setScrubbableRange` (not `timeFilter` — verified it doesn't feed the scrubber), new `getMostRecentlyModifiedStoryboard` on #215 (`getActiveStoryboardDefault` was the wrong helper), `documentUri` (not `plotPath`), `SceneRectangleLayer` from `scene.geometry.coordinates` (not `viewport.corners`), three-trigger transition cancel, `validatePlot` gate, CRUD-during-flight guard, and more.

## What's in this PR

| Artefact | Purpose |
|---|---|
| `spec.md` | Two corrections to #215 helper references (points at the new query we're adding) |
| `plan.md` | Technical context, Constitution Check (all 15 articles ✅), Project Structure, Media Components, Storybook + Webview E2E tables |
| `research.md` | 9 decisions — R1 map/slider tween, R2 scrubbable-range override, R3 VS Code-native modal, R4 scoped `when` clause, R5 antimeridian polygon, R6 in-memory active-Storyboard map, R7 most-recently-modified query, R8 three-trigger transition safety, R9 CRUD-vs-transport race |
| `data-model.md` | Transport state machine, view-model types, SceneRectangleLayer rendering rules — no schema deltas |
| `contracts/` | 5 language-neutral contracts — `playback-service.md`, `vscode-commands.md`, `storyboard-panel-messages.md`, `map-view-flyto.md`, `scene-rectangle-layer.md` |
| `quickstart.md` | 9-section verification script — setup, unit tests, Storybook E2E, webview E2E, manual walk-through, evidence, #218 hand-off |
| `tasks.md` | 96 tasks: 4 Setup + 28 Foundation + 26 US1 (P1) + 21 US2 (P2) + 17 Polish. Final task is `/speckit.pr` for the implementation PR |
| `media/` | Planning post + LinkedIn summary (shipped post comes in the implementation PR) |

## Test plan

This is a planning PR — nothing to execute. Review list:

- [ ] **Spec alignment** — `spec.md` + `plan.md` + `tasks.md` agree on scope (US1 P1 as MVP; US2 P2 adds multi-Storyboard management; Scene editing deferred to #218)
- [ ] **Dependency story** — the new `getMostRecentlyModifiedStoryboard` query in #215 is the only #215 addition; everything else is already shipped
- [ ] **Architecture boundaries** — Constitution Article IV preserved (extension = orchestration only; domain logic stays in `@debrief/components/storyboard`)
- [ ] **Offline + no-new-deps claim** — `plan.md` Technical Context: zero new runtime dependencies, no Python additions, no schema edits
- [ ] **Research gap resolutions** — four code-survey-verified mismatches (scrub mechanism, most-recently-modified helper, `documentUri` key, geometry source) fully folded into plan + contracts
- [ ] **Task format** — every task follows `- [ ] T### [labels] Description \`path\`` per `.specify/templates/tasks-template.md`

## Follow-ups

- Implementation (Phases 1–5) happens in a subsequent PR triggered by `/speckit.implement` then `/speckit.pr` — final task T560 creates that PR + a companion blog PR in `debrief/debrief.github.io`
- Final slice of the epic is #218 (edit suite + housekeeping); this planning pass explicitly reserves Scene editing, thumbnail refresh, and Analysis Log integration for that slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)