### PR TITLE
docs(206): [E11] Audit non-LinkML type declarations — planning stack

### DIFF
--- a/specs/206-audit-non-linkml-types/checklists/requirements.md
+++ b/specs/206-audit-non-linkml-types/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: [E11] Audit non-LinkML type declarations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is an analysis/reporting feature producing a Markdown deliverable and backlog entries; no UI section is present and UI Feature Validation items do not apply.
+- Some in-repo path references (`apps/`, `shared/`, `services/`, `shared/schemas/src/generated/`) and backlog identifiers (`#203`, `#204`, `#205`, `E11`) appear in the spec. These are scope markers for the audit (what to scan / which findings to reuse) rather than implementation details, so they do not violate the "no implementation details" rule.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- **UI Feature Validation items only apply if the spec contains a "User Interface Flow" section**
+- Specs without UI sections should skip the UI Feature Validation checklist entirely

--- a/specs/206-audit-non-linkml-types/contracts/README.md
+++ b/specs/206-audit-non-linkml-types/contracts/README.md
@@ -1,0 +1,32 @@
+# Contracts — 206-audit-non-linkml-types
+
+This feature does not introduce runtime APIs. The "contracts" captured here
+document the shape of the **audit scanner's intermediate JSON output** so
+that:
+
+1. The scanner implementation (`scripts/audits/type-audit/scan.ts`) can be
+   validated against a schema during unit tests.
+2. A future re-runner of the audit can regenerate the report mechanically
+   from a fresh scan without reverse-engineering the format.
+
+## Files
+
+- `type-declaration-record.schema.json` — per-record schema (one record per
+  named TS declaration).
+- `scan-output.schema.json` — top-level wrapper (arrays of records + drift
+  clusters + metadata).
+
+## Usage
+
+```bash
+# Run scanner, write to a temp JSON file
+pnpm tsx scripts/audits/type-audit/scan.ts > /tmp/type-audit.json
+
+# Validate against the schema (e.g. with ajv-cli in CI or a test)
+npx ajv validate \
+  -s specs/206-audit-non-linkml-types/contracts/scan-output.schema.json \
+  -d /tmp/type-audit.json
+```
+
+Neither schema is consumed at runtime by production services — they exist
+solely to formalise the scanner's output contract.

