### PR TITLE
ci: spec-navigator PR comment on spec-touching PRs

### DIFF
--- a/.github/workflows/spec-navigator-comment.yml
+++ b/.github/workflows/spec-navigator-comment.yml
@@ -1,0 +1,100 @@
+name: Spec Navigator Comment
+
+# Posts (or updates) a sticky PR comment pointing reviewers at the
+# production Spec Navigator keyed to this PR, whenever the PR touches
+# anything under specs/. Code-only PRs are silent.
+#
+# The Spec Navigator is a static SPA at
+#   https://debrief.github.io/debrief-future/spec-navigator/
+# that reads ?pr=<number> at runtime and fetches the PR's spec content
+# from GitHub via the API — no per-branch build required.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'specs/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify changed spec directory
+        id: specdir
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const specDirs = new Set();
+            for (const f of files) {
+              const m = f.filename.match(/^specs\/([^/]+)\//);
+              if (m) specDirs.add(m[1]);
+            }
+            const dirs = [...specDirs].sort();
+            core.setOutput('dirs', JSON.stringify(dirs));
+            core.setOutput('count', String(dirs.length));
+
+      - name: Post or update Spec Navigator comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+            const headRef = context.payload.pull_request.head.ref;
+            const dirs = JSON.parse(`${{ steps.specdir.outputs.dirs }}`);
+
+            const marker = '<!-- spec-navigator-comment -->';
+            const navUrl = `https://debrief.github.io/debrief-future/spec-navigator/?pr=${prNumber}`;
+
+            const specLinks = dirs.map((d) => {
+              const treeUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${headRef}/specs/${d}`;
+              return `- [\`specs/${d}/\`](${treeUrl})`;
+            }).join('\n');
+
+            const body = [
+              marker,
+              '## 📋 Spec Navigator',
+              '',
+              `Review this PR's specs interactively:`,
+              '',
+              `👉 **[Open in Spec Navigator](${navUrl})**`,
+              '',
+              dirs.length > 0 ? '**Raw spec directories changed in this PR**:' : '',
+              dirs.length > 0 ? specLinks : '',
+              '',
+              `<sub>Updated for ${headSha.substring(0, 7)} — the navigator reads spec content live from GitHub, so no rebuild is needed.</sub>`,
+            ].filter((line) => line !== '').join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated comment ${existing.id}`);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created comment ${created.id}`);
+            }


### PR DESCRIPTION
## Summary

Adds a sticky PR comment that links reviewers to the **production Spec Navigator** (`?pr=<n>`) whenever a PR touches anything under `specs/`. Code-only PRs stay silent.

The Spec Navigator at `https://debrief.github.io/debrief-future/spec-navigator/` is already a static SPA that reads spec content live from GitHub via the API, so no per-PR build is needed — this workflow just surfaces the right URL at the right time.

## Why

Reviewers currently have to either know the `?pr=<n>` URL pattern or discover the PR via the navigator's built-in "Browse open PRs" affordance. Making the link one click away from the PR reduces friction and matches the existing pattern of the Storybook "🚀 Preview Deployments" sticky comment.

## What it does

- **Trigger**: `pull_request` types `opened` / `synchronize` / `reopened`, filtered to `paths: 'specs/**'`
- **Find-or-update** pattern via marker `<!-- spec-navigator-comment -->` (same shape as `storybook-preview.yml`)
- **Body** includes:
  - The navigator URL keyed to the PR number
  - Direct tree links to every `specs/<dir>/` touched in the PR (fallback for reviewers who just want raw markdown)
  - Short footer with the head SHA so reviewers can tell at a glance whether the comment reflects the latest push

## Test plan

- [ ] Merge this PR
- [ ] Push an empty cosmetic commit to PR #525 (spec-only) and confirm the sticky comment appears
- [ ] Push a subsequent commit to the same PR and confirm the existing comment is updated in place (not duplicated)
- [ ] Verify a code-only PR (e.g. a routine lint-fix branch) does NOT receive the comment

## Risks

- **Forked PRs**: the workflow uses `pull_request` (not `pull_request_target`), so PRs from forks will not get write tokens and the comment step will fail silently on those. The project's storybook-preview workflow has the same constraint, so this matches existing behaviour. If cross-fork support is desired later, we can switch to `pull_request_target` in a follow-up.
- **No permissions changes beyond `pull-requests: write`** — matches existing comment workflows.