### PR TITLE
Elevate web-shell to primary E2E path; deprecate code-server

### DIFF
--- a/.claude/commands/bugfix.md
+++ b/.claude/commands/bugfix.md
@@ -30,7 +30,7 @@ Article VIII states: "Specs before code — no **significant** implementation wi
 Extract the backlog item ID from `$ARGUMENTS`:
 
 - Accept formats: `007`, `7`, `#007`, `#7`, `ID 007`
-- Normalize to numeric (e.g., `007` → `7`)
+- Normalize to a 3-digit zero-padded string (e.g., `7` → `007`, `#12` → `012`) so it matches BACKLOG.md IDs and feature-branch/spec-dir prefixes
 - ERROR if no ID provided: "Please provide a backlog item ID, e.g., `/bugfix 013`"
 
 ### Step 2: Read and Parse BACKLOG.md

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -100,13 +100,20 @@ You **MUST** consider the user input before proceeding (if not empty).
      - Verify bundles: self-contained, < 500KB, renders in isolation
      - Record bundle details in evidence/
    - **Media content**: Create blog posts and LinkedIn summaries using Content Specialist agent
-   - **E2E test tasks**: Playwright tests for Storybook stories (when plan.md has "Storybook E2E Testing" entries):
-     - Create test file in `shared/components/e2e/` using pattern from `.specify/templates/e2e-test-template.ts`
-     - Use Storybook story URL: `/iframe.html?id=category-component--variant`
-     - Test all theme variants using URL globals parameter: `&globals=theme:light|dark|vscode`
-     - Add `data-testid` attributes to components for reliable selection
-     - Capture screenshots for evidence: `await page.screenshot({ path: 'specs/[feature]/evidence/screenshots/...' })`
-     - Run tests: `pnpm --filter @debrief/components test:e2e [testfile]`
+   - **E2E test tasks** — pick the path that matches the feature:
+     - **Storybook E2E** (isolated components, when plan.md has "Storybook E2E Testing" entries):
+       - Create test file in `shared/components/e2e/` using pattern from `.specify/templates/e2e-test-template.ts`
+       - Use Storybook story URL: `/iframe.html?id=category-component--variant`
+       - Test all theme variants using URL globals parameter: `&globals=theme:light|dark|vscode`
+       - Add `data-testid` attributes to components for reliable selection
+       - Capture screenshots for evidence: `await page.screenshot({ path: 'specs/[feature]/evidence/screenshots/...' })`
+       - Run tests: `pnpm --filter @debrief/components test:e2e [testfile]`
+     - **Web-shell E2E** (full extension workflows and blog/PR screenshots, when plan.md has "Web-Shell E2E Testing" entries):
+       - Create test file in `apps/web-shell/playwright/tests/[workflow].spec.ts` — model on `properties-screenshots.spec.ts` (multi-theme + interaction GIF) or `drawing.spec.ts` (workflow interaction).
+       - Reuse page objects in `apps/web-shell/playwright/pages/` (`AnalysisPage`, `CatalogPage`); extend with new selectors rather than duplicating.
+       - Write screenshots/GIFs directly into `specs/[feature]/evidence/screenshots/` from the spec file — this is the source of record for blog/PR media.
+       - Run tests: `cd apps/web-shell && node run-playwright.mjs [workflow]` (cloud) or `pnpm --filter @debrief/web-shell test [workflow]` (local).
+       - **Do NOT** reach for the openvscode-server / `xvfb-run --config tests/e2e/playwright.config.ts` path to capture screenshots — it was explored in #142 and is unreliable; use it only if a test genuinely requires the real VS Code chrome (command palette, sidebar host).
 
 > **⚠️ PLAYWRIGHT WORKS IN CLOUD SESSIONS** — Do NOT skip Playwright tests because you think browsers can't be installed. Standard browser CDN downloads are blocked (403), but `@sparticuz/chromium` bundles a Linux Chromium binary via npm and works fully. The project's `playwright.config.ts` auto-detects the environment and uses the bundled binary when `CLAUDE_CODE=1` is set. Run via `node apps/web-shell/run-playwright.mjs` to extract and configure the bundled browser. Full details: `docs/project_notes/playwright-installation-research.md`
 

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -36,37 +36,21 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Delegate branch numbering to the script**:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
+   The script assigns the next available 3-digit feature number by globally scanning local branches, remote branches, and `specs/` directories for the highest existing `NNN-*` entry (regex `^[0-9]{3}-`), then incrementing. Claude does **not** pre-compute the number.
 