--- a/specs/206-audit-non-linkml-types/contracts/scan-output.schema.json
+++ b/specs/206-audit-non-linkml-types/contracts/scan-output.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://debrief.github.io/schemas/206/scan-output.schema.json",
+  "title": "TypeAuditScanOutput",
+  "description": "Top-level JSON document written by scripts/audits/type-audit/scan.ts. Not committed to the repo; regenerated per run and consumed by the reviewer to produce docs/type-audit-2026.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "scannerVersion",
+    "capturedAt",
+    "gitSha",
+    "scannedPaths",
+    "excludedPaths",
+    "records",
+    "driftClusters"
+  ],
+  "properties": {
+    "scannerVersion": {
+      "type": "string",
+      "description": "Scanner semver (e.g. v1)"
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of the scan"
+    },
+    "gitSha": {
+      "type": "string",
+      "description": "Full commit SHA the scan was run against"
+    },
+    "scannedPaths": {
+      "type": "array",
+      "description": "Absolute-or-repo-relative paths that were traversed",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "excludedPaths": {
+      "type": "array",
+      "description": "Glob or path patterns excluded from traversal (for methodology section)",
+      "items": { "type": "string" }
+    },
+    "records": {
+      "type": "array",
+      "description": "Every in-scope named declaration found",
+      "items": {
+        "$ref": "type-declaration-record.schema.json"
+      }
+    },
+    "driftClusters": {
+      "type": "array",
+      "description": "Groups of records sharing declarationName but with >1 distinct shapeHash",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["declarationName", "memberIds"],
+        "properties": {
+          "declarationName": { "type": "string" },
+          "memberIds": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs/206-audit-non-linkml-types/contracts/type-declaration-record.schema.json
+++ b/specs/206-audit-non-linkml-types/contracts/type-declaration-record.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://debrief.github.io/schemas/206/type-declaration-record.schema.json",
+  "title": "TypeDeclarationRecord",
+  "description": "One record emitted by scripts/audits/type-audit/scan.ts per named TypeScript declaration discovered in in-scope source. The intermediate JSON file is a list of these records; the reviewer consumes it to author docs/type-audit-2026.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "packageName",
+    "filePath",
+    "lineNumber",
+    "declarationName",
+    "kind",
+    "isExported",
+    "shapeHash",
+    "rhsSummary",
+    "imports",
+    "autoTag"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable identifier: ${packageName}:${relativeFilePath}:${declarationName}",
+      "pattern": "^[^:]*:[^:]+:[^:]+$"
+    },
+    "packageName": {
+      "type": "string",
+      "description": "pnpm workspace name (e.g. @debrief/components). Empty string if outside a workspace."
+    },
+    "filePath": {
+      "type": "string",
+      "description": "Repo-relative path, forward-slash normalised"
+    },
+    "lineNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "declarationName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["interface", "type", "enum"]
+    },
+    "isExported": {
+      "type": "boolean"
+    },
+    "shapeHash": {
+      "type": "string",
+      "description": "SHA-1 hex of the AST printed form of the declaration",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "rhsSummary": {
+      "type": ["string", "null"],
+      "description": "For type aliases, truncated textual summary of the RHS (max 160 chars). Null for interface/enum.",
+      "maxLength": 160
+    },
+    "imports": {
+      "type": "array",
+      "description": "Module specifiers imported by the containing file",
+      "items": { "type": "string" }
+    },
+    "autoTag": {
+      "type": "string",
+      "enum": [
+        "schema-rooted-candidate",
+        "boundary-candidate",
+        "drift-shortlist",
+        "none"
+      ]
+    }
+  }
+}

--- a/specs/206-audit-non-linkml-types/data-model.md
+++ b/specs/206-audit-non-linkml-types/data-model.md
@@ -1,0 +1,170 @@
+# Data Model — [E11] Audit non-LinkML type declarations
+
+**Feature**: 206-audit-non-linkml-types
+**Date**: 2026-04-21
+
+This audit does not introduce runtime data models consumed by services or
+frontends. The "data model" here describes the shape of **the audit's
+intermediate JSON and of the report's row-level content** so reviewers can
+extend the scanner or consume its output reliably.
+
+---
+
+## Entities
+
+### 1. TypeDeclarationRecord
+
+Emitted by the scanner — one record per named `interface` / `type` / `enum`
+declaration in in-scope source.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Stable identifier — `${packageName}:${relativeFilePath}:${declarationName}` |
+| `packageName` | `string` | `pnpm` workspace name the declaration belongs to (e.g. `@debrief/components`). Empty string if the file is outside a workspace. |
+| `filePath` | `string` | Repo-relative path, forward-slash normalised |
+| `lineNumber` | `integer` | 1-based line number of the declaration's first token |
+| `declarationName` | `string` | The exported identifier (e.g. `Coordinate`) |
+| `kind` | `enum { interface, type, enum }` | TypeScript declaration kind |
+| `isExported` | `boolean` | `true` if the declaration has an `export` modifier |
+| `shapeHash` | `string` | SHA-1 hash of the declaration's AST printed form (used for Drift-candidate clustering) |
+| `rhsSummary` | `string \| null` | For `type` aliases, a short textual summary of the RHS (truncated to 160 chars); `null` for `interface` / `enum` |
+| `imports` | `string[]` | Module specifiers imported in the containing file — drives Schema-rooted auto-tagging |
+| `autoTag` | `enum { schema-rooted-candidate, boundary-candidate, drift-shortlist, none }` | Cheap machine-applied hint. The reviewer may override. |
+
+**Uniqueness**: `id` is unique per record. Two declarations with identical
+`declarationName` but different `filePath` are distinct records and both
+retain their own `id`.
+
+**State transitions**: Records are immutable once emitted by the scanner.
+Classifications happen downstream inside the reviewer's Markdown report,
+not by mutating these records.
+
+---
+
+### 2. Classification
+
+Applied by the reviewer — one classification per `TypeDeclarationRecord`.
+
+**Enumeration (closed set, per spec FR-004)**:
+
+1. `schema-rooted` — imported from `@debrief/schemas` (or a workspace
+   re-export of it), or a trivial alias/re-export of a schema type.
+2. `boundary-loose` — a parse-time / boundary-facing alias that collapses
+   to `unknown`, `Record<string, unknown>`, or an intersection/union
+   containing either.
+3. `single-domain` — a convenience type with no Python counterpart that
+   lives entirely in one runtime (TS-only). An allowed exception; the
+   reviewer records the justification.
+4. `cross-domain-hand-typed` — describes data that crosses the Python ↔ TS
+   boundary or is serialised to disk, but is not schema-rooted. **Violates
+   the principle; must be promoted to LinkML.**
+5. `drift-candidate` — same declaration name as another record with a
+   different `shapeHash`, or otherwise exhibits drift against a schema type.
+
+**Invariant**: exactly one classification per record; no multi-tagging.
+
+---
+
+### 3. Finding
+
+A row in the report's findings table.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `record` | `TypeDeclarationRecord` | The declaration being classified |
+| `classification` | `Classification` | One of the five buckets |
+| `summary` | `string` | Reviewer-authored one-line description of what the type represents |
+| `recommendedAction` | `string` | Short imperative — "Fold into #204", "Open new item", "Keep — convenience type", "No action", etc. |
+| `backlogItemRef` | `BacklogItemRef \| null` | Required for `cross-domain-hand-typed` and `drift-candidate`; optional otherwise |
+| `justification` | `string \| null` | Required for `single-domain` (why the exception is deliberate) |
+
+**Validation rules** (enforced by spec FR-006 + SC-002):
+
+- If `classification ∈ { cross-domain-hand-typed, drift-candidate }` then
+  `backlogItemRef` MUST be non-null.
+- If `classification === single-domain` then `justification` MUST be non-null.
+- `recommendedAction` MUST be non-empty for every finding.
+
+---
+
+### 4. BacklogItemRef
+
+A reference to an existing or newly opened `BACKLOG.md` entry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `integer` | Numeric backlog item ID (e.g. 203, 204, 205, or a newly minted ID) |
+| `title` | `string` | Short title from `BACKLOG.md` |
+| `isNew` | `boolean` | `true` if opened as part of this audit PR |
+| `anchor` | `string` | Markdown link target — e.g. `BACKLOG.md#206` or `docs/ideas/207-promote-tool-result-envelope.md` |
+
+---
+
+### 5. PythonCrossDomainCandidate
+
+Entries in the report's Python appendix (spec FR-012). Not classified
+against the five buckets; surfaced as signals.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `filePath` | `string` | Repo-relative path to the Python file |
+| `declarationName` | `string` | Class / TypedDict / dataclass name |
+| `kind` | `enum { BaseModel, TypedDict, dataclass, NamedTuple, Enum }` | Python declaration kind |
+| `crossDomainEvidence` | `string` | Why the reviewer believes this type crosses into TS (e.g. "serialised via MCP tool result", "written to STAC Item properties") |
+| `suggestedFollowUp` | `string` | Imperative — "Audit separately under a Python-side E11 phase", etc. |
+
+---
+
+### 6. AuditReport (the committed Markdown document)
+
+Top-level container. The `data-model` is the document's section order and
+required front matter.
+
+**Required front matter** (YAML):
+
+```yaml
+---
+feature: 206-audit-non-linkml-types
+epic: E11
+captured_at: 2026-04-21   # ISO date of audit run
+git_sha: <commit SHA at which the scan was run>
+scanner_version: v1       # bumped if scan.ts semantics change
+---
+```
+
+**Required sections** (in order):
+
+1. Title + back-link to `docs/ideas/E11-schema-first-boundary-typing.md`
+2. Summary (per-bucket counts, list of newly opened backlog items)
+3. Methodology (in-scope paths, exclusions, classification rules, re-run
+   command)
+4. Findings table (sorted by classification → package → file path)
+5. Python cross-domain appendix (may be empty — include section with an
+   explicit "No candidates found" line if so)
+6. Changelog / re-run history (appended on subsequent runs)
+
+---
+
+## Relationships
+
+```text
+AuditReport 1 ─── * Finding
+Finding      1 ─── 1 TypeDeclarationRecord
+Finding      1 ─── 0..1 BacklogItemRef
+AuditReport  1 ─── * PythonCrossDomainCandidate
+```
+
+No circular references. No persistence layer — all data lives in Git-tracked
+files (`docs/type-audit-2026.md`, `BACKLOG.md`, the intermediate JSON emitted
+by the scanner into an uncommitted local path).
+
+---
+
+## Derived metrics (for the Summary section)
+
+| Metric | Source |
+|--------|--------|
+| Total in-scope declarations | count of `TypeDeclarationRecord` |
+| Count per classification | group-by of `Finding.classification` |
+| Count of newly opened backlog items | count of `BacklogItemRef` where `isNew === true` |
+| Drift clusters | count of declaration names with >1 record and >1 distinct `shapeHash` |

--- a/specs/206-audit-non-linkml-types/media/linkedin-planning.md
+++ b/specs/206-audit-non-linkml-types/media/linkedin-planning.md
@@ -1,0 +1,11 @@
+An audit of every type declaration in the codebase sounds dull. Here is why we need one.
+
+Future Debrief's architectural rule is that any type crossing the Python ↔ TypeScript boundary is defined once in LinkML and generated into both languages. Hand-writing those shapes is where drift lives. A recent code-quality pass surfaced around 35 places where we parse untrusted data as `Record<string, unknown>` at a service edge, plus several concepts (`Coordinate`, `DisplayMode`, `PlaybackState`, tool-result envelopes) that had quietly grown two or three slightly different declarations.
+
+Feature 206 is the catalogue. A committed Markdown report will enumerate every hand-written `interface`, `type`, and `enum` in the codebase, classify each into one of five buckets (schema-rooted, boundary, single-domain, cross-domain, or drift candidate), and open backlog items for every actionable finding in the same PR as the report. A small TypeScript-compiler-API scanner auto-tags the cheap signals; humans make the judgement calls.
+
+The point is not the audit itself. It is giving Epic E11 — our schema-first boundary-typing programme — a concrete target list instead of a guess.
+
+Read the full post: [link pending publication]
+
+#FutureDebrief #TypeSafety #OpenSource

--- a/specs/206-audit-non-linkml-types/media/planning-post.md
+++ b/specs/206-audit-non-linkml-types/media/planning-post.md
@@ -1,0 +1,60 @@
+---
+layout: future-post
+title: "Planning: Auditing every hand-typed declaration in the codebase"
+date: 2026-04-21
+track: [momentum]
+author: Ian
+reading_time: 4
+tags: [tracer-bullet, schemas, type-safety, epic-e11]
+excerpt: "Before we tighten boundary typing across the platform, we need a catalogue of every type we've written by hand."
+---
+
+## What We're Building
+
+Our architectural rule is simple: if a type crosses the Python ↔ TypeScript boundary, it is defined once in LinkML and generated into Pydantic models and TypeScript types. We do not hand-write those shapes — the generator does. Everything else (purely internal types, React prop interfaces, view-model shapes) is allowed to live as ordinary TypeScript.
+
+The problem is that we have not, so far, checked carefully enough which hand-written types quietly became boundary types over the past year. A recent code-quality pass surfaced around 35 ESLint warnings where we parse untrusted shapes as `Record<string, unknown>` at the edge of a service, plus a handful of drift cases where the same concept (`Coordinate`, `ViewportPolygon`, `DisplayMode`, `PlaybackState`, tool-result envelopes) was declared in two or three places with subtly different shapes. Each warning is, in effect, one place we parse data without a schema. Without a full inventory we cannot tell whether that's five cases or fifty.
+
+Feature 206 produces the inventory. The deliverable is a single committed Markdown report, `docs/type-audit-2026.md`, that enumerates every named `interface`, `type`, and `enum` declaration under `apps/`, `shared/` (excluding generated schemas), and `services/`, and classifies each into one of five buckets:
+
+- **Schema-rooted** — already flows from LinkML (good, leave alone)
+- **Boundary** — crosses a process or network edge without a schema (needs schema-rooting)
+- **Single-domain convenience** — private to one module (fine as-is)
+- **Cross-domain hand-typed** — reused across domains but hand-written (needs review)
+- **Drift candidate** — multiple declarations of the same concept that have diverged
+
+Every actionable finding links to a backlog item, either an existing one (#203, #204, #205) or a new one opened as part of the audit PR.
+
+## How It Fits
+
+This is the first item under Epic E11 — Schema-First Boundary Typing — which turns the "LinkML is the single source of truth at boundaries" principle from a guideline into a tracked programme of work. E11 cannot sensibly plan its phases without knowing what it's planning over. A boundary-type rollout that targets "about thirty warnings we've seen" is a guess; a rollout that targets a committed, classified inventory is a plan.
+
+The audit is deliberately zero-production-change. The PR touches `docs/`, `BACKLOG.md`, and a small committed scanner under `scripts/audits/type-audit/`. No runtime code moves. That is the point — we want the catalogue first, before anyone starts editing types.
+
+## Key Decisions
+
+A few calls worth surfacing before implementation begins:
+
+- **Compiler-API scanner, not regex**. The scanner is a short `tsx`-run script that walks the TypeScript AST via the official compiler API. Regex is too loose for declaration detection (it trips on generics, comments, and template literals), and bringing in `ts-morph` as a new dependency would need a Constitution Article IX justification we do not think is warranted for a one-script tool.
+
+- **Auto-tag cheap signals; humans classify**. The scanner auto-tags *candidates* for three things it can detect reliably: imports from the schema package (schema-rooted candidate), aliases that bottom out in `unknown` or `Record<string, unknown>` (boundary candidate), and same-name-different-shape pairs (drift shortlist). The Boundary vs Single-domain vs Cross-domain distinction is a judgement call a machine cannot make well, so the final classification is a human review step. Auto-tagging speeds the review; it does not replace it.
+
+- **The scanner is committed, not a throwaway**. Reproducibility is a functional requirement. The report has a methodology section that lists scanned paths, exclusion rules, and classification rules, so anyone can re-run the audit in six months and diff the result.
+
+- **Follow-up backlog items land in the same PR as the report**. We have watched audits elsewhere produce a crisp document and then a trickle of forgotten follow-ups. Doing both in one PR keeps the work honest.
+
+- **Python cross-domain hand-typed types get an appendix, not a bucket**. The five buckets are TypeScript-centric. Forcing Python declarations through them would muddy both. An appendix surfaces the Python cases for Epic E11 to decide whether they want the same treatment or a separate audit.
+
+## What We'd Love Feedback On
+
+Before we start scanning, three questions where outside input would genuinely change the output:
+
+- **Is the five-bucket taxonomy the right cut?** Is there a category we're missing, or one (perhaps Cross-domain hand-typed) that is really two things? We would rather rework the taxonomy now than retrofit the report.
+
+- **Python in an appendix, or a separate audit?** The appendix keeps everything in one document and avoids a second workstream. A separate audit gives Python the same rigour as TypeScript instead of relegating it. We are leaning toward the appendix for now, but we are not sure.
+
+- **Report location and naming.** `docs/type-audit-2026.md` is year-stamped so we can run this again next year without a rename. Is that the right convention, or should it live under `docs/audits/` as a subdirectory for future audits of other kinds?
+
+Nothing is cast yet. The spec, plan, research notes, data model, contracts, and quickstart are in the repository under `specs/206-audit-non-linkml-types/`; implementation has not started.
+
+→ [See the spec](https://github.com/debrief/debrief-future/tree/206-audit-non-linkml-types/specs/206-audit-non-linkml-types)

--- a/specs/206-audit-non-linkml-types/plan.md
+++ b/specs/206-audit-non-linkml-types/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: [E11] Audit non-LinkML type declarations
+
+**Branch**: `206-audit-non-linkml-types` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/206-audit-non-linkml-types/spec.md`
+
+## Summary
+
+Deliver a single committed Markdown report — `docs/type-audit-2026.md` —
+that enumerates every named TypeScript `interface` / `type` / `enum` under
+`apps/`, `shared/`, and `services/` (excluding generated and test-local
+code), classifies each declaration into one of five buckets (Schema-rooted
+/ Boundary / Single-domain convenience / Cross-domain hand-typed / Drift
+candidate), and links every actionable finding to a backlog item (existing
+or newly opened in the same PR). The report feeds Epic E11's phase list
+and establishes a reproducible methodology so the audit can be re-run
+later.
+
+Technical approach (from research.md): a committed TypeScript-compiler-API
+scanner at `scripts/audits/type-audit/scan.ts` emits an intermediate JSON
+file validated against the committed JSON-Schema contracts; a human
+reviewer uses that JSON to author the Markdown report. The feature ships
+zero production-code changes — only docs, scanner, scanner tests, backlog
+edits, and spec artefacts.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (scanner + scanned source); Python 3.11 referenced only in the Python cross-domain appendix
+**Primary Dependencies**: `typescript` compiler API (already a workspace devDep in `apps/vscode`, `apps/loader`, `apps/web-shell`, `apps/spec-navigator`, `shared/components`), `tsx` (root devDep), `ajv` (schema validation in scanner unit tests — already transitively available via pnpm store; pinned at workspace level if introduced)
+**Storage**: N/A — scanner emits an uncommitted intermediate JSON; deliverables are `docs/type-audit-2026.md`, edits to `docs/ideas/E11-schema-first-boundary-typing.md`, new entries in `BACKLOG.md`, and the scanner itself at `scripts/audits/type-audit/`
+**Testing**: `vitest` (or existing root test runner) for scanner unit tests with a small fixture folder — assert record counts, shape-hash determinism, and auto-tag rules. No schema round-trip tests required (no LinkML changes). No Playwright / VS Code E2E required.
+**Target Platform**: Node.js 20.x (scanner); Markdown output consumed in GitHub + MkDocs
+**Project Type**: tooling / analysis — single deliverable
+**Performance Goals**: Scanner completes the full repo traversal in under 30 seconds on a local checkout; re-runs are deterministic (stable sort order for diff-friendly output)
+**Constraints**: Read-only analysis (FR-011); audit must not modify production source code; scanner output must be reproducible from a clean checkout
+**Scale/Scope**: Estimated ~200–500 named declarations across in-scope paths (confirmed on first scan); scanner tests use a ~10-declaration fixture
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Applied against `.specify/memory/constitution.md` v1.2.0.
+
+| Article | Applies? | Assessment |
+|---------|----------|------------|
+| I. Defence-Grade Reliability | No | Audit is read-only docs work; no runtime component. |
+| II. Schema Integrity | Yes | Audit **reinforces** this article — its output surfaces every place where derived types are not LinkML-rooted. No hand-written schema introduced. |
+| III. Data Sovereignty | No | No user data involved; audit operates on repository source code. |
+| IV. Architectural Boundaries | No | No service or UI code changes. |
+| V. Extensibility | No | No extension surface touched. |
+| VI. Testing | Yes | Scanner carries unit tests (fixture-based); schema adherence tests N/A; CI remains green. |
+| VII. Test-Driven AI Collaboration | Yes | Checklists for acceptance already defined in spec + requirements.md; quickstart contains an explicit self-check list. |
+| VIII. Documentation | Yes | Feature is **entirely** documentation + methodology; specs-before-code respected. |
+| IX. Dependencies | Yes | No new runtime dependencies; `typescript` and `tsx` already present. Scanner test validator (`ajv`) kept minimal / workspace-scoped if added. |
+| X. Security | No | No secrets; no classification boundary touched. |
+| XI. Internationalisation | No | Report is an English-language engineering artefact; no user-facing strings. |
+| XII. Community Engagement | Yes | Report, epic back-link, and planning post together advertise progress openly. |
+| XIII. Contribution Standards | Yes | Single PR, atomic commits, CI must pass. |
+| XIV. Pre-Release Freedom | Yes | Audit leverages pre-v4.0 freedom to restructure types — explicitly in-scope. |
+| XV. Strict Type Safety | Yes | Scanner is strict TS with explicit types; audit's entire purpose is to strengthen adherence to this article across the monorepo. |
+
+**Gate status**: PASS. No violations. Complexity Tracking table is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/206-audit-non-linkml-types/
+├── plan.md                 # This file (/speckit.plan command output)
+├── research.md             # Phase 0 output — methodology decisions
+├── data-model.md           # Phase 1 output — scanner record + finding shapes
+├── quickstart.md           # Phase 1 output — how to run / re-run the audit
+├── contracts/
+│   ├── README.md
+│   ├── scan-output.schema.json          # Top-level JSON contract for scanner output
+│   └── type-declaration-record.schema.json
+├── checklists/
+│   └── requirements.md     # Spec quality checklist (from /speckit.specify)
+├── media/                  # Populated by /speckit.plan (planning post + LinkedIn)
+│   ├── planning-post.md
+│   └── linkedin-planning.md
+├── spec.md
+└── tasks.md                # Phase 2 output — generated by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+This feature introduces a single script package plus targeted edits to
+existing documentation files. No new application or service code.
+
+```text
+docs/
+├── ideas/
+│   └── E11-schema-first-boundary-typing.md   # edited — add link to report
+└── type-audit-2026.md                        # NEW — the audit report (main deliverable)
+
+scripts/
+└── audits/
+    └── type-audit/
+        ├── README.md                         # NEW — what the scanner does
+        ├── scan.ts                           # NEW — TS-compiler-API scanner
+        ├── __tests__/
+        │   ├── scan.test.ts                  # NEW — fixture-driven unit tests
+        │   └── fixtures/                     # NEW — ~10 hand-crafted .ts files
+        └── tsconfig.json                     # NEW — minimal TS config
+
+BACKLOG.md                                    # edited — new items for actionable findings (if any)
+```
+
+**Structure Decision**: No new workspace is created. The scanner lives under
+`scripts/` alongside existing Node + shell utilities
+(`scripts/check-no-hand-typed-temporal-enums.sh`,
+`scripts/extract-enum-bundle.py`). The decision keeps the audit tool
+discoverable in the conventional location without introducing workspace
+churn for a one-shot deliverable. If a follow-up E11 phase needs to wire
+the scanner into CI as a regression guard, the existing `scripts/check-*.sh`
+pattern can host a thin wrapper.
+
+## Media Components
+
+No Storybook components are added, modified, or demonstrated by this
+feature. The deliverable is a Markdown report plus a CLI scanner.
+
+**None — backend/infrastructure feature.**
+
+## Storybook E2E Testing
+
+**None — no interactive UI components.**
+
+## VS Code Webview E2E Testing
+
+**None — no extension workflow changes.**
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+Constitution Check passed with no violations. Complexity Tracking table
+intentionally omitted.

--- a/specs/206-audit-non-linkml-types/quickstart.md
+++ b/specs/206-audit-non-linkml-types/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart — Running and re-running the type audit
+
+**Feature**: 206-audit-non-linkml-types
+**Audience**: the engineer delivering the first audit and any maintainer
+re-running it later.
+
+## Prerequisites
+
+- Repo cloned and `pnpm install` run at the root.
+- `tsx` available (already a root devDependency).
+- A workspace that has `typescript` installed (all of `apps/vscode`,
+  `apps/loader`, `apps/web-shell`, `apps/spec-navigator`,
+  `shared/components` qualify), **or** `typescript` hoisted into root
+  `devDependencies`.
+
+## 1. Run the scanner
+
+From the repo root:
+
+```bash
+mkdir -p tmp
+pnpm tsx scripts/audits/type-audit/scan.ts \
+  --roots apps shared services \
+  --exclude "shared/schemas/src/generated/**" \
+  --exclude "**/__tests__/**" \
+  --exclude "**/__fixtures__/**" \
+  --exclude "**/*.test.ts" \
+  --exclude "**/*.spec.ts" \
+  --exclude "**/node_modules/**" \
+  --out tmp/type-audit.json
+```
+
+Expected runtime: under 30 seconds on a full checkout. The command prints
+a one-line summary of per-bucket auto-tagged counts on stderr.
+
+Validate the output against the committed schema:
+
+```bash
+pnpm dlx ajv-cli validate \
+  -s specs/206-audit-non-linkml-types/contracts/scan-output.schema.json \
+  -d tmp/type-audit.json
+```
+
+## 2. Draft the report
+
+1. Copy the scaffolded report from
+   `specs/206-audit-non-linkml-types/templates/report-scaffold.md` to
+   `docs/type-audit-2026.md` (scaffold is created during implementation —
+   see tasks.md).
+2. Fill the YAML front matter (`git_sha` = current `HEAD`,
+   `captured_at` = today's date, `scanner_version` = `v1`).
+3. For each record in `tmp/type-audit.json`:
+   - Accept or override the `autoTag` and assign one of the five
+     classifications: `schema-rooted`, `boundary-loose`, `single-domain`,
+     `cross-domain-hand-typed`, `drift-candidate`.
+   - Author a one-line `summary` and a `recommendedAction`.
+   - For `cross-domain-hand-typed` and `drift-candidate`, link a
+     `backlogItemRef`: first look for an existing item (#203, #204, #205,
+     or another open E11 child); only open a new `BACKLOG.md` entry if no
+     existing item covers the finding.
+   - For `single-domain`, record the justification ("TS-only, UI state",
+     etc.).
+4. Resolve every `driftClusters` entry — each cluster becomes at least one
+   `drift-candidate` finding.
+
+## 3. Open any new backlog items
+
+In the **same PR** as the report:
+
+1. Append new items to `BACKLOG.md` using the existing format; pick the
+   next unused numeric ID.
+2. Update the Summary section's "Newly opened backlog items" table with
+   the IDs and titles.
+
+## 4. Link back-and-forth with the epic
+
+Edit `docs/ideas/E11-schema-first-boundary-typing.md`:
+
+1. In the `## Items` section, add a bullet linking to
+   `docs/type-audit-2026.md`.
+2. In `## Phase inventory`, append any phases the audit has uncovered.
+
+The report must already contain a first-paragraph link to
+`docs/ideas/E11-schema-first-boundary-typing.md` — this closes the
+bidirectional reference SC-003 requires.
+
+## 5. Acceptance self-check
+
+Before opening the PR, confirm:
+
+- [ ] Every record in `tmp/type-audit.json` appears once in the report.
+- [ ] No classification is empty or duplicated.
+- [ ] Every `cross-domain-hand-typed` and `drift-candidate` finding links
+      to a backlog item (existing or new).
+- [ ] `docs/ideas/E11-schema-first-boundary-typing.md` links to the
+      report and vice versa.
+- [ ] `task verify` passes (lint / typecheck / tests — scanner has unit
+      tests).
+- [ ] The PR diff contains **no production source changes**, only
+      `docs/`, `BACKLOG.md`, `scripts/audits/type-audit/`, tests for the
+      scanner, and the spec artefacts.
+
+## Re-running the audit later
+
+Repeat steps 1–5. The scanner is deterministic; diffs between runs are
+attributable to code change. To make re-runs less manual, the reviewer can
+leave `tmp/type-audit.json` side-by-side and `diff` the previous and
+current runs to focus attention on what changed.

--- a/specs/206-audit-non-linkml-types/research.md
+++ b/specs/206-audit-non-linkml-types/research.md
@@ -1,0 +1,220 @@
+# Phase 0 — Research: [E11] Audit non-LinkML type declarations
+
+**Feature**: 206-audit-non-linkml-types
+**Date**: 2026-04-21
+
+## Purpose
+
+Resolve the technical-context questions raised by the spec before design. There
+are **no `[NEEDS CLARIFICATION]` markers** in the spec; the research here locks
+in methodology choices that keep the audit reproducible and the Markdown
+report diff-friendly.
+
+---
+
+## R1 — How should type declarations be discovered?
+
+**Decision**: Walk in-scope source with the **TypeScript compiler API**
+(`typescript` module) via a small `tsx`-run script at
+`scripts/audits/type-audit/scan.ts`. For each `.ts` / `.tsx` file, traverse the
+AST and emit one record per `InterfaceDeclaration`, `TypeAliasDeclaration`, or
+`EnumDeclaration` node. Emit records to an intermediate JSON file, then a
+reviewer uses that JSON to author the committed Markdown report.
+
+**Rationale**:
+
+- AST-level traversal catches `type X = ...`, `interface X {}`, and `enum X {}`
+  uniformly and correctly handles generics, template-literal types, and nested
+  declarations — `grep`-only approaches drift at edge cases.
+- `tsx` is already a root devDependency (`package.json:scripts` already uses
+  it). `typescript` is a workspace-level devDep in several packages
+  (`apps/vscode`, `apps/loader`, `apps/web-shell`, `apps/spec-navigator`,
+  `shared/components`) — the script runs under the workspace resolver (e.g.
+  `pnpm --filter @debrief/components exec tsx ../../scripts/audits/type-audit/scan.ts`)
+  or we hoist `typescript` into the repo-root `devDependencies`.
+- Output is a plain JSON file; the Markdown report is hand-edited on top. This
+  keeps human judgement (classification) in one place without coupling to the
+  scanner's emission format.
+
+**Alternatives considered**:
+
+- **Regex via `ripgrep`** (as used by `scripts/check-no-hand-typed-temporal-enums.sh`)
+  — simpler, works without `typescript`, but prone to false negatives on
+  multi-line declarations and false positives inside comments / strings. Good
+  enough for a narrow guard; too loose for a comprehensive inventory.
+- **`ts-morph`** — ergonomic wrapper around the TS compiler. Would require
+  adding a new dependency for a one-shot audit tool; Article IX ("every
+  dependency is a liability") argues against.
+- **ESLint rule with a JSON reporter** — overkill; adds CI coupling we do not
+  need for a one-shot analysis.
+
+---
+
+## R2 — How do we distinguish Schema-rooted vs. Single-domain convenience?
+
+**Decision**: For each discovered declaration, the scanner also records the
+file's `import` statements. If the containing file imports from
+`@debrief/schemas` (or any workspace re-export of it) **and** the declaration
+is a trivial alias / re-export of a schema type, mark candidate as
+`Schema-rooted` automatically. All other declarations enter the report as
+`Unclassified` and the human reviewer assigns one of the four remaining
+buckets.
+
+**Rationale**: The distinction between Single-domain convenience, Boundary, and
+Cross-domain hand-typed requires judgement about whether the type crosses the
+Python ↔ TS boundary or stays local — a machine cannot infer that reliably.
+Auto-classifying only the unambiguous Schema-rooted case keeps the reviewer's
+workload tractable without introducing misclassification risk.
+
+**Alternatives considered**:
+
+- **Full auto-classification** — rejected. Misclassification would be
+  undetectable at scale.
+- **Zero auto-classification** — every row classified manually. Workable but
+  adds ~hundreds of trivial re-export rows to the reviewer's workload when the
+  scanner could trivially dispatch them.
+
+---
+
+## R3 — Where does the report live, and how do we link it?
+
+**Decision**: The committed report lives at
+`docs/type-audit-2026.md`. The file includes:
+
+- Metadata front matter (`git_sha`, `captured_at`, `scanner_version`) to
+  satisfy the project's evidence-freshness convention.
+- A methodology section (paths, exclusions, classification rules, re-run
+  instructions) — satisfies FR-009 and SC-004.
+- A findings table sorted by classification → package → file path.
+- A summary section with counts per bucket and a list of newly opened
+  backlog items.
+- A Python cross-domain appendix (if any candidates found) — satisfies
+  FR-012.
+
+The report is linked from `docs/ideas/E11-schema-first-boundary-typing.md`
+(satisfies FR-010 / SC-003). The report contains a back-link to the epic
+document in its first paragraph.
+
+**Rationale**: `docs/` is the established home for cross-cutting
+documentation. The `-2026` suffix matches the project's existing naming of
+time-stamped analysis artefacts (c.f. existing `docs/` content) and leaves
+room for a future `-2027` audit without a rename dance.
+
+**Alternatives considered**:
+
+- Place the report inside `specs/206-audit-non-linkml-types/` — rejected. The
+  report is a durable output that outlives the feature branch; it belongs in
+  the long-lived docs tree so it can be referenced from the epic and from
+  future E11 phase items.
+- Split the report across multiple files (one per bucket) — rejected. A
+  single file keeps the summary counts honest and makes re-run diffs easy to
+  review.
+
+---
+
+## R4 — How do we detect Drift candidates?
+
+**Decision**: After scanning, group records by declaration name (case-sensitive).
+Any name declared in more than one in-scope file is flagged as a **Drift
+candidate shortlist** and presented to the reviewer alongside an AST-hash
+column. The reviewer confirms drift (same name, different shape) vs. benign
+re-declaration (identical shape across packages) and assigns the final
+classification.
+
+**Rationale**: Same-name-different-shape is the most dangerous drift pattern
+and is cheap to detect automatically. Identical-shape duplication is still
+worth noting but is not always a bug (e.g. deliberate re-declarations in
+isolated contexts).
+
+**Alternatives considered**:
+
+- **Structural comparison across all types** (not just same-name) — rejected.
+  High false-positive rate; unrelated types with similar shapes would flood
+  the shortlist.
+- **Name-only clustering with no shape check** — rejected. Would miss the
+  case where a deliberate re-export shadow has the same shape (not drift).
+
+---
+
+## R5 — Is the scanner committed to the repo?
+
+**Decision**: **Yes.** The scanner is committed at
+`scripts/audits/type-audit/` (folder — includes `scan.ts`, a small README, and
+any tsconfig needed to run it). It is not wired into `task lint` or CI; it is
+a one-shot / ad-hoc tool invoked by the reviewer when re-running the audit.
+
+**Rationale**: Reproducibility is an explicit FR (FR-009) and success
+criterion (SC-004). A committed script is the cheapest way to make the
+methodology executable rather than descriptive.
+
+**Alternatives considered**:
+
+- Keep the scanner as a throwaway gist — rejected. Violates the
+  reproducibility FR.
+- Wire the scanner into CI as a lint gate — rejected as over-scope for this
+  feature; the scanner is for reviewers, not for blocking merges. A
+  narrower regression-guard script (like
+  `check-no-hand-typed-temporal-enums.sh`) is the appropriate pattern for
+  follow-up E11 phases.
+
+---
+
+## R6 — How should `Record<string, unknown>` / `unknown` aliases be flagged?
+
+**Decision**: The scanner looks at each `TypeAliasDeclaration`'s right-hand
+side (`node.type`). If the RHS resolves (syntactically) to
+`Record<string, unknown>`, `Record<string, any>`, `unknown`, `any`, or an
+intersection/union that contains any of those, the record is auto-tagged as
+`boundary-candidate`. Reviewer confirms to `Boundary / parse-time loose type`.
+
+**Rationale**: These aliases are the textbook boundary pattern E11 is
+chartered to eliminate. Surfacing them automatically focuses reviewer
+attention on the cases most likely to need schema-promotion.
+
+**Alternatives considered**:
+
+- Rely entirely on the reviewer to spot these — rejected. Loose aliases are
+  exactly what the audit is looking for; machine help is trivially cheap.
+
+---
+
+## R7 — How do we open the follow-up backlog items?
+
+**Decision**: In the same pull request that lands the report, append the
+newly required items to `BACKLOG.md` following the project's existing item
+format (next available ID, category `Infrastructure`, status `approved` if
+ready or `needs-interview` if scope still hazy). The report's "Newly opened
+backlog items" summary table lists each new ID with a one-line description
+and a link into `BACKLOG.md`.
+
+**Rationale**: Co-locating the report and the backlog edits in one PR keeps
+the audit's actionable findings traceable and prevents the "report published
+but nobody filed the follow-ups" failure mode.
+
+**Alternatives considered**:
+
+- Land the report first, open backlog items afterwards — rejected. Creates a
+  window where the report references IDs that do not yet exist.
+- Open GitHub Issues rather than BACKLOG.md entries — rejected. The project's
+  canonical backlog lives in `BACKLOG.md`; issues are for execution work after
+  backlog triage.
+
+---
+
+## Technical-context resolution
+
+All items below are derived from the decisions above.
+
+| Field | Value |
+|-------|-------|
+| Language/Version | TypeScript 5.x (scanner + scanned source); Python 3.11 only referenced in appendix |
+| Primary dependencies | `typescript` compiler API (already in multiple workspaces), `tsx` (root devDep) |
+| Storage | N/A — writes to `docs/type-audit-2026.md`, `docs/ideas/E11-schema-first-boundary-typing.md`, `BACKLOG.md`, and commits the scanner at `scripts/audits/type-audit/` |
+| Testing | Light unit tests for the scanner using small fixture files (enumerate expected count, verify auto-tagging heuristics); no schema/CI tests required |
+| Target Platform | Node.js (scanner), Markdown (report) |
+| Project Type | tooling / analysis — single deliverable |
+| Performance Goals | Scanner completes in under 30 seconds on full repo; not a hot path |
+| Constraints | Read-only analysis (FR-011); scanner must be deterministic (stable ordering for diff-friendly re-runs) |
+| Scale/Scope | Estimated ~200–500 named declarations across in-scope paths (subject to confirmation on first run) |
+
+No `[NEEDS CLARIFICATION]` markers remain.

--- a/specs/206-audit-non-linkml-types/spec.md
+++ b/specs/206-audit-non-linkml-types/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: [E11] Audit non-LinkML type declarations
+
+**Feature Branch**: `206-audit-non-linkml-types`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: User description: "206 from the backlog (working in a worktree)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Complete classified inventory for E11 planning (Priority: P1)
+
+As the owner of Epic E11 (Schema-First Boundary Typing), I need a single written inventory that lists every non-generated, named type declaration across the monorepo's application, shared, and service code, with each entry assigned exactly one of five classifications, so that I can decide which boundaries still need to be rooted in LinkML before I authorise further E11 phases.
+
+**Why this priority**: Without this inventory the E11 phase list is incomplete — we know about five known boundaries but cannot tell whether we're looking at 5 / 20 / 50 candidates. Every downstream E11 phase depends on the audit being comprehensive and trustworthy, which is why it must land before heavy investment in phases 3+.
+
+**Independent Test**: Can be fully validated by picking any ten named TypeScript type declarations at random from the in-scope directories and confirming each appears in the report with a classification and recommended action.
+
+**Acceptance Scenarios**:
+
+1. **Given** the audit report has been published, **When** a reader scans it, **Then** every named type declaration found under `apps/`, `shared/` (excluding `shared/schemas/src/generated/`), and `services/` appears exactly once with a classification.
+2. **Given** a type declaration has been classified as "Cross-domain hand-typed" or "Drift candidate", **When** the reader follows the recommended action, **Then** they find either an existing backlog item reference (e.g. #203, #204, #205) or a newly opened backlog item link.
+3. **Given** a previously unknown type is introduced to the codebase after the audit, **When** the audit is re-run using the documented methodology, **Then** the new type is discoverable and the re-run produces the same classifications for existing types.
+
+---
+
+### User Story 2 - Backlog items exist for every actionable finding (Priority: P2)
+
+As an engineer planning the next E11 phase, I need every "Cross-domain hand-typed" and "Drift candidate" finding to be addressable via a backlog item — either an existing item or a new one opened as part of the audit — so that follow-up work has a concrete home and no finding gets lost on a report page.
+
+**Why this priority**: A report that does not drive work is shelfware. This story turns the inventory into committed backlog entries so the audit feeds E11's rollout directly.
+
+**Independent Test**: Can be validated by filtering the report to its actionable rows and confirming each row's recommended action resolves to a backlog item ID (existing or newly created) linked from the report.
+
+**Acceptance Scenarios**:
+
+1. **Given** a finding in the "Cross-domain hand-typed" bucket, **When** a reader checks the recommended action, **Then** they see either a link to an existing backlog item (#203, #204, #205, or another open E11 child) or a link to a newly created item.
+2. **Given** a finding in the "Drift candidate" bucket, **When** a reader checks the recommended action, **Then** the same rule applies.
+3. **Given** the report has been accepted, **When** the E11 epic document is viewed, **Then** it links to the audit report so the phase list can be read in context.
+
+---
+
+### User Story 3 - Reproducible methodology (Priority: P3)
+
+As a future maintainer, I need the audit report to document how it was produced — which paths were scanned, which were excluded, which markers identified generated vs. authored code, and how classifications were assigned — so that the audit can be re-run to detect drift that creeps back in, without re-deriving the method from scratch.
+
+**Why this priority**: Drift is the problem the audit is trying to surface; a one-off audit whose method is lost offers half the value. Reproducibility is lower priority than the inventory itself but is what makes the audit a durable control rather than a snapshot.
+
+**Independent Test**: Another engineer, given only the report and the repo at a later commit, can follow the methodology section and arrive at an equivalent inventory within one working session.
+
+**Acceptance Scenarios**:
+
+1. **Given** the report, **When** a new engineer reads its methodology section, **Then** they can identify the exact in-scope and out-of-scope paths and the rule used to distinguish generated from authored code.
+2. **Given** the methodology section, **When** a re-run is attempted six months later, **Then** any discrepancy between the re-run and the original audit is attributable to code change, not methodology ambiguity.
+
+---
+
+### Edge Cases
+
+- **Test-local types** (declared inside `__tests__/`, `__fixtures__/`, `*.test.ts`, `*.spec.ts`): excluded from the inventory but the exclusion rule is stated in the methodology; if a test-local type is later promoted to production use it becomes in-scope.
+- **Re-exports of schema types** (e.g. `export type { Coordinate } from '@debrief/schemas'`): classified as Schema-rooted via transitive reference — not treated as a new declaration.
+- **Anonymous / inline types** (e.g. object literal types in function parameters): out of scope — the audit covers only named `interface` / `type` / `enum` declarations.
+- **Type aliases that collapse to `Record<string, unknown>` or `unknown`**: classified as Boundary / parse-time loose type regardless of their declared name.
+- **Same-name, different-shape types across packages** (e.g. two `Coordinate` definitions in different folders): recorded once per declaration site and both tagged as Drift candidate cross-referencing each other.
+- **Re-exports from third-party packages** (`export type { Foo } from 'leaflet'`): excluded — vendored or upstream types are not in scope.
+- **TypeScript declaration files (`.d.ts`)**: included if authored in-repo; excluded if under `node_modules/` or a generated output path.
+- **Python cross-domain types** (e.g. a hand-authored Pydantic `BaseModel` whose instances are serialised and consumed by the TypeScript side): flagged in a separate "Python cross-domain candidates" appendix if encountered during the sweep, without being classified against the five TS buckets.
+- **Generated output discovered outside the known generated directory**: noted as a methodology gap and escalated, not silently classified.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The audit MUST enumerate every named `interface`, `type`, and `enum` declaration in TypeScript source files under `apps/`, `shared/`, and `services/`.
+- **FR-002**: The audit MUST exclude declarations under `shared/schemas/src/generated/` and any other path whose output is produced by the LinkML generators.
+- **FR-003**: The audit MUST exclude declarations inside test-only locations (`__tests__/`, `__fixtures__/`, files ending `.test.ts` or `.spec.ts`) and document the exclusion rule.
+- **FR-004**: Each in-scope declaration MUST be assigned exactly one of five classifications: Schema-rooted, Boundary / parse-time loose type, Single-domain convenience type, Cross-domain hand-typed, or Drift candidate.
+- **FR-005**: Each entry MUST record the declaration's name, source file path, line number, a one-line summary of what it represents, its classification, and a recommended action.
+- **FR-006**: For every entry classified Cross-domain hand-typed or Drift candidate, the recommended action MUST resolve to a backlog item reference — either an existing item (including #203, #204, #205) or a newly opened item.
+- **FR-007**: The audit MUST be delivered as a single Markdown report committed to the repository at a stable path under `docs/`.
+- **FR-008**: The report MUST include a summary section with counts per classification bucket and a list of newly opened backlog items.
+- **FR-009**: The report MUST include a methodology section describing the scanned paths, exclusion rules, the distinction between generated and authored code, and the rule applied for each classification bucket, sufficient for an independent re-run.
+- **FR-010**: The Epic E11 document (`docs/ideas/E11-schema-first-boundary-typing.md`) MUST be updated to link to the report.
+- **FR-011**: The audit MUST NOT modify production source code; it is read-only analysis producing documentation and backlog entries only.
+- **FR-012**: Where a Python hand-authored type appears to cross the Python ↔ TypeScript boundary, the audit MUST list it in a separate appendix rather than silently dropping it, even though the five-bucket classification is TypeScript-focused.
+
+### Key Entities
+
+- **Type declaration**: a named TypeScript `interface`, `type`, or `enum` located in an in-scope source file; uniquely identified by source file path + declaration name.
+- **Classification**: the bucket assigned to a type declaration — one of Schema-rooted, Boundary / parse-time loose, Single-domain convenience, Cross-domain hand-typed, Drift candidate.
+- **Finding**: the combination of a type declaration, its classification, a one-line summary, a recommended action, and any linked backlog item. A finding is the unit of content in the report table.
+- **Audit report**: the Markdown document containing the methodology, the findings table, the summary counts, and the appendices.
+- **Backlog item link**: a reference (by ID and URL/anchor) to an existing or newly opened backlog item that will carry out the recommended action for an actionable finding.
+- **E11 epic link**: a bidirectional reference — the epic document points to the report, and the report points back to the epic — so the phase plan stays traceable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of named `interface`, `type`, and `enum` declarations discovered in the in-scope paths appear in the report with an assigned classification; zero appear unclassified or with multiple classifications.
+- **SC-002**: Every finding in the Cross-domain hand-typed and Drift candidate buckets links to a backlog item (existing or newly opened); the report's summary section lists the newly opened items so the count is auditable.
+- **SC-003**: The Epic E11 document contains a working link to the report, and the report contains a working link back to the epic.
+- **SC-004**: An engineer unfamiliar with the audit can reproduce the inventory from the methodology section within one working session; a re-run's differences are attributable only to code change, not to method ambiguity.
+- **SC-005**: No production source code files are modified as part of delivering this feature (zero non-documentation code diffs in the audit's pull request, excluding backlog file edits).
+
+## Assumptions
+
+- Scope for the five-bucket classification is TypeScript declarations only; Python hand-typed cross-domain candidates are surfaced in an appendix rather than classified, because the Python side is expected to be Pydantic-generated-from-LinkML and any hand-authored cross-domain Python type is a signal rather than a bucket.
+- The generated-vs-authored boundary is defined primarily by path (`shared/schemas/src/generated/`); if any generator writes elsewhere, the methodology will note this as a gap rather than silently re-classify.
+- The report file will live under `docs/` at a path chosen by the implementer during planning (e.g. `docs/type-audit-2026.md` as suggested in the original idea) — the exact filename is not material provided the E11 epic links to it.
+- "Backlog item" means an entry in `BACKLOG.md` following the project's existing item format; existing items #203, #204, #205 already cover several findings and should be reused rather than duplicated.
+- The audit is a one-shot deliverable; however, reproducibility of the methodology is a first-class requirement so the audit can be re-run later.
+
+## Dependencies
+
+- No code dependencies (read-only analysis).
+- References existing backlog items #203, #204, #205 and Epic E11; those items must remain findable and accurately scoped or the report's "fold into existing item" links will break.

--- a/specs/206-audit-non-linkml-types/tasks.md
+++ b/specs/206-audit-non-linkml-types/tasks.md
@@ -1,0 +1,256 @@
+# Tasks: [E11] Audit non-LinkML type declarations
+
+**Input**: Design documents from `/specs/206-audit-non-linkml-types/`
+**Prerequisites**: plan.md (required), spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Scanner unit tests ARE included (see plan.md Testing field — "fixture-based unit tests for the scanner"). No other test types apply; no runtime or Playwright tests.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented, tested, and delivered as an independent increment.
+
+---
+
+## Evidence Requirements
+
+> **Purpose**: Capture artefacts that prove the audit deliverable is complete and the methodology is reproducible. Used in the PR description and linked from the shipped blog post.
+
+**Evidence Directory**: `specs/206-audit-non-linkml-types/evidence/`
+**Media Directory**: `specs/206-audit-non-linkml-types/media/`
+
+**Feature type**: Infrastructure / Analysis — produces a committed Markdown report plus a committed scanner tool. No UI, no runtime service, no extension workflow.
+
+### Planned Artefacts
+
+| Artefact | Description | Captured When |
+|----------|-------------|---------------|
+| `evidence/test-summary.md` | Scanner unit-test results (vitest pass/fail counts, YAML front matter with `git_sha` and `captured_at`) | After Phase 2 tests pass |
+| `evidence/usage-example.md` | Walk-through of running the scanner + applying a classification to a sample record | After Phase 3 complete |
+| `evidence/scanner-run.txt` | Terminal transcript of `pnpm tsx scripts/audits/type-audit/scan.ts` run on the full repo, with per-bucket auto-tag counts | After Phase 3 complete |
+| `evidence/scan-output.sample.json` | Redacted / trimmed excerpt (~10 records) of the intermediate JSON produced by the scanner | After Phase 3 complete |
+| `evidence/ajv-validation.txt` | Output of validating `scan-output.sample.json` against `contracts/scan-output.schema.json` — proves the scanner honours its contract | After Phase 3 complete |
+| `evidence/report-link.md` | One-line stub pointing to the committed report at `docs/type-audit-2026.md` (which is itself the primary deliverable) | After Phase 5 complete |
+| `evidence/backlog-diff.txt` | `git diff BACKLOG.md` showing newly opened items (if any) | After Phase 4 complete |
+| `evidence/rerun-methodology.md` | Short write-up confirming a second engineer reproduced the inventory from the methodology section (spec SC-004) | After Phase 5 complete |
+
+### Media Content
+
+| Artefact | Description | Created When |
+|----------|-------------|--------------|
+| `media/planning-post.md` | Blog post announcing the audit | **Done** — `/speckit.plan` |
+| `media/linkedin-planning.md` | LinkedIn summary for planning | **Done** — `/speckit.plan` |
+| `media/shipped-post.md` | Blog post celebrating completion (findings summary, key surprises, what E11 does next) | Polish phase |
+| `media/linkedin-shipped.md` | LinkedIn summary for shipped | Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in `debrief/debrief-future` with report, scanner, backlog edits, and evidence | Final task in Polish phase |
+| Blog PR | PR in `debrief/debrief.github.io` publishing `shipped-post.md` | Triggered by `/speckit.pr` |
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the scanner's folder skeleton and make `typescript` available to the scanner at repo-root level.
+
+- [ ] T001 Create scanner folder structure with a README explaining purpose, CLI flags, and invocation `scripts/audits/type-audit/README.md`
+- [ ] T002 [P] Add a minimal `tsconfig.json` for the scanner that targets Node 20 + ESM and enables `strict: true` `scripts/audits/type-audit/tsconfig.json`
+- [ ] T003 Add `typescript` (^5.x) to the repo-root `devDependencies` so the scanner does not need to piggy-back on a workspace install `package.json`
+- [ ] T004 [P] Add `vitest` + `ajv` to the repo-root `devDependencies` for scanner unit tests and schema-contract validation `package.json`
+- [ ] T005 [P] Create fixtures directory with ~10 hand-crafted `.ts` files covering each of: exported interface, non-exported interface, type alias, enum, alias bottoming out in `Record<string, unknown>`, drift pair (same name different shape across two files), schema-rooted re-export, and an excluded test-local declaration `scripts/audits/type-audit/__tests__/fixtures/`
+- [ ] T006 Run `pnpm install` at the repo root to materialise the new devDependencies `package.json`
+
+**Checkpoint**: Scanner folder exists, TypeScript compiler available at root, fixtures in place. Phase 2 can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the committed scanner at `scripts/audits/type-audit/scan.ts`. Every user story consumes this scanner's JSON output — nothing downstream can start until it exists and its contract is honoured.
+
+**⚠️ CRITICAL**: No user-story work can begin until this phase is complete.
+
+### Tests for Foundation (fixture-driven, written first) ⚠️
+
+> **NOTE**: Write these tests FIRST, ensure they FAIL before implementing the scanner.
+
+- [ ] T007 [P] [test] Fixture unit test — scanner enumerates the expected number of records from the fixtures folder and produces stable-sorted output `scripts/audits/type-audit/__tests__/scan.enumerate.test.ts`
+- [ ] T008 [P] [test] Fixture unit test — auto-tag rules: `schema-rooted-candidate` fires on files importing `@debrief/schemas`, `boundary-candidate` fires on aliases bottoming out in `unknown` / `Record<string, unknown>` `scripts/audits/type-audit/__tests__/scan.autotag.test.ts`
+- [ ] T009 [P] [test] Fixture unit test — `driftClusters` groups same-name-different-shape declarations and excludes same-name-same-shape duplicates `scripts/audits/type-audit/__tests__/scan.drift.test.ts`
+- [ ] T010 [P] [test] Contract test — scanner output validates against `specs/206-audit-non-linkml-types/contracts/scan-output.schema.json` via ajv `scripts/audits/type-audit/__tests__/scan.contract.test.ts`
+- [ ] T011 [P] [test] Determinism test — running the scanner twice on the same fixtures produces byte-identical JSON (stable sort order, stable SHA-1 shape hashes) `scripts/audits/type-audit/__tests__/scan.determinism.test.ts`
+
+### Implementation for Foundation
+
+- [ ] T012 Implement AST traversal — walk each `.ts` / `.tsx` file and emit one record per top-level `InterfaceDeclaration`, `TypeAliasDeclaration`, `EnumDeclaration` (spec FR-001, data-model §1) `scripts/audits/type-audit/scan.ts`
+- [ ] T013 Implement exclusion rules — skip paths matching `shared/schemas/src/generated/**`, `**/__tests__/**`, `**/__fixtures__/**`, `**/*.test.ts`, `**/*.spec.ts`, `**/node_modules/**`, `**/dist/**` (spec FR-002, FR-003) `scripts/audits/type-audit/scan.ts`
+- [ ] T014 Compute stable `id` (`${packageName}:${relativeFilePath}:${declarationName}`) + `shapeHash` (SHA-1 of normalised AST print) per record `scripts/audits/type-audit/scan.ts`
+- [ ] T015 Collect import specifiers per file and attach to each record's `imports` array `scripts/audits/type-audit/scan.ts`
+- [ ] T016 Implement auto-tagging: set `autoTag` to `schema-rooted-candidate` / `boundary-candidate` / `drift-shortlist` / `none` per research.md R2, R4, R6 `scripts/audits/type-audit/scan.ts`
+- [ ] T017 Implement drift-cluster post-pass — group records by `declarationName`, emit a cluster when membership size ≥ 2 and distinct `shapeHash` count ≥ 2 `scripts/audits/type-audit/scan.ts`
+- [ ] T018 Emit the top-level wrapper — `scannerVersion` = `"v1"`, `capturedAt` (ISO-8601), `gitSha` (from `git rev-parse HEAD`), `scannedPaths`, `excludedPaths`, `records`, `driftClusters` (data-model §6, contract: `scan-output.schema.json`) `scripts/audits/type-audit/scan.ts`
+- [ ] T019 Add CLI flag parsing (`--roots`, `--exclude`, `--out`) matching the invocation documented in `quickstart.md` `scripts/audits/type-audit/scan.ts`
+- [ ] T020 Print a one-line stderr summary on completion (`Scanned N files, emitted M records, K drift clusters`) — confirms the scanner ran without forcing stdout noise `scripts/audits/type-audit/scan.ts`
+- [ ] T021 Wire up `vitest` configuration for the scanner tests (minimal — Node environment, no DOM, no Playwright) `scripts/audits/type-audit/vitest.config.ts`
+- [ ] T022 Run the scanner once against the full repo and verify it completes in under 30 seconds (plan.md Performance Goal); record timing in a commit message or throwaway log — this is a developer smoke-test, not an evidence task
+
+**Parallel opportunity**: T007–T011 (all tests in different files) can be drafted simultaneously. T013–T017 mutate `scan.ts` and must be done sequentially in that file (unless split into modules).
+
+**Checkpoint**: `pnpm --filter-root vitest run scripts/audits/type-audit` is green; the scanner produces schema-valid output. User-story phases can begin.
+
+---
+
+## Phase 3: User Story 1 — Complete classified inventory for E11 planning (Priority: P1)
+
+**Goal**: Publish the committed report `docs/type-audit-2026.md` with the full findings table — every in-scope TS declaration classified into exactly one of the five buckets.
+
+**Independent Test**: Randomly sample 10 named TypeScript type declarations from `apps/`, `shared/` (excluding `shared/schemas/src/generated/`), and `services/`; confirm each appears exactly once in the report with a classification and a recommended action (spec SC-001).
+
+### Implementation for User Story 1
+
+- [ ] T023 [US1] Run the scanner against the full repo and save the intermediate JSON to a local throwaway path (e.g. `tmp/type-audit.json`) — `.gitignore` the `tmp/` folder if not already ignored `tmp/type-audit.json`
+- [ ] T024 [US1] Validate `tmp/type-audit.json` against `contracts/scan-output.schema.json` with ajv-cli; abort if validation fails (spec SC-001 depends on trusting the scanner's output) `tmp/type-audit.json`
+- [ ] T025 [US1] Create the report scaffold with YAML front matter (`feature`, `epic`, `captured_at`, `git_sha`, `scanner_version`), an intro paragraph that back-links to `docs/ideas/E11-schema-first-boundary-typing.md`, and the six required section headings from data-model §6 `docs/type-audit-2026.md`
+- [ ] T026 [US1] Populate the Findings table — one row per record, sorted classification → package → file path. For each row, confirm or override the scanner's `autoTag` and assign one of the five final classifications (`schema-rooted`, `boundary-loose`, `single-domain`, `cross-domain-hand-typed`, `drift-candidate`). Author a one-line `summary` per row. Leave `recommendedAction` cells for Phase 4 where they need backlog IDs `docs/type-audit-2026.md`
+- [ ] T027 [P] [US1] For every `single-domain` row, author the `justification` column (spec data-model §3 validation rule) `docs/type-audit-2026.md`
+- [ ] T028 [P] [US1] Resolve every entry in `driftClusters` — each cluster becomes at least one `drift-candidate` finding, cross-referencing the sibling declarations `docs/type-audit-2026.md`
+- [ ] T029 [US1] Fill the Summary section with per-bucket counts (derive from the populated Findings table) — leave the "Newly opened backlog items" sub-list for Phase 4 `docs/type-audit-2026.md`
+- [ ] T030 [US1] Spot-check: pick 10 random TS declarations from in-scope paths and verify each appears in the Findings table (SC-001). Record the sample IDs in a commit message, not the report `docs/type-audit-2026.md`
+
+**Checkpoint**: The report's Findings table is complete and internally consistent; every record is classified. Phase 4 can fill in backlog linkage.
+
+---
+
+## Phase 4: User Story 2 — Backlog items for every actionable finding (Priority: P2)
+
+**Goal**: Ensure every actionable finding (`cross-domain-hand-typed` or `drift-candidate`) links to a backlog item — either an existing one (#203, #204, #205, or another E11 child) or a new entry opened in this same PR. Update the report's summary to list the newly opened items.
+
+**Independent Test**: Filter the report to `cross-domain-hand-typed` + `drift-candidate` rows; confirm every row's `recommendedAction` cell resolves to a `#NNN` reference (existing or new) with a working link target (spec SC-002).
+
+### Implementation for User Story 2
+
+- [ ] T031 [US2] For every `cross-domain-hand-typed` and `drift-candidate` finding, attempt to fold into an existing backlog item first (#203 spatial types, #204 RawGeoJSONFeature, #205 DisplayMode/PlaybackState, or another open E11 child). Update the `recommendedAction` cell to `Fold into #NNN — <short rationale>` `docs/type-audit-2026.md`
+- [ ] T032 [US2] Determine the next available backlog ID in `BACKLOG.md` by scanning existing rows (current max + 1) `BACKLOG.md`
+- [ ] T033 [US2] For each remaining actionable finding that does not fit an existing item, append a new row to `BACKLOG.md` using the project's existing table format — category `Infrastructure`, status `approved` if scope is clear else `needs-interview`, link to the audit report anchor as the rationale source `BACKLOG.md`
+- [ ] T034 [US2] (Optional, if any new item's scope warrants it) Create idea documents under `docs/ideas/` following the pattern of `docs/ideas/203-*.md`, `204-*.md`, `205-*.md` `docs/ideas/`
+- [ ] T035 [US2] Update every actionable finding's `recommendedAction` cell in the report to `Open #NNN — <title>` (for newly opened items) or `Fold into #NNN` (for existing) so every row has a non-empty link target `docs/type-audit-2026.md`
+- [ ] T036 [US2] Fill the report's "Newly opened backlog items" summary sub-list with each new ID + one-line title + link to `BACKLOG.md` `docs/type-audit-2026.md`
+- [ ] T037 [US2] Self-check against spec SC-002: filter the Findings table to `cross-domain-hand-typed` + `drift-candidate` rows and confirm zero rows have an empty `backlogItemRef` `docs/type-audit-2026.md`
+
+**Checkpoint**: Every actionable finding has a backlog home. The Summary section's counts match the number of new items committed to `BACKLOG.md`.
+
+---
+
+## Phase 5: User Story 3 — Reproducible methodology (Priority: P3)
+
+**Goal**: The report's methodology section is detailed enough that a future maintainer can re-run the audit from a clean checkout and produce an equivalent inventory without needing to ask questions. Close the bidirectional link with Epic E11.
+
+**Independent Test**: A second engineer (real or simulated via a code-review pass) reads only the methodology section and the quickstart and reproduces the scan on a freshly-cloned worktree; their output's drift vs. the committed report is attributable to code changes, not methodology ambiguity (spec SC-004).
+
+### Implementation for User Story 3
+
+- [ ] T038 [US3] Author the Methodology section: list the exact in-scope paths (`apps/`, `shared/`, `services/`), the exclusion patterns (verbatim globs), the rule for distinguishing generated vs. authored code (path-based — `shared/schemas/src/generated/`), and the rule applied for each of the five classification buckets (spec FR-009) `docs/type-audit-2026.md`
+- [ ] T039 [US3] In the Methodology section, embed the exact re-run command (copy from `quickstart.md` §1) so the report is self-contained `docs/type-audit-2026.md`
+- [ ] T040 [US3] Add a "Known methodology gaps / caveats" subsection listing any generated output discovered outside `shared/schemas/src/generated/` (per spec edge-case bullet) or any classification judgement that felt borderline and deserves a second look `docs/type-audit-2026.md`
+- [ ] T041 [P] [US3] Populate the Python cross-domain appendix: sweep `services/` and `shared/` Python packages for hand-authored types whose instances appear to cross the Python ↔ TS boundary (e.g. Pydantic `BaseModel` subclasses consumed by MCP tool results). If none found, include an explicit "No candidates found" line — the section is not optional (spec FR-012) `docs/type-audit-2026.md`
+- [ ] T042 [US3] Update `docs/ideas/E11-schema-first-boundary-typing.md` — add a bullet under `## Items` linking to `docs/type-audit-2026.md`, and append any new phases surfaced by the audit to `## Phase inventory` (spec FR-010 / SC-003) `docs/ideas/E11-schema-first-boundary-typing.md`
+- [ ] T043 [US3] Confirm the report's intro paragraph back-links to `docs/ideas/E11-schema-first-boundary-typing.md` (T025 scaffolded the link — verify it survived editing) `docs/type-audit-2026.md`
+- [ ] T044 [US3] Add a "Re-run log / changelog" section at the bottom of the report with a first entry: `2026-MM-DD — Initial audit (git_sha: ...)` — future re-runs append rows here without rewriting the body `docs/type-audit-2026.md`
+
+**Checkpoint**: All three user stories are independently testable. Report and epic cross-link bidirectionally. Methodology is complete enough to support re-runs.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Capture evidence, write the shipped post, and open the PR. This phase is where the audit becomes visible to reviewers.
+
+### Cross-cutting cleanup
+
+- [ ] T045 Run `task verify` (lint + typecheck + test) and fix any regressions introduced by adding `typescript` / `vitest` / `ajv` to root devDeps
+- [ ] T046 [P] Verify no production source files were modified — `git diff --stat origin/main...HEAD` should only touch `docs/`, `BACKLOG.md`, `scripts/audits/type-audit/`, `package.json`, `pnpm-lock.yaml`, and `specs/206-audit-non-linkml-types/` (spec SC-005)
+- [ ] T047 Update `CLAUDE.md` "Recent Changes" section with a 206 entry (previous auto-update was a no-op) `CLAUDE.md`
+
+### Evidence Collection (REQUIRED)
+
+- [ ] T048 Create evidence directory `specs/206-audit-non-linkml-types/evidence/`
+- [ ] T049 Capture test summary using the template at `.specify/templates/evidence/test-summary-template.md` — YAML front matter with `feature: 206-audit-non-linkml-types`, `captured_at`, `git_sha`, `tests_passed`, `tests_failed`, `tests_skipped`, `coverage_pct`; body covers scanner unit tests + contract validation `specs/206-audit-non-linkml-types/evidence/test-summary.md`
+- [ ] T050 [P] Record usage example — a narrated walk-through of running the scanner, validating with ajv, and assigning a classification to one sample record `specs/206-audit-non-linkml-types/evidence/usage-example.md`
+- [ ] T051 [P] Capture terminal transcript of a full-repo scanner run with stderr one-line summary `specs/206-audit-non-linkml-types/evidence/scanner-run.txt`
+- [ ] T052 [P] Capture a trimmed (~10 records) redacted excerpt of the intermediate scanner JSON `specs/206-audit-non-linkml-types/evidence/scan-output.sample.json`
+- [ ] T053 [P] Capture ajv validation output against `contracts/scan-output.schema.json` `specs/206-audit-non-linkml-types/evidence/ajv-validation.txt`
+- [ ] T054 [P] Capture `git diff BACKLOG.md` showing newly opened items (or a "no new items" note if none were opened) `specs/206-audit-non-linkml-types/evidence/backlog-diff.txt`
+- [ ] T055 [P] Write a short note referencing the committed report as the primary deliverable `specs/206-audit-non-linkml-types/evidence/report-link.md`
+- [ ] T056 Execute the re-run sanity check from spec SC-004: on a fresh worktree at the same SHA, re-run the scanner + ajv validate; document that the JSON output is byte-identical (determinism test already enforces this, but a live re-run is the evidence) `specs/206-audit-non-linkml-types/evidence/rerun-methodology.md`
+
+### Media Content
+
+- [ ] T057 Create shipped blog post using the Content Specialist agent (`.claude/agents/media/content.md`) — include What We Built (surprising findings, counts per bucket, anything notable), Lessons Learned (any classification call that was hard), What's Next (the E11 phase list the audit unlocked) `specs/206-audit-non-linkml-types/media/shipped-post.md`
+- [ ] T058 [P] Create LinkedIn shipped summary (150–200 words, hook opening referencing a concrete number from the findings, link placeholder to full post) `specs/206-audit-non-linkml-types/media/linkedin-shipped.md`
+
+### PR Creation
+
+- [ ] T059 Create PR and publish blog: run `/speckit.pr`
+
+**Task T059 must run last. It depends on T045 through T058 being complete — CI must be green, evidence must be captured, and both blog posts must be drafted before the PR opens.**
+
+---
+
+## Dependencies
+
+### Phase dependencies
+
+- **Phase 1 (Setup)** — no dependencies. T001/T002/T005 are `[P]`. T003 + T004 both edit `package.json` and must be sequential. T006 depends on T003 + T004.
+- **Phase 2 (Foundation)** — depends on Phase 1 complete. **Blocks all user stories.**
+- **Phase 3 (US1, P1)** — depends on Phase 2. Independently testable per spec §User Story 1.
+- **Phase 4 (US2, P2)** — depends on Phase 3 complete (needs the classified Findings table to know which rows need backlog links). Independently testable per spec §User Story 2.
+- **Phase 5 (US3, P3)** — depends on Phase 2 (methodology is about the scanner + classification). Can proceed in parallel with Phase 4; T042 depends on Phase 4 having committed new backlog items, so run T042 after Phase 4.
+- **Phase 6 (Polish)** — depends on Phases 3, 4, 5 all complete.
+
+### Within-phase dependencies
+
+- **Phase 2 tests (T007–T011)** — all `[P]`, independent files, can be drafted in parallel.
+- **Phase 2 implementation (T012–T022)** — T013–T017 all mutate `scan.ts` and should be sequential; T021 (`vitest.config.ts`) is independent `[P]`-eligible. T022 (smoke-test) runs last.
+- **Phase 3 (T023–T030)** — T023 → T024 → T025 → T026 are strictly sequential (each builds on the previous). T027 + T028 (`[P]`) edit different parts of the report and can overlap once T026 has laid out the table skeleton. T029 + T030 run after.
+- **Phase 4 (T031–T037)** — T031 → T032 → T033 → T034 → T035 → T036 → T037 run sequentially; T034 is optional.
+- **Phase 5 (T038–T044)** — T038–T040 sequentially edit the Methodology subsection. T041 `[P]` edits an independent section (Python appendix). T042 edits a different file (`docs/ideas/E11-*.md`). T043 + T044 close the section.
+- **Phase 6** — T045 runs first (CI gate). T046–T055 (`[P]`-flagged) can run in parallel where files differ. T056 depends on the scanner being unchanged since T045. T057 + T058 can overlap. **T059 (PR) is the final task and must not run until every other task is complete.**
+
+### Parallel opportunities
+
+- Phase 1: T001, T002, T005 in parallel; T003 + T004 sequential because both edit `package.json`.
+- Phase 2: T007–T011 in parallel (all tests, different files).
+- Phase 3: T027 + T028 in parallel once the table skeleton from T026 exists.
+- Phase 5: T041 (Python appendix) runs in parallel with T038–T040 (Methodology) and T042 (epic doc edit).
+- Phase 6: T050, T051, T052, T053, T054, T055 all `[P]` — different evidence files. T058 runs in parallel with T057.
+
+---
+
+## Implementation Strategy
+
+### Incremental delivery
+
+1. **Phase 1 + Phase 2** — land the scanner and its tests. At this checkpoint the scanner is committed but the report does not yet exist. The work is independently verifiable via `vitest` and ajv contract tests. A second engineer could pick up here without any historical context.
+2. **Phase 3 (US1)** — land the Findings table. The report exists, every record is classified, but actionable rows do not yet have backlog links. The Summary counts are already honest.
+3. **Phase 4 (US2)** — land backlog linkage + any new `BACKLOG.md` entries in the same PR. The report is now actionable.
+4. **Phase 5 (US3)** — land the Methodology section + Python appendix + bidirectional E11 link. The report is now reproducible and durable.
+5. **Phase 6** — land evidence + shipped blog post + PR.
+
+Each of Phases 3, 4, 5 is an independently-testable increment per spec §User Scenarios. If time pressure forces a stop, Phases 1–3 alone still deliver a useful artefact (the inventory itself); Phase 4 + 5 upgrade it to the final E11-ready deliverable.
+
+### Single-developer cadence
+
+This feature is naturally single-threaded. Recommended sequence:
+
+- Day 1: Phase 1 + Phase 2 (setup + scanner + tests).
+- Day 2: Phase 3 (Findings table — the bulk of reviewer judgement work).
+- Day 3: Phase 4 + Phase 5 (backlog linkage + methodology).
+- Day 4: Phase 6 (evidence, shipped post, PR).
+
+The Findings table (T026) is the largest single effort and benefits from being uninterrupted.
+
+### Stop-the-world triggers
+
+- If the scanner crashes on a real-world file (not a fixture), fix in Phase 2 before proceeding — every downstream task trusts the scanner's output.
+- If a classification call is genuinely 50/50, tag the row as such in the Findings table and surface it in the "Known methodology gaps" subsection (T040) rather than silently picking one bucket.
+- If the count of actionable findings is surprisingly high (double-digit new backlog items), pause and raise with the E11 owner before opening them all — the audit may need scope adjustment.


### PR DESCRIPTION
## Summary

- **Planning stack only** — ships spec, plan, research, contracts, tasks, and the planning blog post for backlog item #206. No implementation in this PR.
- First child of **Epic E11 — Schema-First Boundary Typing**. Implementation lands in subsequent PR(s) per `tasks.md`.
- Deliverable (once implemented) will be `docs/type-audit-2026.md` — a classified inventory of every named TypeScript `interface` / `type` / `enum` declaration under `apps/`, `shared/` (excluding `shared/schemas/src/generated/`), and `services/`, with every actionable finding linked to a backlog item (existing or newly opened in the same PR as the report).

## Why a planning-only PR

Follows the precedent set by `docs(205): planning stack` (commit `b7747e86`) and `docs(217): planning stack` (commit `2b3228d5`) — ship the planning artefacts as their own small, reviewable PR before heavy implementation. Reviewers can challenge scope, taxonomy, and methodology before we invest in the scanner and the report-drafting work.

## Artefacts in this PR

- `spec.md` — 3 prioritised user stories (P1 complete inventory → P2 backlog linkage → P3 reproducible methodology), 12 FRs, 5 measurable SCs, 9 edge cases. No UI flow section (analysis feature).
- `plan.md` — Constitution Check **PASS** (no violations; Articles II, VI, VIII, IX, XV strengthened by the audit). No new runtime deps; scanner is `typescript` compiler API via `tsx`.
- `research.md` — 7 decisions locked: TS-compiler-API scanner (reject regex, reject ts-morph); auto-tag cheap signals, humans classify; committed scanner at `scripts/audits/type-audit/` for reproducibility; report at `docs/type-audit-2026.md`; drift detection by shape-hash clustering; same-PR backlog edits; Python cross-domain types get an appendix rather than the five TS-centric buckets.
- `data-model.md` — scanner record + finding + backlog-ref + Python-appendix shapes. Closed 5-bucket classification enum.
- `contracts/scan-output.schema.json` + `contracts/type-declaration-record.schema.json` — JSON Schema for the scanner's intermediate output.
- `quickstart.md` — run/re-run procedure with a 6-item acceptance self-check.
- `tasks.md` — 59 tasks across 6 phases (Setup / Foundation / US1 / US2 / US3 / Polish), 5 fixture-driven scanner tests, 9 evidence artefacts, `/speckit.pr` as the final task.
- `media/planning-post.md` + `media/linkedin-planning.md` — planning announcement (drafted by the content specialist).
- `checklists/requirements.md` — spec quality checklist (all items pass).

## Scope of this PR

- **Only touches** `specs/206-audit-non-linkml-types/`. No source code changes. No backlog, docs, or script edits outside the feature folder.
- 12 files added, 1,292 lines inserted.

## Feedback welcome

Per the planning post, three questions where reviewer input would change the output before implementation begins:

1. **Is the five-bucket taxonomy the right cut?** Is there a category missing, or one (perhaps Cross-domain hand-typed) that is really two things?
2. **Python in an appendix, or a separate audit?** Leaning toward appendix, but genuinely unsure.
3. **Report location and naming.** `docs/type-audit-2026.md` is year-stamped so we can re-run next year without a rename. Should it instead live under `docs/audits/` as a subdirectory?

## Test plan

- [ ] Spec reviewed against requirements checklist at `specs/206-audit-non-linkml-types/checklists/requirements.md` (all items already ticked by author)
- [ ] Constitution Check in `plan.md` confirmed (no violations)
- [ ] Feedback on the three open questions captured (in this PR or via issue comments) before `/speckit.implement` begins
- [ ] No source code or non-feature documentation changes — confirmed by diff inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)