### PR TITLE
Add backlog ID preservation to speckit workflow

### DIFF
--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -40,14 +40,17 @@ Given that feature description, do this:
 
    The script assigns the next available 3-digit feature number by globally scanning local branches, remote branches, and `specs/` directories for the highest existing `NNN-*` entry (regex `^[0-9]{3}-`), then incrementing. Claude does **not** pre-compute the number.
 
-   Run the script once, passing only the short-name and feature description:
+   **Exception — backlog-driven sessions**: If the feature description starts with a `[backlog-id:NNN]` tag (e.g. it was handed off from `/speckit.start 210`), extract `NNN` and pass it as `--number NNN` to the script. Strip the tag from the description before using it. This preserves the `BACKLOG.md` ID → spec-dir prefix invariant (`| 210 | ... | [desc](specs/210-short-name/spec.md) | ...`), which would otherwise break because the script's auto-numbering is `highest+1`, not the backlog ID.
 
-   - Bash example: `.specify/scripts/bash/create-new-feature.sh --json --short-name "user-auth" "Add user authentication"`
+   Run the script once, passing only the short-name and feature description (plus `--number` only if the exception applies):
+
+   - Bash example (standalone): `.specify/scripts/bash/create-new-feature.sh --json --short-name "user-auth" "Add user authentication"`
+   - Bash example (from `/speckit.start 210`): `.specify/scripts/bash/create-new-feature.sh --json --number 210 --short-name "user-auth" "Add user authentication"`
    - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
    - Run the script exactly once per feature.
-   - Do **not** pass `--number`; let the script compute it. Feature numbers are **global** (shared across all short-names) and zero-padded to 3 digits (e.g. `207-user-auth`), never reset per short-name.
+   - Do **not** pass `--number` **unless** the description arrived with a `[backlog-id:NNN]` tag (see exception above). For standalone use, let the script compute the number — feature numbers are **global** (shared across all short-names) and zero-padded to 3 digits (e.g. `207-user-auth`), never reset per short-name.
    - The JSON is provided in the terminal as output — always refer to it to get the actual content you're looking for.
    - The JSON output contains `BRANCH_NAME`, `SPEC_FILE`, `FEATURE_NUM`, and (in worktree mode) `WORKTREE_PATH`.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g. `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`).

--- a/.claude/commands/speckit.start.md
+++ b/.claude/commands/speckit.start.md
@@ -144,7 +144,13 @@ Proceed with specification? (The handoff button below will continue)
 
 When the user confirms (clicks the handoff button), the description will be passed to `/speckit.specify`.
 
-**Important**: The description from BACKLOG.md becomes the feature description for speckit.specify.
+**Important**: The description from BACKLOG.md becomes the feature description for speckit.specify. **Prefix it with `[backlog-id:{ID}]`** so that `/speckit.specify` preserves the backlog ID as the feature number (by passing `--number {ID}` to `create-new-feature.sh`). Without this prefix the script would auto-assign `highest+1`, breaking the BACKLOG.md → `specs/NNN-short-name/spec.md` link invariant.
+
+Example handoff payload for item `210`:
+
+```
+[backlog-id:210] Implement user authentication with OAuth2
+```
 
 ### Step 6: Post-Specification Update (CRITICAL)
 


### PR DESCRIPTION
## Summary
Updated the speckit specification workflow to preserve backlog item IDs when handing off from `/speckit.start` to `/speckit.specify`. This ensures that features created from backlog items maintain their original ID as the feature number, preventing breaks in the BACKLOG.md → specs directory link invariant.

## Key Changes

- **speckit.specify.md**: 
  - Added exception handling for backlog-driven sessions: when a feature description includes a `[backlog-id:NNN]` tag, extract the ID and pass it as `--number NNN` to the creation script
  - Updated script invocation examples to show both standalone and backlog-sourced workflows
  - Clarified that `--number` should only be passed when the description contains the backlog ID tag
  - Emphasized that auto-numbering (`highest+1`) would break the backlog ID invariant

- **speckit.start.md**:
  - Updated the handoff instruction to require prefixing the description with `[backlog-id:{ID}]` before passing to `/speckit.specify`
  - Added concrete example showing the expected handoff payload format for a backlog item
  - Explained the rationale: without the prefix, auto-numbering would break the BACKLOG.md → `specs/NNN-short-name/spec.md` link invariant

## Implementation Details
The solution uses a simple tag-based protocol (`[backlog-id:NNN]`) to communicate the desired feature number from the backlog context to the specification creation step. This allows the workflow to maintain referential integrity between the backlog and generated spec directories while preserving the auto-numbering behavior for standalone feature creation.

https://claude.ai/code/session_01GmgLsdoUoJZ7qLJYz3ow1Q