-      ```bash
-      git fetch --all --prune
-      ```
+   Run the script once, passing only the short-name and feature description:
 
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   - Bash example: `.specify/scripts/bash/create-new-feature.sh --json --short-name "user-auth" "Add user authentication"`
+   - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
-   - You must only ever run this script once per feature
-   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
-   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
-   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+   - Run the script exactly once per feature.
+   - Do **not** pass `--number`; let the script compute it. Feature numbers are **global** (shared across all short-names) and zero-padded to 3 digits (e.g. `207-user-auth`), never reset per short-name.
+   - The JSON is provided in the terminal as output — always refer to it to get the actual content you're looking for.
+   - The JSON output contains `BRANCH_NAME`, `SPEC_FILE`, `FEATURE_NUM`, and (in worktree mode) `WORKTREE_PATH`.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g. `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`).
 
 3. Load `.specify/templates/spec-template.md` to understand required sections.
 

--- a/.claude/commands/speckit.start.md
+++ b/.claude/commands/speckit.start.md
@@ -31,7 +31,7 @@ This command bridges the gap between backlog prioritization and the speckit work
 Extract the backlog item ID from `$ARGUMENTS`:
 
 - Accept formats: `007`, `7`, `#007`, `#7`, `ID 007`
-- Normalize to numeric (e.g., `007` → `7`)
+- Normalize to a 3-digit zero-padded string (e.g., `7` → `007`, `#12` → `012`) so it matches BACKLOG.md IDs and feature-branch/spec-dir prefixes
 - ERROR if no ID provided: "Please provide a backlog item ID, e.g., `/speckit.start 007`"
 
 ### Step 1a: Check for Stale Worktrees (Cleanup)

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -145,7 +145,8 @@ Based on the feature type detected from spec.md and plan.md:
 | **API/Service** | Sample request + response JSON | `sample-request.json`, `sample-response.json` |
 | **Library/SDK** | Code examples with results | `usage-example.py`, `output.txt` |
 | **Data Processing** | Before/after samples | `input-sample.*`, `output-sample.*` |
-| **UI Component** | 3 theme screenshots (light/dark/vscode) + interaction GIF showing key user flow | `screenshots/component-light.png`, `screenshots/component-dark.png`, `screenshots/component-vscode.png`, `screenshots/interaction.gif` |
+| **UI Component** | 3 theme screenshots (light/dark/vscode) + interaction GIF showing key user flow (via Storybook E2E) | `screenshots/component-light.png`, `screenshots/component-dark.png`, `screenshots/component-vscode.png`, `screenshots/interaction.gif` |
+| **VS Code Extension Workflow** | Workflow screenshots + interaction GIF captured by Playwright driving the **web-shell** (`apps/web-shell/playwright/tests/`, run via `node apps/web-shell/run-playwright.mjs`). The web-shell hosts the same shared components as the extension, so its screenshots are the source of record for blog/PR media. Do **not** route screenshots through openvscode-server / `xvfb-run` — that path is unreliable. | `screenshots/workflow-*.png`, `screenshots/interaction.gif`, `webview-e2e-summary.md` |
 | **Parser/Converter** | Input/output file pairs side-by-side | `sample-input.rep`, `parsed-output.json` |
 | **Schema Change** | Round-trip proof (Python -> JSON -> TypeScript -> JSON) | `round-trip-evidence.md` |
 | **Integration** | End-to-end flow demo + sequence diagram | `integration-flow.md`, `sequence.mermaid` |

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -143,30 +143,33 @@ directories captured above]
 
 *If no e2e tests needed, write "None - no interactive UI components"*
 
-## VS Code Webview E2E Testing
+## Web-Shell E2E Testing
 
-*Identify extension workflows that require end-to-end testing through code-server. Skip if feature has no VS Code extension changes.*
+*Identify extension workflows that require end-to-end testing. Skip if the feature has no extension workflow changes. This is the path for any workflow-level screenshots destined for evidence/blog.*
 
-> **Reference**: `docs/e2e-testing-guide.md` — full guide to the webview E2E architecture, patches, and patterns.
+> **Reference**: `docs/e2e-testing-guide.md` §3 — web-shell architecture, page objects, screenshot/GIF patterns.
+>
+> The web-shell (`apps/web-shell/`) is a standalone React app hosting the same shared components as the VS Code extension. Driving it with Playwright is the supported path for full-workflow E2E and is the source of record for blog/PR screenshots. Do **not** route workflow tests through openvscode-server / `xvfb-run` — that path (#142) is unreliable and reserved for chrome-level concerns.
 
-| Workflow | Panels Involved | Key Selectors | Interactions |
-|----------|----------------|---------------|--------------|
-| [e.g., Open REP file] | Map Panel, Activity Panel | `.leaflet-container`, `.catalog-overview` | open file, verify tracks render |
+| Workflow | Panels/Components Involved | Key Selectors | Interactions |
+|----------|---------------------------|---------------|--------------|
+| [e.g., Open plot + filter tracks] | MapView, FilterBar, FeatureList | `.leaflet-container`, `[data-testid="filter-bar"]`, `[data-testid="feature-list"]` | load plot, apply filter, verify count |
 
 **Testing Strategy**:
-- [ ] Extension workflow works end-to-end in code-server
-- [ ] Webview content accessible via `frameLocator` chaining
-- [ ] Page objects updated for new selectors
-- [ ] Screenshots captured for evidence
+- [ ] Workflow runs end-to-end in the web-shell
+- [ ] Page objects in `apps/web-shell/playwright/pages/` extended for new selectors (reuse `AnalysisPage` / `CatalogPage` rather than duplicating)
+- [ ] Screenshots and/or interaction GIF written **directly** into `specs/[feature]/evidence/screenshots/` from the spec file (follow the path-resolution pattern in `apps/web-shell/playwright/tests/properties-screenshots.spec.ts`)
 
-**Test File Location**: `tests/e2e/test-{workflow}.spec.ts`
+**Test File Location**: `apps/web-shell/playwright/tests/{workflow}.spec.ts`
 
-**Infrastructure**:
-- Patches applied by `tests/e2e/scripts/patch-webview.sh`
-- Content injection via `tests/e2e/helpers/webview-injector.ts`
-- Headed Chromium required: `xvfb-run --auto-servernum npx playwright test ...`
+**Run Commands**:
+- Cloud: `cd apps/web-shell && node run-playwright.mjs {workflow}` (auto-provisions `@sparticuz/chromium`)
+- Local: `pnpm --filter @debrief/web-shell test {workflow}`
 
-*If no webview E2E tests needed, write "None - no extension workflow changes"*
+**Optional — chrome-level VS Code Webview tests**:
+Only for tests that genuinely require real VS Code chrome (command palette, sidebar host lifecycle, native notifications). See `docs/e2e-testing-guide.md` §4. Not the path for evidence/blog screenshots.
+
+*If no workflow E2E tests needed, write "None - no extension workflow changes"*
 
 ## Complexity Tracking
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -183,15 +183,20 @@ Examples of foundational tasks (adjust based on your project):
 - [ ] T0XX [P] [US1] Add interaction tests for user flows
 - [ ] T0XX [US1] Run e2e tests: `pnpm --filter @debrief/components test:e2e [Component]`
 
-### VS Code Webview E2E Tests for User Story 1 (REQUIRED for extension workflows) 🖥️
+### Web-Shell E2E Tests for User Story 1 (REQUIRED for extension workflows) 🖥️
 
-> **NOTE**: Include this section when the user story involves VS Code extension workflows (opening files, running commands, interacting with webview panels).
-> See plan.md "VS Code Webview E2E Testing" section for which workflows need tests.
+> **NOTE**: Include this section when the user story involves a full extension workflow (opening a plot, running a tool, interacting with multiple panels) rather than a single isolated component. The web-shell (`apps/web-shell/`) is a standalone React app that hosts the same shared components as the VS Code extension (MapView, FilterBar, FeatureList, drawing tools, LogPanel, PropertiesPanel, etc.); driving it with Playwright is the supported path for full-workflow tests and blog/PR screenshots.
+>
+> See plan.md "Web-Shell E2E Testing" section for which workflows need tests.
 > Full architecture guide: `docs/e2e-testing-guide.md`
+>
+> **⚠️ PLAYWRIGHT WORKS IN CLOUD SESSIONS** — Do NOT skip these tests because you think browsers can't be installed. The web-shell runner at `apps/web-shell/run-playwright.mjs` extracts the bundled `@sparticuz/chromium` binary and configures Playwright to use it. Full details: `docs/project_notes/playwright-installation-research.md`
+>
+> **Do NOT use the `tests/e2e/` + `xvfb-run` + openvscode-server path.** It was explored in #142 but is unreliable and is not the source of record for screenshots. Reach for it only if a test genuinely requires the real VS Code chrome (command palette, sidebar host); otherwise use web-shell.
 
-- [ ] T0XX [P] [US1] Update page objects in `tests/e2e/models/` with new selectors
-- [ ] T0XX [P] [US1] Create Playwright test `tests/e2e/test-[workflow].spec.ts`
-- [ ] T0XX [US1] Run webview e2e tests: `xvfb-run --auto-servernum npx playwright test --config tests/e2e/playwright.config.ts test-[workflow]`
+- [ ] T0XX [P] [US1] Update page objects in `apps/web-shell/playwright/pages/` with new selectors (reuse `AnalysisPage` / `CatalogPage` where possible)
+- [ ] T0XX [P] [US1] Create Playwright test `apps/web-shell/playwright/tests/[workflow].spec.ts` (model on `properties-screenshots.spec.ts` or `drawing.spec.ts`)
+- [ ] T0XX [US1] Run web-shell e2e tests: `cd apps/web-shell && node run-playwright.mjs [workflow]` (or `pnpm --filter @debrief/web-shell test [workflow]` locally)
 
 ### Implementation for User Story 1
 
@@ -299,14 +304,17 @@ Examples of foundational tasks (adjust based on your project):
 - [ ] VS Code theme: `screenshots/component-vscode.png`
 ```
 
-### VS Code Webview E2E Evidence Collection (REQUIRED for extension workflows) 🖥️
+### Web-Shell E2E Evidence Collection (REQUIRED for extension workflows) 🖥️
 
-> **Purpose**: Capture workflow evidence from VS Code webview tests
+> **Purpose**: Capture workflow screenshots and GIFs from Playwright tests driving the web-shell. This is the supported path for blog/PR screenshots of extension workflows — the openvscode-server / `xvfb-run` route is not in use.
+>
 > Full guide: `docs/e2e-testing-guide.md`
+>
+> **⚠️ PLAYWRIGHT WORKS IN CLOUD SESSIONS** — `apps/web-shell/run-playwright.mjs` auto-provisions the bundled `@sparticuz/chromium` binary. Full details: `docs/project_notes/playwright-installation-research.md`
 
-- [ ] TXXX Run webview e2e suite: `xvfb-run --auto-servernum npx playwright test --config tests/e2e/playwright.config.ts`
-- [ ] TXXX [P] Capture workflow screenshots to tests/e2e/evidence/
-- [ ] TXXX Document webview e2e results in evidence/webview-e2e-summary.md
+- [ ] TXXX Run web-shell e2e suite: `cd apps/web-shell && node run-playwright.mjs`
+- [ ] TXXX [P] Capture workflow screenshots directly into `specs/[feature]/evidence/screenshots/` from the spec file (see `apps/web-shell/playwright/tests/properties-screenshots.spec.ts` for the pattern — it writes PNGs + an interaction GIF into the feature's evidence dir)
+- [ ] TXXX Document web-shell e2e results in evidence/webview-e2e-summary.md
 
 **Checkpoint**: Evidence collected - ready for PR creation via `/speckit.pr`
 

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -1,19 +1,21 @@
 # E2E Testing Guide
 
-How to write and run end-to-end tests for Debrief features that involve UI components. Covers both **Storybook component tests** (isolated React components) and **VS Code webview tests** (full extension running in code-server).
+How to write and run end-to-end tests for Debrief features that involve UI components. Covers **Storybook component tests** (isolated React components), **web-shell workflow tests** (full extension workflows via a standalone React host — the default path for extension E2E and blog/PR screenshots), and **VS Code webview tests** (full extension running in code-server — optional, for chrome-level concerns only).
 
-## 1. Two Kinds of E2E Test
+## 1. Three Kinds of E2E Test
 
 | Kind | What It Tests | Runs In | Test Location |
 |------|--------------|---------|---------------|
 | **Storybook E2E** | Individual React components via Storybook stories | Storybook dev server (`localhost:6006`) | `shared/components/e2e/` |
-| **VS Code Webview E2E** | Full extension: webviews, commands, sidebar panels | code-server (headless VS Code) | `tests/e2e/` |
+| **Web-Shell E2E** (default for extension workflows) | Full workflows using the same shared components as the VS Code extension, hosted in a standalone React app (MapView, FilterBar, FeatureList, drawing tools, LogPanel, PropertiesPanel, GoldenLayout, etc.) | `apps/web-shell` (Vite dev server) | `apps/web-shell/playwright/tests/` |
+| **VS Code Webview E2E** (optional, chrome-level only) | Tests that genuinely require real VS Code chrome (command palette, sidebar host, notification toasts) | code-server (headless VS Code) | `tests/e2e/` |
 
 **When to use which:**
 
 - Adding or modifying a **shared component** (map, timeline, chart, feature list) → Storybook E2E
-- Adding or modifying an **extension workflow** (open file → view tracks → run tool) → VS Code Webview E2E
-- Major features often need **both**: Storybook tests for component correctness, webview tests for integration
+- Adding or modifying an **extension workflow** (open file → view tracks → run tool → edit properties) → **Web-Shell E2E**. This is also the source of record for the screenshots and GIFs that land in `specs/[feature]/evidence/screenshots/` and later in blog posts.
+- Testing behaviour that depends on the real VS Code chrome (command palette invocation, sidebar host lifecycle, native notifications) → VS Code Webview E2E. For everything else prefer web-shell — the code-server path was explored in #142, is unreliable, and is not the source of blog/PR screenshots.
+- Major features often need **both** Storybook tests (component correctness) and Web-Shell tests (workflow integration + screenshots).
 
 ## 2. Storybook E2E Tests
 
@@ -66,7 +68,90 @@ pnpm --filter @debrief/components test:e2e MyComponent
 
 The `plan-template.md` and `tasks-template.md` already include Storybook E2E sections. When `/speckit.plan` identifies UI components, it populates the "Storybook E2E Testing" table. When `/speckit.tasks` generates task lists, it includes E2E test tasks alongside implementation tasks.
 
-## 3. VS Code Webview E2E Tests
+## 3. Web-Shell E2E Tests
+
+### Overview
+
+`apps/web-shell/` is a small Vite/React app that mounts the same shared components the VS Code extension uses — MapView, FilterBar, FeatureList, drawing tools, GoldenLayout panels, LogPanel, PropertiesPanel, TimeController. Playwright drives it in a regular browser page, which avoids every class of flake we hit when driving code-server (service-worker collisions, CSP hash invalidation, `resolveWebviewView` lifecycle bugs, etc.). This is the default path for full-workflow E2E tests and is the **source of record** for the screenshots and GIFs that land in `specs/[feature]/evidence/screenshots/` and later in blog posts.
+
+### Test Layout
+
+```
+apps/web-shell/
+  playwright/
+    playwright.config.ts          # config — uses bundled chromium when CLAUDE_CODE=1
+    global-setup.ts
+    pages/
+      AnalysisPage.ts             # panels, filters, tool runs, properties form
+      CatalogPage.ts              # STAC catalog browsing
+      index.ts
+    tests/
+      properties-screenshots.spec.ts   # multi-theme + interaction GIF (reference pattern)
+      drawing.spec.ts                  # workflow interaction pattern
+      plot-load.spec.ts                # load + render pattern
+      ...
+  run-playwright.mjs              # cloud runner: extracts @sparticuz/chromium then runs tests
+```
+
+### Creating a Test
+
+Model on `properties-screenshots.spec.ts` (screenshot + GIF capture) or `drawing.spec.ts` (workflow interaction). Write evidence directly into the feature's evidence folder:
+
+```typescript
+// apps/web-shell/playwright/tests/my-workflow.spec.ts
+import { test, expect } from '@playwright/test';
+import { mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EVIDENCE_DIR = resolve(
+  __dirname,
+  '../../../../specs/NNN-my-feature/evidence/screenshots',
+);
+mkdirSync(EVIDENCE_DIR, { recursive: true });
+
+test('captures the key workflow', async ({ page }) => {
+  await page.goto('/');
+  // ... interact using page objects from apps/web-shell/playwright/pages/
+  await page.screenshot({ path: `${EVIDENCE_DIR}/workflow-default.png` });
+});
+```
+
+Reuse page objects in `apps/web-shell/playwright/pages/` rather than re-implementing selectors — extend them with new accessors where needed.
+
+### Theme Variants
+
+For multi-theme screenshots (`component-light.png`, `component-dark.png`, `component-vscode.png`), inject a small CSS override that sets the VS Code CSS variables on `:root`. See `properties-screenshots.spec.ts`'s `applyTheme()` helper for the canonical pattern.
+
+### Interaction GIFs
+
+Enable `recordVideo` in the test's context options, drive the workflow, then convert the resulting `.webm` to `.gif` (ffmpeg). `properties-screenshots.spec.ts` shows the full pattern including the move + rename step.
+
+### Running
+
+```bash
+# Cloud session (Claude Code) — uses bundled @sparticuz/chromium
+cd apps/web-shell && node run-playwright.mjs
+
+# Single test file
+cd apps/web-shell && node run-playwright.mjs my-workflow
+
+# Local dev (macOS/Windows) — requires system Chromium
+pnpm --filter @debrief/web-shell test
+pnpm --filter @debrief/web-shell test my-workflow
+
+# With Playwright UI
+pnpm --filter @debrief/web-shell test:ui
+```
+
+### Speckit Integration
+
+`plan-template.md` and `tasks-template.md` have a "Web-Shell E2E Testing" section. When `/speckit.plan` identifies an extension workflow, it populates that table. When `/speckit.tasks` generates tasks, it emits web-shell test + screenshot-capture tasks that write directly into the feature's evidence directory.
+
+## 4. VS Code Webview E2E Tests (optional — chrome-level only)
+
+> **Status**: Explored in #142 and documented below for reference. This path is **unreliable** and is **not** the source of record for screenshots or blog media — use web-shell (§3) for workflow E2E and screenshot capture. Reach for this path only when a test must exercise real VS Code chrome that the web-shell cannot simulate (command palette, sidebar host lifecycle, native notification toasts, VSIX install flows).
 
 ### The Problem
 
@@ -223,20 +308,25 @@ npx playwright test --config tests/e2e/playwright.config.ts --trace on
 | `.provenance-source` | Provenance lineage markers | US2: Tool Execution |
 | `.notification-toast-container` | VS Code notification toasts | US3: Error Feedback |
 
-## 4. CI Configuration
+## 5. CI Configuration
 
 ### Storybook E2E in CI
 
 Already integrated in `.github/workflows/ci.yml`. The Storybook dev server starts, Playwright runs against it, and results are reported.
 
-### VS Code Webview E2E in CI
+### Web-Shell E2E in CI
 
-Runs as a separate CI job (see `specs/005-e2e-workflow-tests/plan.md`, Decision 8):
+Runs as part of the main CI pipeline — see `CLAUDE.md` "Before Pushing" for the exact step:
 
-1. Build extension VSIX
-2. Start code-server with extension sideloaded
-3. Run `patch-webview.sh`
-4. Run Playwright tests with `xvfb-run`
+```sh
+cd apps/web-shell && node run-playwright.mjs
+```
+
+The runner extracts `@sparticuz/chromium` on first run, starts the Vite dev server via Playwright's `webServer` config, then runs the suite.
+
+### VS Code Webview E2E in CI (optional)
+
+Not currently wired into the main CI gate. Historical reference: `specs/005-e2e-workflow-tests/plan.md`, Decision 8 documented a separate CI job that built the extension VSIX, started code-server with it sideloaded, ran `patch-webview.sh`, and invoked Playwright via `xvfb-run`. If you re-enable this for chrome-level tests, follow that pattern.
 
 ### Chromium in Cloud Sessions
 
@@ -249,7 +339,7 @@ npm install @sparticuz/chromium
 
 Config requires `executablePath` pointing to the extracted binary and sandbox-disable flags. See `docs/project_notes/playwright-installation-research.md` for full details.
 
-## 5. Adding E2E Tests for a New Feature (Checklist)
+## 6. Adding E2E Tests for a New Feature (Checklist)
 
 ### For a Storybook component:
 
@@ -260,7 +350,17 @@ Config requires `executablePath` pointing to the extracted binary and sandbox-di
 5. Run `pnpm --filter @debrief/components test:e2e {Component}`
 6. Capture screenshots to `specs/{feature}/evidence/screenshots/`
 
-### For a VS Code extension workflow:
+### For an extension workflow (default — web-shell):
+
+1. Identify which panels and shared components are exercised (map, filter bar, feature list, drawing, properties, log, catalog, time controller, …)
+2. Reuse/extend page objects in `apps/web-shell/playwright/pages/` (`AnalysisPage`, `CatalogPage`); add new selectors there rather than duplicating
+3. Create `apps/web-shell/playwright/tests/{workflow}.spec.ts` — model on `properties-screenshots.spec.ts` (screenshots + interaction GIF) or `drawing.spec.ts` (workflow interaction)
+4. Write screenshots and GIFs **directly** into `specs/{feature}/evidence/screenshots/` from the spec file (see `properties-screenshots.spec.ts` for the canonical path-resolution pattern)
+5. Run with `cd apps/web-shell && node run-playwright.mjs {workflow}` (cloud) or `pnpm --filter @debrief/web-shell test {workflow}` (local)
+
+### For a chrome-level VS Code webview test (optional):
+
+Only when a test genuinely requires real VS Code chrome that web-shell cannot simulate.
 
 1. Identify which webview panels are involved (editor, sidebar, or both)
 2. Add DOM selectors to the **Selectors Reference** above
@@ -268,24 +368,51 @@ Config requires `executablePath` pointing to the extracted binary and sandbox-di
 4. Create test file in `tests/e2e/test-{workflow}.spec.ts`
 5. Use `frameLocator` chaining for webview content access
 6. Run with `xvfb-run` for headed mode (required for webview iframe creation)
-7. Capture screenshots to `tests/e2e/evidence/`
+7. Capture evidence to `tests/e2e/evidence/` — but do **not** rely on this path for blog/PR screenshots; produce those via web-shell instead.
 
 ### Speckit workflow:
 
-When using `/speckit.plan`, fill in both the "Storybook E2E Testing" section (for components) and the "VS Code Webview E2E Testing" section (for extension workflows). `/speckit.tasks` will generate the corresponding test tasks automatically.
+When using `/speckit.plan`, fill in:
+- **"Storybook E2E Testing"** for isolated component tests
+- **"Web-Shell E2E Testing"** for full extension workflows and any screenshots destined for evidence/blog
 
-## 6. Troubleshooting
+`/speckit.tasks` will generate the corresponding test tasks automatically, including screenshot-capture tasks that write into the feature's evidence directory.
+
+## 7. Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `#active-frame` not created | Patches not applied | Run `bash tests/e2e/scripts/patch-webview.sh` |
-| Webview loads but content is blank | `resolveWebviewView` not called | Use `webview-injector.ts` helper |
-| `vscode-resource` URLs 404 | DNS unreachable in sandbox | Add route interception (see Section 3) |
-| Chromium won't launch | Standard download blocked | Use `@sparticuz/chromium` (see Section 4) |
-| Tests pass locally, fail in CI | Missing `xvfb-run` | Wrap command: `xvfb-run --auto-servernum npx playwright test ...` |
-| Wrong sidebar frame selected | Multiple webview hosts | Use frame-finding pattern (see Section 3) |
+| Chromium won't launch | Standard download blocked | Use `@sparticuz/chromium` via `apps/web-shell/run-playwright.mjs` (see §5) |
+| Web-shell test starts but page is empty | Vite dev server not ready | Check `playwright.config.ts` `webServer` block; increase `timeout` if cold-boot is slow |
+| Screenshot written to the wrong folder | Incorrect relative path from spec file | Match the pattern in `properties-screenshots.spec.ts` — resolve against `fileURLToPath(import.meta.url)` |
+| Theme override isn't applied | VS Code CSS variables not set on `:root` | Use the `applyTheme()` helper pattern from `properties-screenshots.spec.ts` |
+| **Chrome-level only:** `#active-frame` not created | Patches not applied | Run `bash tests/e2e/scripts/patch-webview.sh` |
+| **Chrome-level only:** Webview loads but content is blank | `resolveWebviewView` not called | Use `webview-injector.ts` helper |
+| **Chrome-level only:** `vscode-resource` URLs 404 | DNS unreachable in sandbox | Add route interception (see §4) |
+| **Chrome-level only:** Tests pass locally, fail in CI | Missing `xvfb-run` | Wrap command: `xvfb-run --auto-servernum npx playwright test ...` |
+| **Chrome-level only:** Wrong sidebar frame selected | Multiple webview hosts | Use frame-finding pattern (see §4) |
 
-## 7. File Reference
+## 8. File Reference
+
+### Web-Shell E2E (default path)
+
+| File | Purpose |
+|------|---------|
+| `apps/web-shell/playwright/playwright.config.ts` | Playwright config — uses bundled chromium when `CLAUDE_CODE=1` |
+| `apps/web-shell/playwright/global-setup.ts` | Starts the Vite dev server before tests |
+| `apps/web-shell/playwright/pages/AnalysisPage.ts` | Page object for panels, filters, tool runs, properties form |
+| `apps/web-shell/playwright/pages/CatalogPage.ts` | Page object for STAC catalog browsing |
+| `apps/web-shell/playwright/tests/*.spec.ts` | Web-shell workflow E2E tests |
+| `apps/web-shell/run-playwright.mjs` | Cloud runner: extracts `@sparticuz/chromium`, then runs tests |
+
+### Storybook E2E
+
+| File | Purpose |
+|------|---------|
+| `shared/components/playwright.config.ts` | Playwright config for Storybook tests |
+| `shared/components/e2e/*.spec.ts` | Storybook component E2E tests |
+
+### VS Code Webview E2E (optional — chrome-level only)
 
 | File | Purpose |
 |------|---------|
@@ -297,9 +424,13 @@ When using `/speckit.plan`, fill in both the "Storybook E2E Testing" section (fo
 | `tests/e2e/models/code-server-page.ts` | Page object for VS Code chrome |
 | `tests/e2e/models/debrief-webview.ts` | Page object for Debrief webview content |
 | `tests/e2e/fixtures/base.ts` | Custom Playwright fixtures |
-| `shared/components/playwright.config.ts` | Playwright config for Storybook tests |
-| `shared/components/e2e/*.spec.ts` | Storybook component E2E tests |
+
+### Speckit templates and research notes
+
+| File | Purpose |
+|------|---------|
 | `.specify/templates/plan-template.md` | Plan template with E2E sections |
 | `.specify/templates/tasks-template.md` | Tasks template with E2E task patterns |
-| `docs/project_notes/webview-e2e-research.md` | Original research notes (detailed) |
+| `.specify/templates/e2e-test-template.ts` | Storybook E2E boilerplate |
+| `docs/project_notes/webview-e2e-research.md` | Original research notes on the code-server path |
 | `docs/project_notes/playwright-installation-research.md` | Chromium installation research |


### PR DESCRIPTION
## Summary

Restructures the E2E testing guide and supporting templates to establish `apps/web-shell/` as the default, supported path for full-workflow extension E2E tests and blog/PR screenshot capture. Demotes the code-server + `xvfb-run` path (explored in #142) to optional, chrome-level-only use cases, with clear guidance on when to use each.

## Key Changes

- **E2E Testing Guide** (`docs/e2e-testing-guide.md`):
  - Expanded "Three Kinds of E2E Test" section to explicitly cover web-shell as the primary workflow path
  - Added comprehensive §3 "Web-Shell E2E Tests" with architecture overview, test layout, page object patterns, theme variant handling, interaction GIF capture, and running instructions
  - Moved VS Code webview tests to §4 and marked as "optional — chrome-level only" with a status note referencing #142
  - Updated troubleshooting table to separate web-shell issues from chrome-level-only issues
  - Added dedicated "File Reference" section with separate tables for web-shell, Storybook, and VS Code webview paths
  - Updated checklist (§6) to make web-shell the default for extension workflows and clarify when to reach for chrome-level tests

- **Plan Template** (`.specify/templates/plan-template.md`):
  - Renamed "VS Code Webview E2E Testing" section to "Web-Shell E2E Testing"
  - Updated guidance to emphasize web-shell as the source of record for blog/PR screenshots
  - Added explicit warning against routing workflow tests through openvscode-server / `xvfb-run`
  - Updated example selectors and testing strategy to reflect web-shell patterns

- **Tasks Template** (`.specify/templates/tasks-template.md`):
  - Renamed "VS Code Webview E2E Tests" section to "Web-Shell E2E Tests"
  - Updated task descriptions to reference `apps/web-shell/playwright/` paths and `run-playwright.mjs` runner
  - Added prominent warnings about Playwright working in cloud sessions (with `@sparticuz/chromium`)
  - Clarified that openvscode-server path is not in use for screenshot capture
  - Updated evidence collection section to write directly into feature evidence directories from spec files

- **Implement Command** (`.claude/commands/speckit.implement.md`):
  - Expanded E2E test task guidance to distinguish between Storybook and web-shell paths
  - Added web-shell-specific instructions: page object reuse, test file location, screenshot/GIF patterns, run commands
  - Included explicit warning against using openvscode-server / `xvfb-run` for screenshot capture

- **Speckit Specify Command** (`.claude/commands/speckit.specify.md`):
  - Simplified branch creation workflow: removed manual number pre-computation
  - Clarified that feature numbers are global (not per short-name) and zero-padded to 3 digits
  - Updated to reflect that the script computes the next available number automatically

## Notable Implementation Details

- Web-shell tests write evidence (screenshots, GIFs) **directly** into `specs/[feature]/evidence/screenshots/` from the spec file, making it the single source of truth for blog/PR media
- Page objects in `apps/web-shell/playwright/pages/` (AnalysisPage, CatalogPage) are reused and extended rather than duplicated across tests
- Theme variants are captured via CSS variable injection on `:root` (canonical pattern in `properties-screenshots.spec.ts`)
- Interaction GIFs are recorded via Playwright's `recordVideo` context option and converted to `.gif` via ffmpeg
- Cloud runner (`apps/web-shell/run-playwright.mjs`) auto-provisions `@sparticuz/chromium` binary, enabling Playwright in Claude Code sessions
- Code-server path remains documented for reference and chrome-level concerns (command palette, sidebar host lifecycle, native notifications) but is explicitly marked as unreliable and not the path for evidence/blog screenshots

https://claude.ai/code/session_01DWLwdoJ8rWWVTXpGhyLwJL