### PR TITLE
Buffer scene-thumbnail asset entries until save (feature 219)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ Only updated when a feature introduces a technology not already listed here.
 - Storyboards and Scenes are **GeoJSON Features inside the (215-storyboarding-schema)
 - Python 3.11 (matches project baseline; stdlib-first). + Python stdlib (`pathlib`, `re`, `datetime`, `argparse`, `json`, `urllib.request`, `subprocess`), `PyYAML` (already in `uv.lock` via `linkml` transitively; used for shipped-post front matter parsing). Optional: `gh` CLI (shelled out for PR description retrieval; graceful degradation if absent — see FR-010 edge case). (228-regenerate-blog-archive)
 - Python 3.11 (matches project baseline, stdlib-first) + Python stdlib (`re`, `pathlib`, `dataclasses`, (231-blog-archive-screenshot-fix-impl)
+- TypeScript 5.x (strict mode), Node 20.x runtime via VS Code extension host + VS Code Extension API (^1.85.0), existing modules — `sceneThumbnailService`, `storyboardEditService`, `sessionManager`, `MapPanel`, `saveSession` command. **No new runtime dependencies.** (219-buffer-asset-entries)
 
 ## Before Pushing
 
@@ -246,5 +247,6 @@ pnpm --filter @debrief/spec-navigator build && cd apps/spec-navigator && node ru
 Note: `vitest` does not catch TypeScript type errors — only `tsc` (run during typecheck) does. The `pnpm build` step also runs `tsc`, but typecheck is the explicit CI gate.
 
 ## Recent Changes
+- 219-buffer-asset-entries: Added TypeScript 5.x (strict mode), Node 20.x runtime via VS Code extension host + VS Code Extension API (^1.85.0), existing modules — `sceneThumbnailService`, `storyboardEditService`, `sessionManager`, `MapPanel`, `saveSession` command. **No new runtime dependencies.**
 - 231-blog-archive-screenshot-fix-impl: Added Python 3.11 (matches project baseline, stdlib-first) + Python stdlib (`re`, `pathlib`, `dataclasses`,
 - 228-regenerate-blog-archive: Added Python 3.11 (matches project baseline; stdlib-first). + Python stdlib (`pathlib`, `re`, `datetime`, `argparse`, `json`, `urllib.request`, `subprocess`), `PyYAML` (already in `uv.lock` via `linkml` transitively; used for shipped-post front matter parsing). Optional: `gh` CLI (shelled out for PR description retrieval; graceful degradation if absent — see FR-010 edge case).

--- a/specs/219-buffer-asset-entries/checklists/requirements.md
+++ b/specs/219-buffer-asset-entries/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a tech-debt / architectural-cleanness feature with no UI surface, so the optional "User Interface Flow" section was excluded from the spec and the UI Feature Validation section is omitted from this checklist per the template guidance.
+- The spec preserves a few proper-noun references that the backlog item itself relies on (`item.json`, `features.geojson`, the existing `gcOrphanAssets` GC pass, the `thumbnail_asset_ref` property name, and the Scene-Thumbnail asset key naming convention `scene-thumbnail-{id}` / `-sm`). These name on-disk artefacts and existing data contracts that any equivalent description would have to refer to anyway — they are part of the user-visible vocabulary of the persisted plot, not implementation details to be hidden.
+- Validation pass: 1 of 1 (no failing items, no clarification markers).

--- a/specs/219-buffer-asset-entries/contracts/scene-thumbnail-buffer.md
+++ b/specs/219-buffer-asset-entries/contracts/scene-thumbnail-buffer.md
@@ -1,0 +1,296 @@
+# Contract: Scene-Thumbnail Buffer Service & Refactored Capture API
+
+**Feature**: 219 — Buffer Scene-Thumbnail Asset Entries Until Save
+**Date**: 2026-04-25
+
+This contract defines the public TypeScript surface of:
+1. The new `SceneThumbnailBuffer` service.
+2. The refactored `sceneThumbnailService.writeSceneThumbnail` function.
+3. The save-path integration point in `saveSession`'s `storeThumbnails` helper.
+
+REST/GraphQL contracts are not applicable — this is a VS Code extension internal API. The contract is expressed as TypeScript signatures with behavioural guarantees.
+
+---
+
+## 1. `SceneThumbnailBuffer` (NEW)
+
+**Module**: `apps/vscode/src/services/sceneThumbnailBuffer.ts`
+
+### Type definitions
+
+```ts
+/** Mirror of a single STAC asset entry, awaiting save-time persistence. */
+export interface PendingAssetEntry {
+  readonly key: string;                          // 'scene-thumbnail-{ulid}' | 'scene-thumbnail-{ulid}-sm'
+  readonly href: string;                         // './scene-thumbnails/scene-{ulid}.png' (or '-sm.png')
+  readonly type: 'image/png';
+  readonly title: string;
+  readonly roles: readonly ['thumbnail'];
+}
+
+/** Predicate used at flush time to test whether a buffered key still has a live Scene. */
+export type LivePredicate = (assetKey: string) => boolean;
+```
+
+### Public class / functional API
+
+```ts
+export class SceneThumbnailBuffer {
+  /**
+   * Add one or more pending entries for a plot. Idempotent on entry.key —
+   * a re-enqueue of the same key replaces the previous entry. Order is
+   * not significant.
+   */
+  enqueue(stacItemPath: string, entries: readonly PendingAssetEntry[]): void;
+
+  /**
+   * Snapshot of the entries currently pending for `stacItemPath`. Returns
+   * an empty array (never throws, never undefined) when there is no buffer
+   * for that plot.
+   */
+  pending(stacItemPath: string): readonly PendingAssetEntry[];
+
+  /** Drops the buffer for `stacItemPath`. No-op if the plot has no buffer. */
+  clear(stacItemPath: string): void;
+
+  /** Drops every buffer. Used on extension deactivation and in test cleanup. */
+  clearAll(): void;
+
+  /**
+   * Returns the entries that should be committed into item.json (those whose
+   * `key` passes `live`). Removes them from the buffer. Non-live entries are
+   * also removed silently — they will never be persisted.
+   *
+   * After this call, `pending(stacItemPath)` returns []. The buffer is
+   * drained whether or not the caller subsequently writes item.json
+   * successfully — see "Save failure" below.
+   */
+  flush(stacItemPath: string, live: LivePredicate): readonly PendingAssetEntry[];
+}
+```
+
+### Behavioural guarantees
+
+| Property | Guarantee |
+|----------|-----------|
+| Per-plot isolation | `clear(A)` MUST NOT affect `pending(B)`. `flush(A, live)` MUST NOT touch buffer entries under any other `stacItemPath`. |
+| Deterministic ordering | `pending()` and `flush()` MUST return entries in insertion order. Tests rely on this for stable assertions. |
+| Idempotency | `enqueue(P, [e])` followed by `enqueue(P, [e])` MUST yield exactly one entry under `e.key` (the second). |
+| No filesystem effects | The buffer MUST NOT touch the filesystem. It deals exclusively with metadata. |
+| No PNG bytes retained | The buffer MUST NOT hold PNG byte buffers. (Avoid memory pressure; PNG bytes are on disk.) |
+| Save-failure recovery | Spec FR-007 mandates that a failed save preserve the buffer. Therefore `flush()` MUST return the would-be-committed entries WITHOUT removing them; the caller (`storeThumbnails`) MUST call a separate `commit(stacItemPath, committedKeys)` after a successful `item.json` rewrite. **See revision in §3 below.** |
+
+> **Revision note**: To satisfy FR-007 cleanly, the API actually adopts a two-phase pattern. The `flush` method as described above is replaced by `peekPending` (read-only snapshot of currently pending live entries) + `commit` (drop the entries that were successfully written). See §3 for the final API.
+
+### Final API (after FR-007 revision)
+
+```ts
+export class SceneThumbnailBuffer {
+  enqueue(stacItemPath: string, entries: readonly PendingAssetEntry[]): void;
+  pending(stacItemPath: string): readonly PendingAssetEntry[];
+
+  /**
+   * Returns the live subset of pending entries (those whose key passes
+   * `live`) WITHOUT removing them. Caller writes item.json with these
+   * entries merged in, then — on success — calls `commit` to drop them.
+   */
+  peekLive(stacItemPath: string, live: LivePredicate): readonly PendingAssetEntry[];
+
+  /**
+   * Drops the entries with the given keys from the per-plot buffer.
+   * Called by the save path after a successful item.json rewrite.
+   * Non-live entries (those filtered out at peek time) MAY also be passed —
+   * the call is forgiving of missing keys.
+   */
+  commit(stacItemPath: string, committedKeys: readonly string[]): void;
+
+  /** Drops the buffer for `stacItemPath`. */
+  clear(stacItemPath: string): void;
+
+  /** Drops every buffer. */
+  clearAll(): void;
+}
+```
+
+> Note on the non-live drop: when a Scene was undone/deleted, its buffered entry is filtered out of `peekLive` but **also** dropped from the buffer at the next `commit` (since the caller does not pass its key in `committedKeys`, but the buffer can detect the orphan and clean up — alternative: a separate `discardOrphans(stacItemPath, live)` step called inside `commit`). The simplest implementation drops orphans during `peekLive` (since they will never be live again — the predicate is monotonic over a save-cycle). **Final choice**: `peekLive` drops non-live entries from the buffer as a side-effect; `commit` drops the keys it is given. This keeps the API surface to two phases without an `discardOrphans` step.
+
+---
+
+## 2. Refactored `sceneThumbnailService.writeSceneThumbnail`
+
+**Module**: `apps/vscode/src/services/sceneThumbnailService.ts`
+
+### Today
+
+```ts
+export interface WriteSceneThumbnailResult {
+  readonly assetKey: string;
+  readonly largePath: string;
+  readonly smallPath: string;
+}
+
+export async function writeSceneThumbnail(
+  stacItemPath: string,
+  sceneId: string,
+  largePngBase64: string,
+  smallPngBase64: string,
+  deps?: SceneThumbnailServiceDeps,
+): Promise<WriteSceneThumbnailResult>;
+// Side effect: writes two PNGs AND merges item.json.assets atomically.
+```
+
+### After
+
+```ts
+export interface WriteSceneThumbnailResult {
+  readonly assetKey: string;
+  readonly largePath: string;
+  readonly smallPath: string;
+  /**
+   * The two pending asset entries (large + small). Caller is expected to
+   * enqueue these into SceneThumbnailBuffer. Returned (rather than enqueued
+   * by this function) so the service stays free of DI on the buffer
+   * singleton — keeps it pure and easily testable.
+   */
+  readonly pendingEntries: readonly [PendingAssetEntry, PendingAssetEntry];
+}
+
+export async function writeSceneThumbnail(
+  stacItemPath: string,
+  sceneId: string,
+  largePngBase64: string,
+  smallPngBase64: string,
+  deps?: SceneThumbnailServiceDeps,
+): Promise<WriteSceneThumbnailResult>;
+// Side effect: writes two PNGs atomically. NO LONGER reads or mutates item.json.
+```
+
+### Behavioural changes
+
+| Property | Today | After |
+|----------|-------|-------|
+| PNGs on disk after success | Yes, atomic | Yes, atomic — unchanged |
+| `item.json` read | Yes | **No** — function no longer touches `item.json` |
+| `item.json` mutated | Yes (assets merged + atomic rewrite) | **No** |
+| Error taxonomy | `invalid-scene-id`, `empty-png`, `stac-item-not-found`, `item-json-unreadable`, `item-json-malformed`, `write-failed`, `rename-failed` | Same minus `item-json-unreadable`, `item-json-malformed`, and the rename-failed-on-item.json variant. PNG-write failures (`write-failed`, `rename-failed` for PNG paths) are preserved. |
+| Atomicity contract | If `item.json` rewrite fails, `item.json` is unchanged but PNGs may already be on disk (orphan). | If a PNG write fails, no `item.json` mutation has happened (because there is none in this function), and any tmp file is cleaned up. The first PNG may be on disk if the second fails — same partial-failure shape as today (orphans handled by GC). |
+
+### Atomicity boundary (FR-012)
+
+The save-time `item.json` rewrite (in `storeThumbnails`, see §3) preserves the existing all-or-nothing guarantee by reusing the same tmp + fsync + rename helper that today's `writeSceneThumbnail` uses internally. Failure during the rewrite leaves `item.json` byte-identical to its pre-save state.
+
+---
+
+## 3. Save-path integration: `storeThumbnails` in `saveSession.ts`
+
+**Module**: `apps/vscode/src/commands/saveSession.ts`
+
+### Today
+
+```ts
+function storeThumbnails(
+  storePath: string,
+  plotUri: string,
+  largePngBase64: string,
+  smallPngBase64: string,
+): void;
+// Reads item.json, sets assets.thumbnail and assets.thumbnail-sm, writes back.
+```
+
+### After
+
+```ts
+function storeThumbnails(
+  storePath: string,
+  plotUri: string,
+  largePngBase64: string,
+  smallPngBase64: string,
+  pendingSceneEntries: readonly PendingAssetEntry[],   // NEW
+): void;
+// Reads item.json, sets assets.thumbnail / assets.thumbnail-sm,
+// merges in every entry from pendingSceneEntries, writes back atomically.
+```
+
+The factory `createSaveSessionCommand` is extended to also accept the `SceneThumbnailBuffer` singleton:
+
+```ts
+export function createSaveSessionCommand(
+  sessionManager: SessionManager,
+  getStorePath: (storeId: string) => string | undefined,
+  getMapPanel?: () => MapPanel | undefined,
+  buffer?: SceneThumbnailBuffer,                       // NEW (optional for tests; required at runtime)
+): () => Promise<void>;
+```
+
+### Save command order of operations (after change)
+
+1. Read active session + plot URI; abort if absent (unchanged).
+2. Check dirty flag; abort if clean (unchanged).
+3. Resolve save path (unchanged).
+4. Persist session state via `saveSession(...)` (unchanged).
+5. Capture plot thumbnail via `MapPanel.requestThumbnailCapture(5000)` (unchanged).
+6. **NEW**: Resolve `stacItemPath` from `parseStacUri` + `getStorePath`. Build `livePredicate` from current in-memory features (the `MapPanel.getCurrentFeatures()` result). Call `buffer.peekLive(stacItemPath, live)` to obtain the live pending entries.
+7. Call `storeThumbnails(storePath, plotUri, largeBase64, smallBase64, peekedEntries)` — single atomic `item.json` rewrite, merging plot thumbnails AND buffered scene-thumbnail entries.
+8. **NEW**: On success, call `buffer.commit(stacItemPath, peekedEntries.map(e => e.key))` to drain the committed entries from the buffer.
+9. **NEW**: On failure of step 7, the buffer is left intact (FR-007). Subsequent save retries re-peek and re-attempt.
+
+### Atomicity
+
+Single `item.json` rewrite per save. If step 7 fails:
+- `item.json` is byte-identical to pre-save (existing tmp + fsync + rename guarantee).
+- Buffer is unchanged — `commit` is only called on success.
+- Plot thumbnail PNG files written by `storeThumbnails` may already be on disk; this is the same partial-failure shape as today, accepted by spec (orphan cleanup via GC).
+
+---
+
+## 4. Capture path integration: `captureScene` command
+
+**Module**: `apps/vscode/src/commands/captureScene.ts`
+
+### Change at line 256–271 (today: `await deps.writeSceneThumbnail(stacItemPath, sceneId, large, small)`)
+
+After change: the same call is made, the returned `pendingEntries` are enqueued into the buffer:
+
+```ts
+const result = await deps.writeSceneThumbnail(
+  stacItemPath, sceneId, thumbnails.largePngBase64, thumbnails.smallPngBase64,
+);
+deps.buffer.enqueue(stacItemPath, result.pendingEntries);
+```
+
+`CaptureCommandDeps` gains a `buffer: SceneThumbnailBuffer` field; tests inject a real or fake buffer. The `extension.ts` wiring (around line 269 — `setThumbnailService({ captureThumbnail })`) is updated to pass the singleton through to the capture port.
+
+The `EditThumbnailService.captureThumbnail` port shape (which returns `{ assetKey }`) is unchanged — the port implementation in `extension.ts` enqueues into the buffer immediately after the PNG write, before returning the asset key.
+
+---
+
+## 5. Plot-close hook (no public API change)
+
+When a plot closes (existing `mapPanel` lifecycle / `StoryboardEditService.onPlotClosed`), the buffer for that `stacItemPath` is cleared:
+
+```ts
+buffer.clear(stacItemPath);
+```
+
+This is wired in `extension.ts` alongside the existing `gcOrphanAssets` call on plot close. The order is: clear buffer → run `gcOrphanAssets`. The buffer clear is necessary because (a) any captured-but-unsaved entries are no longer reachable, (b) without the clear, a re-open of the same plot would inherit stale buffer state.
+
+---
+
+## 6. Type-safety notes (Constitution Article XV)
+
+- All new types are concrete; no `any`.
+- `PendingAssetEntry.type` and `.roles` are literal types (`'image/png'`, `readonly ['thumbnail']`) — narrower than the on-disk shape, but a strict subset, so the merge into `item.json.assets` is type-safe.
+- `LivePredicate` is a named type alias for clarity at the call site.
+
+---
+
+## 7. Failure-mode summary (audit table)
+
+| Scenario | Before this change | After this change |
+|----------|--------------------|-------------------|
+| Capture succeeds, save succeeds | `item.json` rewritten on capture, then again on save | `item.json` rewritten once on save |
+| Capture succeeds, save fails | `item.json` already updated on capture; save failure leaves it inconsistent (asset entries committed but session not saved) | `item.json` untouched on capture; save failure leaves both `item.json` and session unsaved (consistent) |
+| Capture succeeds, user discards | `item.json` already updated on capture; discard leaves stale asset entries pointing at PNGs that never get a Scene reference | `item.json` byte-identical to pre-session state; PNGs orphan, GC reclaims |
+| Capture succeeds, Scene undone, save | `item.json` has stale asset entries from the captured-then-undone Scene; orphan-asset GC cleans up on plot close | Buffered entries filtered out at save (filter-on-flush); `item.json` never sees them |
+| Capture fails (PNG write fails) | Throw `SceneThumbnailError(write-failed)`; `item.json` unchanged (failure happens before merge) | Same — throw `SceneThumbnailError(write-failed)`; `item.json` unchanged |
+| Capture succeeds, capture fails on second PNG | First PNG orphaned, throw; `item.json` unchanged | Same — first PNG orphaned, throw; `item.json` unchanged. Buffer not enqueued (caller only enqueues on full success). |

--- a/specs/219-buffer-asset-entries/data-model.md
+++ b/specs/219-buffer-asset-entries/data-model.md
@@ -1,0 +1,122 @@
+# Data Model: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Feature**: 219 — Buffer Scene-Thumbnail Asset Entries Until Save
+**Date**: 2026-04-25
+
+This feature does **not** introduce or modify any LinkML schema. The model below describes only the in-memory data structures added to the VS Code extension. All on-disk shapes (`item.json` STAC Item, `Scene` Feature, `Storyboard` Feature) are unchanged.
+
+---
+
+## Entities
+
+### `PendingAssetEntry` (in-memory)
+
+A single STAC asset entry awaiting persistence into `item.json.assets`. Fields mirror the on-disk shape exactly so save-time merge is a verbatim copy.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | `string` | Yes | Asset key, e.g. `scene-thumbnail-{ulid}` or `scene-thumbnail-{ulid}-sm`. Used as the unique identifier within a plot's buffer. |
+| `href` | `string` | Yes | Relative href from the STAC item directory, e.g. `./scene-thumbnails/scene-{ulid}.png`. |
+| `type` | `string` | Yes | MIME type. Always `image/png` for this feature. |
+| `title` | `string` | Yes | Human-readable label (e.g. `Scene thumbnail`, `Scene thumbnail (small)`). |
+| `roles` | `readonly string[]` | Yes | STAC roles. Always `['thumbnail']` for this feature. |
+
+**Validation**:
+- `key` MUST match `^scene-thumbnail-[0-9A-HJKMNP-TV-Z]{26}(-sm)?$` (ULID + optional `-sm` suffix).
+- `href` MUST start with `./scene-thumbnails/` and end with `.png`.
+- `type` MUST equal `image/png`.
+
+**Lifecycle**:
+- Created on capture (immediately after the PNG file is written atomically).
+- Held in the per-plot buffer.
+- Either committed into `item.json` at save or dropped on plot close / discard.
+- Filtered out at save time if no Scene Feature in the in-memory plot has `thumbnail_asset_ref` matching its `key` (or `key + '-sm'`).
+
+---
+
+### `SceneThumbnailBuffer` (singleton in-memory service)
+
+The container for pending entries. One per extension activation, holding entries for any number of currently-open plots.
+
+**Internal state** (conceptual — not part of the public API):
+
+```text
+buffers: Map<stacItemPath, Map<assetKey, PendingAssetEntry>>
+```
+
+The outer key (`stacItemPath`) is the absolute filesystem path of the STAC item directory. The inner key (`assetKey`) is `PendingAssetEntry.key`.
+
+**Public surface** (full interface contract in [contracts/scene-thumbnail-buffer.md](./contracts/scene-thumbnail-buffer.md)):
+
+- `enqueue(stacItemPath, entries)` — adds one or more entries to the per-plot buffer. Idempotent on `assetKey`.
+- `pending(stacItemPath)` — returns a snapshot of the current buffer for one plot.
+- `clear(stacItemPath)` — drops the buffer for one plot. Called on save success and on plot close.
+- `clearAll()` — drops every buffer. Used in test cleanup and on extension deactivation.
+- `flush(stacItemPath, livePredicate)` — returns the entries that should be merged into `item.json` (those whose `key` passes `livePredicate`), and drops them from the buffer; non-live entries are also dropped silently. Mutating; called by `saveSession`.
+
+**Invariants**:
+- An entry's presence in the buffer means: "the PNG is already on disk; the `item.json` registration is pending."
+- The buffer is the **only** in-memory record of pending registrations. Once flushed (or discarded), there is no shadow state.
+- Per-plot isolation: a `clear(plotA)` MUST NOT affect `plotB`.
+- The buffer does **not** retain PNG bytes. It retains only the asset-entry metadata.
+
+---
+
+### Scene Feature (unchanged)
+
+For reference only — this feature does not modify `Scene.properties.thumbnail_asset_ref`. The buffer's filter-on-flush logic uses this property at save time:
+
+```text
+livePredicate(assetKey) :=
+  any feature in current in-memory plot has
+    feature.properties.kind == 'scene' AND
+    (feature.properties.thumbnail_asset_ref == assetKey OR
+     feature.properties.thumbnail_asset_ref + '-sm' == assetKey)
+```
+
+Identical predicate to the one in `gcOrphanAssets` (`sceneThumbnailService.ts:373-380`), reused at the new flush site.
+
+---
+
+### `item.json` (on-disk STAC Item, unchanged)
+
+Stays exactly as today: a JSON object with an `assets: Record<string, AssetEntry>` field. Saved by atomic write (tmp + fsync + rename) — that helper is preserved verbatim. The only change is *who* mutates this record and *when*: post-Phase-1, the capture path is no longer a writer; the save path is the sole writer for all asset-entry mutations (plot-level `thumbnail` / `thumbnail-sm` PLUS buffered scene-thumbnail entries).
+
+---
+
+## State Transitions
+
+```text
+[no buffer entry]   ──capture──▶  [buffer entry; PNG on disk; item.json untouched]
+                                                │
+                                                ├──save success──▶  [no buffer entry; PNG on disk; item.json contains entry]
+                                                │
+                                                ├──save fail──▶     [buffer entry preserved; PNG on disk; item.json untouched]
+                                                │                                  │
+                                                │                                  └──save retry──▶  [no buffer entry; entry committed]
+                                                │
+                                                ├──scene undone / deleted──▶
+                                                │      [buffer entry still present (filter-on-flush); PNG on disk]
+                                                │      │
+                                                │      └──save──▶  [entry dropped silently; PNG orphan; item.json unchanged]
+                                                │                                       │
+                                                │                                       └──gcOrphanAssets pass──▶  [PNG removed]
+                                                │
+                                                └──plot close (no save)──▶  [buffer cleared; PNG orphan]
+                                                                                           │
+                                                                                           └──gcOrphanAssets pass──▶  [PNG removed]
+```
+
+The two terminal states for a captured-then-discarded Scene — orphan PNG awaiting GC — are **identical to today's behaviour** for partial-failure orphans. No new GC class is required (FR-009).
+
+---
+
+## Multi-plot scope
+
+Each open plot has its own buffer entry under `buffers[stacItemPath]`. Operations on plot A do not touch plot B's buffer. The `saveSession` command flushes only the active plot's buffer (FR-011).
+
+---
+
+## Lifetime / persistence
+
+The buffer is **in-memory only**. A crash, hard close, or extension restart discards it. Spec assumption: this matches the existing behaviour of unsaved features (`features.geojson` is not flushed until save either). PNG files captured before a crash become orphans and are reclaimed on next plot open / close by the existing `gcOrphanAssets` pass.

--- a/specs/219-buffer-asset-entries/evidence/opening-context.md
+++ b/specs/219-buffer-asset-entries/evidence/opening-context.md
@@ -1,0 +1,16 @@
+## What We're Building
+
+When an analyst captures a few Scenes into a Storyboard while exploring a plot, then closes without saving, the persisted plot file should look exactly like it did before they opened it. Until this change, it didn't. Every capture rewrote `item.json` on disk to register a `scene-thumbnail-{id}` asset entry, even though the rest of the editor only flushes plot mutations at save time. "Discard changes" silently left a trail of entries pointing at PNGs the user never committed to.
+
+This work moves Scene-thumbnail asset-entry registration off the capture path and into the save path, where every other on-disk plot mutation already lives. The change is invisible mid-session — captured Scenes still appear immediately in the Storyboard panel — but the contract underneath is now consistent: `item.json` is a save-time artefact, full stop. Discard means discard, and the in-memory-session-vs-persisted-plot boundary holds the way an engineer reading the code would expect.
+
+## How It Fits
+
+A follow-up to #216 (Storyboarding Capture), this tightens the seam between `sceneThumbnailService.writeSceneThumbnail` and the save-time `item.json` rewrite that already lives in `saveSession.ts` for plot-level thumbnails. The new buffer flushes through that same rewrite. Discarded captures leave orphan PNGs on disk, which the existing `gcOrphanAssets` pass continues to reclaim — no new GC mechanism, no new orphan class.
+
+## Key Decisions
+
+- **PNGs stay eager; only the `item.json` registration is deferred.** The Storyboard panel renders thumbnails by file-path convention — it never reads `item.json.assets`. Eager PNG writes already satisfy "the user sees their captured Scene immediately" without teaching any consumer about buffering. Deferring PNG bytes too would have meant base64 in memory for every capture and a buffer-aware resolver in the panel, for no consumer-visible gain.
+- **Filter-on-flush, not eager remove-on-undo.** At save time we commit only buffered entries whose Scene still exists in the in-memory plot. The storyboardEdit undo path, delete-scene path, and Zustand undo stack stay ignorant of the buffer. It's the same liveness predicate `gcOrphanAssets` already uses, applied pre-save.
+- **The save-time merge piggybacks on the existing `item.json` rewrite.** `saveSession.ts` already reads `item.json`, sets the plot-level `thumbnail` keys, and writes atomically. Folding the buffer-flush into that same step keeps save to one `item.json` write — the headline metric drops from N (one per capture) to 1.
+- **Buffer is in-memory only.** A crash discards captures and the PNGs become orphans the existing GC handles, matching how `features.geojson` already behaves on crash — the symmetry this whole change is about.

--- a/specs/219-buffer-asset-entries/plan.md
+++ b/specs/219-buffer-asset-entries/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Branch**: `219-buffer-asset-entries` (cloud-session branch: `claude/speckit-specify-219-r7BCW`) | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/219-buffer-asset-entries/spec.md`
+
+## Summary
+
+Restore the in-memory-session-vs-persisted-plot boundary that #216 currently violates: today every Scene capture rewrites `item.json` to register a `scene-thumbnail-{id}` (and `-sm`) asset entry, even though the rest of the editor flushes plot mutations only at save time. The fix is narrow because Scene thumbnails are rendered by file-path convention (`{stacItemPath}/scene-thumbnails/scene-{id}.png`) — `item.json.assets` is consumed only by the orphan-asset GC pass, not by any rendering surface. So we keep the PNG write eager (consumers keep working with no awareness of buffering) and defer purely the item.json asset-entry merge into a per-plot in-memory buffer that flushes through the existing save-time `item.json` rewrite in `saveSession.ts`.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode), Node 20.x runtime via VS Code extension host
+**Primary Dependencies**: VS Code Extension API (^1.85.0), existing modules — `sceneThumbnailService`, `storyboardEditService`, `sessionManager`, `MapPanel`, `saveSession` command. **No new runtime dependencies.**
+**Storage**: Local filesystem — STAC item directory (`{stacItemPath}/item.json`, `{stacItemPath}/scene-thumbnails/*.png`). In-memory `Map<stacItemPath, Map<assetKey, PendingAssetEntry>>` for the buffer.
+**Testing**: vitest (unit) — `apps/vscode/tests/unit/sceneThumbnailService.test.ts`, `captureScene.test.ts` (migrate); add `sceneThumbnailBuffer.test.ts` and extend `saveSession.test.ts`.
+**Target Platform**: VS Code extension (`apps/vscode/`), runs in extension host on Linux/macOS/Windows.
+**Project Type**: Single project — existing monorepo, change is contained to `apps/vscode/src/{services,commands,extension.ts}`.
+**Performance Goals**: Capture path drops one synchronous `item.json` read + atomic write (~5–10ms saved). Save path adds one merge step over the buffer (negligible — ≤ 100 entries typical, single rewrite).
+**Constraints**: Atomic save-time `item.json` rewrite (existing `writeAtomic` helper preserved). No new orphan-asset class (existing `gcOrphanAssets` continues to be the sole GC mechanism). Multi-plot isolation. Must not regress existing `Captures, Storyboard edits, save flow, GC` tests.
+**Scale/Scope**: Typical session has ≤ 50 captured Scenes per plot, ≤ 5 open plots, single user. Buffer memory footprint bounded by the asset-entry metadata (≈ 200 bytes × N entries) — irrelevant.
+
+## Constitution Check
+
+*Re-evaluated post-Phase-1; result unchanged.*
+
+| Article | Status | Notes |
+|---------|--------|-------|
+| I. Defence-Grade Reliability | PASS | Offline-only by construction; no network. No silent failures — buffer-flush failures surface through the existing save error path. Reproducible. |
+| II. Schema Integrity | N/A | No LinkML schema changes. `Scene.thumbnail_asset_ref` stays an opaque string ref; `item.json` shape unchanged. |
+| III. Data Sovereignty | PASS — net win | Provenance preserved (storyboard activity log untouched). Source preservation is *strengthened*: `item.json` is now untouched until save, matching how `features.geojson` is treated. Data stays local. |
+| IV. Architectural Boundaries | PASS — net win | Restores the boundary this feature exists to fix. Service still returns data only (asset key); no UI coupling. Frontends still don't persist directly. |
+| V. Extensibility | N/A | Internal refactor; no extension surface change. |
+| VI. Testing | PASS | Buffer service gets its own unit suite; existing capture/save/GC suites migrated, not weakened. |
+| VII. Test-Driven AI Collaboration | PASS | Spec acceptance scenarios are executable; quickstart spells out the verification recipe. |
+| VIII. Documentation | PASS | This plan, spec, research, data-model, contracts, quickstart. ADR-worthy paragraph captured below in §"Decisions of Note". |
+| IX. Dependencies | PASS | Zero new dependencies. |
+| X. Security | N/A | No new attack surface. |
+| XI. Internationalisation | N/A | No user-facing strings. |
+| XII. Community Engagement | N/A | Internal architectural cleanup. |
+| XIII. Contribution Standards | PASS | Atomic commits planned per task; PR review required. |
+| XIV. Pre-Release Freedom | PASS | Pre-v4.0.0 — internal contract changes are permitted. |
+| XV. Strict Type Safety | PASS | All new code typed; no `any`. The buffer entry type is a narrow concrete interface. |
+
+**Gate result**: PASS. No complexity violations to track.
+
+### Decisions of Note (ADR-flavour, captured here rather than a separate doc)
+
+1. **PNGs stay eager; only `item.json` registration is deferred.** Justified by the consumer model — the Storyboard panel resolves thumbnails by path convention and never consults `item.json.assets`. Eager PNG writes therefore have no consumer-visible cost, and they keep the panel rendering immediately on capture without any buffer-aware code path. Discarded captures become orphan PNGs and are reclaimed by the existing `gcOrphanAssets` pass — the same mechanism that already handles partial-failure orphans today.
+2. **Save-time merge piggybacks on the existing `item.json` rewrite in `saveSession.ts`.** Today the save path already reads `item.json`, sets the plot-level `thumbnail` / `thumbnail-sm` keys, and rewrites atomically. Folding the buffer-flush into that same rewrite keeps the save path to a single `item.json` write per save (preserving SC-002).
+3. **Buffer flush filters by live `thumbnail_asset_ref` references.** At save time we only commit buffered entries whose Scene still exists in the in-memory plot. This makes undo/scene-delete handling implicit — no plumbing required into the storyboardEdit undo path. (Effectively: `gcOrphanAssets`-style logic, applied to the buffer rather than to `item.json`.)
+4. **Buffer keyed by `stacItemPath`, owned by a singleton service.** Matches the existing `sceneThumbnailService` API (which already takes `stacItemPath`) and avoids coupling to `documentUri` parsing. The singleton lifecycle is the extension activation lifetime; per-plot entries are cleared on plot close and on save success.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/219-buffer-asset-entries/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── scene-thumbnail-buffer.md  # Phase 1 output — buffer service & refactored sceneThumbnailService API
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already filled in /speckit.specify)
+└── evidence/
+    └── opening-context.md  # Phase 2 output — cached opener for the eventual feature post
+```
+
+### Source Code (repository root)
+
+```text
+apps/vscode/
+├── src/
+│   ├── services/
+│   │   ├── sceneThumbnailService.ts           # MODIFIED — split write into PNG-only + return entry descriptors
+│   │   ├── sceneThumbnailBuffer.ts            # NEW — per-plot in-memory buffer of pending asset entries
+│   │   └── sceneThumbnailError.ts             # UNCHANGED — existing error taxonomy preserved
+│   ├── commands/
+│   │   ├── captureScene.ts                    # MODIFIED — captures enqueue into buffer, do not rewrite item.json
+│   │   └── saveSession.ts                     # MODIFIED — flush buffer through the existing item.json rewrite
+│   └── extension.ts                           # MODIFIED — instantiate buffer singleton, wire into captureThumbnail port and saveSession factory
+└── tests/
+    └── unit/
+        ├── sceneThumbnailBuffer.test.ts       # NEW — buffer add/remove/flush/clear semantics
+        ├── sceneThumbnailService.test.ts      # MIGRATED — assertions move from "item.json rewritten" to "PNGs written; entries returned"
+        ├── captureScene.test.ts               # MIGRATED — assert capture enqueues into buffer, item.json untouched
+        └── saveSession.test.ts                # EXTENDED — assert buffer flushes into item.json on save; preserved on save failure
+```
+
+**Structure Decision**: Single project (existing monorepo). All changes live inside `apps/vscode/`. No shared package, schema, or service surface is touched. The new buffer service is a peer of `sceneThumbnailService` rather than a method on it, because (a) it has independent lifecycle (singleton, state), (b) its tests benefit from being able to construct it without filesystem deps, and (c) it is consumed by both the capture path and the save path — co-locating with either side would force the other to import across an unnatural seam.
+
+## Media Components
+
+None — backend/infrastructure feature. No new visual components, no Storybook stories, no user-facing UI. The Storyboard panel and any other thumbnail consumer continue to render via the existing path-based resolver, with zero awareness of the buffering change.
+
+## Storybook E2E Testing
+
+None — no interactive UI components.
+
+## Web-Shell E2E Testing
+
+None — no extension workflow change is observable to the user. The behavioural change is bounded by the persistence boundary (when does `item.json` get written), which is verified at the unit level. Existing capture/save end-to-end coverage already exercises the user-visible flow; those tests will be updated in-place where they make on-disk assertions about `item.json`.
+
+## Complexity Tracking
+
+No constitutional violations. No complexity to justify.

--- a/specs/219-buffer-asset-entries/quickstart.md
+++ b/specs/219-buffer-asset-entries/quickstart.md
@@ -1,0 +1,164 @@
+# Quickstart: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Feature**: 219 — Buffer Scene-Thumbnail Asset Entries Until Save
+
+This quickstart walks a reviewer through verifying the feature locally. Because the change is internal (no UI surface), verification is via unit tests + a single end-to-end manual check that confirms the visible behaviour: discarding captured Scenes leaves `item.json` byte-identical.
+
+---
+
+## Prerequisites
+
+```sh
+# From repo root
+pnpm install         # if you haven't already
+uv sync              # ditto
+```
+
+You should be on the feature branch:
+
+```sh
+git status     # → 'On branch 219-buffer-asset-entries' (or 'claude/speckit-specify-219-r7BCW' in cloud sessions)
+```
+
+---
+
+## 1. Run the new and migrated unit tests
+
+```sh
+# Buffer service contract
+pnpm --filter @debrief/vscode test sceneThumbnailBuffer
+
+# Refactored thumbnail service — assertions migrated from "item.json updated" to
+# "PNGs written, item.json untouched, pending entries returned"
+pnpm --filter @debrief/vscode test sceneThumbnailService
+
+# Capture command — assertions migrated to "PNGs on disk, buffer enqueued,
+# item.json byte-identical to pre-capture"
+pnpm --filter @debrief/vscode test captureScene
+
+# Save command — extended to assert buffer flushes into item.json on save success,
+# and is preserved on save failure
+pnpm --filter @debrief/vscode test saveSession
+```
+
+All four MUST pass.
+
+---
+
+## 2. Run the full extension test suite
+
+```sh
+pnpm --filter @debrief/vscode test
+```
+
+No regression in storyboard-edit, capture, save, or GC suites.
+
+---
+
+## 3. Run the project-wide CI bundle (matches the `task verify` gate)
+
+```sh
+task verify
+# or equivalently:
+uv run ruff check . && pnpm lint
+uv run pyright && pnpm -r typecheck
+uv run pytest && pnpm --filter '!@debrief/web-shell' test
+cd apps/web-shell && node run-playwright.mjs && cd ../..
+```
+
+This is the same set of checks CI runs. All MUST pass before pushing.
+
+---
+
+## 4. Manual end-to-end verification (the headline behaviour change)
+
+This is the visible payoff of the feature — the discard-leaves-no-trace acceptance scenario from spec User Story 1.
+
+### Setup
+
+1. Open a plot in the VS Code extension (use any sample plot from `preview/workspace/samples/local-store/`).
+2. Note the plot's STAC item directory — call it `$ITEM_DIR`. Locate `$ITEM_DIR/item.json`.
+3. Take a snapshot of the asset keys today:
+   ```sh
+   jq -S '.assets | keys' "$ITEM_DIR/item.json" > /tmp/before.json
+   ```
+
+### Capture-then-discard
+
+4. Capture three Scenes (any timestamps — use the Storyboard panel's capture button or the `Debrief: Capture Scene` command three times).
+5. Verify each Scene's thumbnail renders in the Storyboard panel. **All three thumbnails MUST be visible** (this confirms FR-004 — the Storyboard panel resolves PNGs by path, no buffer-awareness needed).
+6. While the session is dirty, snapshot `item.json` again:
+   ```sh
+   jq -S '.assets | keys' "$ITEM_DIR/item.json" > /tmp/after-capture.json
+   diff /tmp/before.json /tmp/after-capture.json
+   ```
+   **Expected**: `diff` exits with status 0 — `item.json.assets` keys are identical pre-capture and post-capture. *(Today, you would see three new `scene-thumbnail-*` pairs added.)*
+7. Close the plot **without** saving. Confirm the discard prompt appears; click "Discard Changes".
+8. Snapshot `item.json` once more:
+   ```sh
+   jq -S '.assets | keys' "$ITEM_DIR/item.json" > /tmp/after-discard.json
+   diff /tmp/before.json /tmp/after-discard.json
+   ```
+   **Expected**: `diff` exits with status 0 — `item.json` is byte-identical to its pre-session state. **This is the architectural fix in action.**
+
+### Capture-then-save
+
+9. Reopen the same plot. Capture two Scenes. Save the session (Ctrl+S / `Debrief: Save Session`).
+10. Snapshot `item.json`:
+    ```sh
+    jq -S '.assets | keys' "$ITEM_DIR/item.json" > /tmp/after-save.json
+    diff /tmp/before.json /tmp/after-save.json
+    ```
+    **Expected**: four new keys appear (`scene-thumbnail-{id1}`, `scene-thumbnail-{id1}-sm`, `scene-thumbnail-{id2}`, `scene-thumbnail-{id2}-sm`). All pre-existing keys preserved.
+
+### Capture-then-undo-then-save
+
+11. Reopen the plot. Capture one Scene, then undo (Ctrl+Z) until the Scene is gone. Save the session.
+12. Snapshot `item.json`:
+    ```sh
+    jq -S '.assets | keys' "$ITEM_DIR/item.json" > /tmp/after-undo-save.json
+    diff /tmp/after-save.json /tmp/after-undo-save.json
+    ```
+    **Expected**: `diff` exits with status 0 — no new asset keys (the captured-then-undone Scene's buffered entries were filtered out at flush; PNGs on disk are orphans awaiting next GC pass).
+
+### Reset for next reviewer
+
+13. Either revert your sample-data changes (`git checkout preview/workspace/samples/`) or run the standard sample-data regenerator to restore the catalogue.
+
+---
+
+## 5. What to look for in the diff
+
+When reviewing `apps/vscode/src/services/sceneThumbnailService.ts`:
+- `writeSceneThumbnail` no longer reads `item.json` (no `readItemJson` call inside the function body).
+- `writeSceneThumbnail` no longer writes `item.json` (no atomic rewrite of `itemJsonPath`).
+- The function returns `pendingEntries` describing the two asset entries the buffer will hold.
+- Error taxonomy narrowed: `item-json-unreadable` and `item-json-malformed` no longer thrown by `writeSceneThumbnail` (still produced by `gcOrphanAssets` and `deleteSceneThumbnail`).
+
+When reviewing `apps/vscode/src/services/sceneThumbnailBuffer.ts` (NEW):
+- Concrete `class SceneThumbnailBuffer` with private `Map<string, Map<string, PendingAssetEntry>>` state.
+- Public methods match the contract in `contracts/scene-thumbnail-buffer.md` §3.
+- Zero filesystem imports — purely a metadata buffer.
+
+When reviewing `apps/vscode/src/commands/saveSession.ts`:
+- `storeThumbnails` accepts a fifth parameter `pendingSceneEntries`.
+- The save command call-site reads `buffer.peekLive(stacItemPath, livePredicate)` before invoking `storeThumbnails`, then calls `buffer.commit(...)` on success.
+- A failed save path leaves `buffer.commit(...)` uncalled.
+
+When reviewing `apps/vscode/src/extension.ts`:
+- A single `SceneThumbnailBuffer` instance is constructed at activation.
+- It is passed through to `createSaveSessionCommand` and to the `captureThumbnail` port.
+- A `buffer.clear(stacItemPath)` call appears alongside the existing `gcOrphanAssets` plot-close hook.
+
+---
+
+## 6. Smoke-test the success criteria
+
+| SC | Verification |
+|----|--------------|
+| SC-001 (discard leaves item.json byte-identical) | Step 8 above — `diff /tmp/before.json /tmp/after-discard.json` empty. |
+| SC-002 (item.json rewrites per save = 1) | `git grep -n 'JSON.stringify(.*nextItem' apps/vscode/src/` should show only one save-time write site for asset entries (in `saveSession.ts`); no per-capture rewrite remains. |
+| SC-003 (thumbnails render uniformly for buffered + saved) | Step 5 above — three buffered thumbnails visible in Storyboard panel. |
+| SC-004 (no new orphan-asset class) | Existing `gcOrphanAssets` test suite still passes; no new GC code added. |
+| SC-005 (existing tests pass without weakening) | `pnpm --filter @debrief/vscode test` green. |
+| SC-006 (buffer survives save failure) | Test in `saveSession.test.ts` — inject failure on item.json write, assert buffer state unchanged, retry succeeds. |

--- a/specs/219-buffer-asset-entries/research.md
+++ b/specs/219-buffer-asset-entries/research.md
@@ -1,0 +1,111 @@
+# Research: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Feature**: 219 — Buffer Scene-Thumbnail Asset Entries Until Save
+**Date**: 2026-04-25
+**Status**: Phase 0 complete — no `[NEEDS CLARIFICATION]` markers carried over from spec.
+
+This document records the small set of design decisions taken before any code was written. Each entry follows the standard Decision / Rationale / Alternatives shape.
+
+---
+
+## R-1. Where the buffer lives
+
+**Decision**: A new singleton service `SceneThumbnailBuffer` colocated with the existing `sceneThumbnailService` in `apps/vscode/src/services/sceneThumbnailBuffer.ts`. Instantiated once in `extension.ts` and injected into both the capture path (via the `captureThumbnail` port already wired into `StoryboardEditService`) and the save path (via the `createSaveSessionCommand` factory).
+
+**Rationale**:
+- The buffer has its own lifecycle (per-extension-activation) and its own state (per-plot pending entries). Co-locating it with `sceneThumbnailService` would either force that module to become stateful (regression — it is currently a pure functional façade) or split its API across instance/static surfaces (regression — internal cognitive cost).
+- The buffer is consumed by two unrelated callers — capture and save. A peer service serves both without creating an awkward "import sceneThumbnailService from saveSession" coupling.
+- Singleton state is acceptable here because the extension host is a single-process / single-window context. The same pattern is used elsewhere in the extension (e.g. `ResultsPanelService`, `StoryboardEditService`).
+
+**Alternatives considered**:
+- **Attach to per-plot session state (`SessionStoreWithUndo`)**. Rejected — would couple session-state, which is generic and reused by other surfaces, to an asset-entry concern that only the VS Code extension cares about. Spec FR-008 (discard drops the buffer) and FR-011 (per-plot isolation) are easy to satisfy without dragging session-state into it.
+- **Stateful method on `sceneThumbnailService`**. Rejected — the service is a deliberately stateless functional façade and the surrounding tests rely on that. Adding state would force a constructor / DI rework everywhere it is currently called.
+- **Inline state in `MapPanel`**. Rejected — the buffer is plot-scoped, not panel-scoped. Multi-plot sessions need independent buffers; tying to `MapPanel` would require us to invent a way for the save path to find the right `MapPanel` instance from the save command.
+
+---
+
+## R-2. What the buffer key is
+
+**Decision**: Buffer entries are keyed by `stacItemPath` (outer map) and `assetKey` (inner map). `stacItemPath` is the absolute path of the STAC item directory — exactly the value the existing `sceneThumbnailService.writeSceneThumbnail` already accepts.
+
+**Rationale**:
+- `stacItemPath` is the canonical handle the capture path already passes to the thumbnail service. Reusing it keeps the buffer API symmetrical with the existing service surface.
+- The save path can derive the same `stacItemPath` from `parseStacUri(plotUri)` + the store path resolver — both already available in `saveSession.ts`. No new lookup machinery required.
+- `assetKey` (inner key) — `scene-thumbnail-{id}` and `scene-thumbnail-{id}-sm` — gives the buffer a natural dedup unit and trivial collision-free insert.
+
+**Alternatives considered**:
+- **Key by `documentUri`**. Rejected — `documentUri` is a `stac://store/catalog/item.json` URI in the editor. Going from a URI to a filesystem path requires `parseStacUri` + the store-path lookup, which only exists where it's already needed (save path). Capture path has `stacItemPath` directly. Choosing `stacItemPath` minimises coordination cost.
+- **Key by Scene ID**. Rejected — a Scene produces *two* asset entries (large + small). Keying by Scene ID forces the buffer to wrap pairs into a record, which is just a stylistic choice that doesn't simplify add/remove logic.
+
+---
+
+## R-3. How the buffer handles undo / scene-delete
+
+**Decision**: The buffer is treated as **append-on-capture, filter-on-flush**. At save time we only commit a buffered entry if some Scene Feature in the current in-memory plot still has `thumbnail_asset_ref` matching that entry's `assetKey`. Discarded entries are dropped silently; the corresponding PNG remains on disk and is reclaimed by the existing `gcOrphanAssets` pass on next plot close.
+
+**Rationale**:
+- Avoids plumbing buffer-awareness into the storyboardEdit undo / delete-scene paths (which today are concerned only with the in-memory plot, not with on-disk assets).
+- Matches the existing `gcOrphanAssets` model — the same liveness predicate (`feature.properties.thumbnail_asset_ref === assetKey || === assetKey + '-sm'`) is reused, just applied pre-save against the buffer rather than post-save against `item.json.assets`.
+- Satisfies FR-010 ("system MUST remove its corresponding entry from the buffer so save does not register an orphan asset") via filter-on-flush: a buffered entry whose Scene was undone is silently skipped.
+
+**Alternatives considered**:
+- **Explicit `buffer.remove(sceneId)` calls from undo / delete-scene**. Rejected — would require touching `storyboardEditService.deleteScene`, the undo machinery (Zustand undo stack), and the `update-to-current` and `duplicate` paths. Filter-on-flush keeps the buffer one-way (write-only on capture, drained on save) and ignorant of all those code paths.
+- **Eager remove via a lifecycle event on plot mutation**. Rejected — would couple the buffer to the in-memory plot mutation cadence (every `mapPanel.setFeatures`). Filter-on-flush is observed once per save, regardless of how many intermediate edits happened.
+
+---
+
+## R-4. Where the save-time merge happens
+
+**Decision**: The buffer flushes through the existing `storeThumbnails(...)` helper in `apps/vscode/src/commands/saveSession.ts`, augmented to also accept the buffer's pending entries and merge them in the same `item.json` rewrite that already sets the plot-level `thumbnail` / `thumbnail-sm` assets.
+
+**Rationale**:
+- `storeThumbnails` already does the precise pattern we need: read `item.json`, mutate `assets`, write atomically. Adding the buffer's entries to that mutate step means save commits exactly one `item.json` rewrite — directly satisfies SC-002 ("rewrites drop from N to 1").
+- Save success / failure semantics fall out for free: the existing function already writes once at the end; if we clear the buffer only after the write returns successfully, FR-006 (clear on success) and FR-007 (preserve on failure) are satisfied without new control flow.
+- Avoids introducing a separate "flush buffer" step that could race with or duplicate the plot-thumbnail rewrite.
+
+**Alternatives considered**:
+- **Separate buffer-flush phase before/after `storeThumbnails`**. Rejected — would double the `item.json` write count per save and risk inconsistent state between the two writes.
+- **Inline into `sceneThumbnailService` as a new "commit" function**. Rejected — would split the save-path orchestration across two files. Saved-here and discarded-here logic is easier to reason about as a single helper in `saveSession.ts`.
+
+---
+
+## R-5. PNG write timing — eager or also deferred?
+
+**Decision**: PNG writes stay **eager**, exactly as today. Only the `item.json` asset-entry registration is deferred. PNGs that are captured-then-discarded become orphans and are reclaimed by the existing `gcOrphanAssets` pass.
+
+**Rationale**:
+- The Storyboard panel renders Scene thumbnails by file-path convention: `webview.asWebviewUri(file://{stacItemPath}/scene-thumbnails/scene-{id}.png)`. The renderer never reads `item.json.assets`. So eager PNG writes are sufficient to satisfy FR-004 ("expose buffered entries to in-process consumers") — the consumer already sees them by virtue of the file existing on disk.
+- `stacService` only consumes the plot-level `thumbnail` / `thumbnail-sm` keys (not `scene-thumbnail-*`). So scene-thumbnail asset entries in `item.json` are exclusively a declarative record consumed by `gcOrphanAssets`.
+- Deferring the PNG write would require a memory-resident buffer of base64 PNG bytes for every captured Scene (50 captures × ~50 KB/large + ~10 KB/small ≈ 3 MB). Manageable, but unnecessary.
+- Discarded captures becoming orphan PNGs is **already a tolerated state** in the codebase — `sceneThumbnailService.writeSceneThumbnail` documents that on partial-failure paths "any already-renamed PNGs are orphaned (harmless — the Scene is never created when this service throws, and orphan PNGs have no item.json asset entry pointing at them)" (sceneThumbnailService.ts:18-20). The existing `gcOrphanAssets` pass handles them.
+
+**Alternatives considered**:
+- **Defer PNG writes too (full in-memory capture buffer)**. Rejected on the trade-off above. The marginal cleanness gain — no orphan PNGs from discarded captures — is outweighed by (a) the new memory residency of base64 bytes, (b) the consumer-side complexity (Storyboard panel would need a buffer-aware resolver), (c) the brand-new failure mode of "PNG write fails at save time, after the user thought their captures were committed".
+
+---
+
+## R-6. Test migration strategy
+
+**Decision**: Existing tests in `sceneThumbnailService.test.ts` and `captureScene.test.ts` that assert "after capture, `item.json.assets` contains the new keys" are migrated to the new model:
+
+| Today | After |
+|-------|-------|
+| `writeSceneThumbnail(...)` → assert `item.json.assets` has the new keys | `writeSceneThumbnail(...)` → assert PNGs on disk and **not** in `item.json.assets`; assert buffer holds the pending entry |
+| Capture command → assert `item.json.assets` has scene entries post-capture | Capture command → assert PNGs on disk; assert buffer holds the entries; assert `item.json` byte-identical to pre-capture |
+
+A new `sceneThumbnailBuffer.test.ts` covers the buffer's own contract (add / list pending / clear / per-plot isolation / filter-by-live-refs).
+
+`saveSession.test.ts` is extended to assert (a) buffer entries flush into `item.json` on save, (b) buffer cleared on save success, (c) buffer preserved on save failure.
+
+**Rationale**:
+- Spec FR-013 explicitly mandates that existing tests pass without weakening their assertions; tests that asserted the old contract are migrated to assert the new contract verbatim.
+- Per Constitution Article VI, no service code is merged without tests — the buffer service gets its own unit suite from day one.
+
+**Alternatives considered**:
+- **Leave old `writeSceneThumbnail` alongside a new `writeSceneThumbnailDeferred`**. Rejected — duplicate code paths multiply test surface and invite drift. A single rewritten function with migrated tests is cleaner.
+
+---
+
+## Summary
+
+No `[NEEDS CLARIFICATION]` markers remain. The five decisions above commit a narrow, low-risk refactor that uses existing infrastructure (eager PNG writes, the save-time `item.json` rewrite, the `gcOrphanAssets` pass) and adds exactly one new module (the buffer service) with a small, testable surface.

--- a/specs/219-buffer-asset-entries/spec.md
+++ b/specs/219-buffer-asset-entries/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Feature Branch**: `219-buffer-asset-entries`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: User description: "Buffer item.json asset-entry updates to save-time — today #216's sceneThumbnailService.writeSceneThumbnail rewrites item.json on every capture (PNG write + asset entry merge + JSON rename-on-tmp). Per-capture cost is sub-10ms so not a perf blocker, but it entangles the in-memory session state vs persisted plot boundary that the rest of the editor maintains cleanly (features.geojson is flushed at save-time only). Shift asset-entry updates to an in-memory buffer, reconcile with item.json at the save path (where other on-disk mutations already live). Architectural cleanness win, not a perf win. (follow-up to #216)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discarding unsaved scene captures leaves the persisted plot untouched (Priority: P1)
+
+A plot author opens an existing plot, captures several Scenes into a new or existing Storyboard while reviewing options, then closes the plot without saving (or selects "discard changes"). After this, the on-disk plot descriptor is bit-for-bit identical to the state before they opened it. The captured Scenes, the active Storyboard's in-memory edits, and any references to them are gone — exactly as a user already expects when they discard a session.
+
+**Why this priority**: This is the architectural defect that justifies the work. Today the editor treats the persisted plot descriptor as partially "live" — captures mutate it irrespective of save state — which contradicts the cleanly-bounded session model used everywhere else (features.geojson is only flushed at save-time). Restoring symmetry is the primary user-visible value.
+
+**Independent Test**: Open a plot whose `item.json` has a known set of `assets` keys. Capture three Scenes. Without saving, close the plot (or discard the session). Reopen the plot and inspect `item.json.assets` — it MUST contain exactly the same keys that were present before any captures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plot with `item.json` containing only the existing `thumbnail` and `thumbnail-sm` asset keys, **When** the user captures two Scenes and then closes the plot without saving, **Then** the on-disk `item.json.assets` is unchanged from the pre-capture state (no `scene-thumbnail-*` keys appear).
+2. **Given** the same starting state, **When** the user captures two Scenes and then saves the session, **Then** the on-disk `item.json.assets` contains the original keys plus exactly four new keys (`scene-thumbnail-{id}` and `scene-thumbnail-{id}-sm` for each captured Scene).
+3. **Given** a session with three captured but unsaved Scenes, **When** the user uses "undo" until all three captures are reverted and then saves, **Then** the on-disk `item.json.assets` is unchanged from the pre-capture state (the buffer reconciles to "no net change").
+
+---
+
+### User Story 2 - Storyboard panel and existing surfaces continue to render thumbnails for unsaved Scenes (Priority: P1)
+
+While the user is mid-session — captures complete but session unsaved — the Storyboard panel, scene preview surfaces, and any other UI that consumes Scene thumbnails MUST continue to display the captured PNGs without regression. The user sees no functional or visual difference from today's behaviour during the unsaved-session window.
+
+**Why this priority**: Without this guarantee the architectural improvement would be a regression. Scene thumbnails are the core artefact of #216's capture flow; if buffering breaks rendering, the change is unshippable.
+
+**Independent Test**: Capture a Scene and observe its thumbnail in the Storyboard panel. Without saving, switch tabs / refresh the panel / open a peek surface that shows scene thumbnails. The captured Scene's thumbnail MUST render in every surface that renders it today.
+
+**Acceptance Scenarios**:
+
+1. **Given** a captured but unsaved Scene, **When** the Storyboard panel renders the Scene list, **Then** the Scene's thumbnail is shown using the same visual fidelity as today.
+2. **Given** a captured but unsaved Scene, **When** another surface (peek panel, summary view, etc.) requests the Scene's thumbnail by its asset reference, **Then** the bytes for that thumbnail are returned successfully.
+3. **Given** a session with a mix of saved Scenes (already in `item.json`) and newly captured unsaved Scenes (in the buffer), **When** any consumer iterates Scenes, **Then** all thumbnails — saved and buffered — render with no visual or functional difference between the two groups.
+
+---
+
+### User Story 3 - Save reconciles all buffered asset changes in a single atomic write (Priority: P1)
+
+When the user saves the session, all buffered asset-entry additions for the active plot are merged into `item.json` in one atomic rewrite. If save succeeds the buffer is cleared. If save fails the buffer is preserved so the user can retry without losing pending Scenes.
+
+**Why this priority**: The whole point of buffering is that save becomes the single point of persistence. The reconciliation must be atomic (no partial updates), and the failure mode must be recoverable.
+
+**Independent Test**: Capture five Scenes, then save. Verify that `item.json.assets` is rewritten exactly once during save and contains all ten new asset keys (large + small per Scene) plus any pre-existing keys. Then induce a save failure (e.g. read-only filesystem) and verify the buffer survives so the next save attempt commits the same set of entries.
+
+**Acceptance Scenarios**:
+
+1. **Given** five captured Scenes pending in the buffer, **When** the user saves successfully, **Then** `item.json` is rewritten exactly once during the save flow, contains all expected new asset keys, and the in-memory buffer is empty afterwards.
+2. **Given** five captured Scenes pending in the buffer, **When** the save fails after a successful capture (e.g. the filesystem rejects the rewrite), **Then** the on-disk `item.json` is unchanged, the in-memory buffer still holds all five pending entries, and a subsequent successful save commits all of them.
+3. **Given** an existing `item.json` with arbitrary non-thumbnail assets (e.g. `data`, custom roles), **When** save reconciles the buffer, **Then** all pre-existing asset entries are preserved unchanged and only the buffered Scene-thumbnail entries are added.
+
+---
+
+### Edge Cases
+
+- **PNG bytes vs asset-entry registration during the unsaved window**: The captured PNG files are written to disk eagerly today (so the Storyboard panel can load them by path). After this change, those files exist on disk before their `item.json` asset entry is written. The system MUST tolerate this transient state: any consumer that needs to display a buffered Scene's thumbnail must be able to resolve the bytes either from the buffer or from a known on-disk path that matches the buffer's pending entry.
+- **Discard leaves orphan PNGs on disk**: When a user discards the session, the PNG files for captured-but-unbuffered Scenes remain on disk without any `item.json` reference. These are reclaimed by the existing orphan-asset garbage collection pass on next plot open or close. The system MUST NOT introduce a new leak class — orphan PNGs from discarded captures must be GC'd via the existing mechanism that already handles this case.
+- **Same Scene captured then deleted within a session**: If the user captures a Scene and then removes it before saving (e.g. via undo or an explicit delete), the buffer entry for that Scene MUST be removed too, so save does not register a Scene that no longer exists in the in-memory plot.
+- **Multi-plot sessions**: If the user has multiple plots open, each plot has its own independent buffer. Saving one plot only flushes that plot's buffer; captures pending in other plots are unaffected.
+- **Crash or hard close mid-session**: If the editor crashes after captures but before save, the on-disk `item.json` is unchanged (matching today's behaviour for features.geojson). Captured PNGs become orphans and are reclaimed on next open by the existing GC.
+- **Re-opening a plot whose `item.json` already contains scene-thumbnail entries from prior saved sessions**: The buffer starts empty. Subsequent captures append to the buffer; save merges only the buffered entries on top of whatever is on disk. Already-saved scene-thumbnail entries are not re-written or duplicated.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST NOT mutate `item.json` on disk during a Scene capture. Capture writes the PNG files but defers all `item.json` asset-entry registration to a later save step.
+- **FR-002**: The system MUST maintain a per-plot in-memory buffer of pending Scene-thumbnail asset entries (additions only — deletions during the unsaved window are realised by removing the corresponding buffer entry, not by recording a removal).
+- **FR-003**: Each pending buffer entry MUST capture exactly the same metadata that would otherwise be written to `item.json` (asset key, href, type, title, roles), so the save-time reconciliation is a faithful merge.
+- **FR-004**: The system MUST expose buffered entries to in-process consumers (Storyboard panel, scene-preview surfaces, any other consumer that resolves a Scene's `thumbnail_asset_ref`) so that thumbnails render uniformly for saved and unsaved Scenes during the same session.
+- **FR-005**: When the user saves the session, the system MUST merge all buffered entries for that plot into `item.json` in a single atomic rewrite, preserving every pre-existing asset entry that is not being replaced.
+- **FR-006**: On a successful save the system MUST clear the per-plot buffer.
+- **FR-007**: On a failed save the system MUST preserve the per-plot buffer so a subsequent save attempt commits the same pending entries.
+- **FR-008**: When the user discards the session (close-without-save, explicit discard, or session reset), the system MUST drop the per-plot buffer without writing to `item.json`.
+- **FR-009**: Captured PNG files written eagerly during the unsaved window that are later discarded MUST be reclaimed by the existing orphan-asset garbage-collection mechanism. This change MUST NOT introduce a new orphan class that the existing GC cannot detect.
+- **FR-010**: When a captured Scene is removed from the plot before save (e.g. via undo, or an explicit Scene delete), the system MUST remove its corresponding entry from the buffer so save does not register an orphan asset.
+- **FR-011**: Each open plot MUST have an independent buffer. A save of one plot MUST NOT alter another plot's buffer or `item.json`.
+- **FR-012**: The system MUST preserve the existing atomicity contract for the save-time reconciliation: a failure during the `item.json` rewrite MUST leave the on-disk `item.json` unchanged (matching the all-or-nothing guarantee already provided by the per-capture rewrite this change replaces).
+- **FR-013**: Existing automated tests for the Scene capture and Storyboard edit flows MUST continue to pass. Where tests assert that `item.json` is rewritten on capture, they MUST be migrated to the new model (capture writes PNG only; save merges buffer into `item.json`).
+
+### Key Entities *(include if feature involves data)*
+
+- **Pending Asset Entry Buffer**: An in-memory, per-plot collection of asset-entry descriptors awaiting persistence. Each entry carries the asset key, href, MIME type, title, and roles. The buffer is keyed by plot identifier (so multi-plot sessions stay isolated) and lives for the lifetime of the unsaved session.
+- **Scene-Thumbnail Asset Entry**: The metadata describing one PNG asset on a STAC Item — the same shape that exists today inside `item.json.assets`. Two entries are produced per captured Scene (large + small).
+- **Persisted Plot Descriptor (`item.json`)**: The on-disk STAC Item document. Becomes a true save-time-only artefact for asset-entry mutations after this change, mirroring how `features.geojson` is already treated.
+- **Orphan PNG**: A captured-then-discarded thumbnail file that exists on disk but has no `item.json` reference. Reclaimed by the existing orphan-asset GC pass.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After this change, a user who captures any number of Scenes and then discards the session leaves `item.json` byte-identical (modulo non-thumbnail edits made elsewhere) to its pre-session state in 100% of cases.
+- **SC-002**: The number of `item.json` rewrites during a single capture-save cycle drops to exactly one, regardless of how many Scenes were captured. Today the count is N (one per capture); after this change it is one (at save).
+- **SC-003**: Storyboard panel and any other thumbnail consumer renders thumbnails for buffered (unsaved) Scenes with zero visual or functional difference from saved Scenes — verified by side-by-side review of a session containing both.
+- **SC-004**: No new orphan-asset class appears in the codebase. The existing orphan-asset GC pass continues to be the single mechanism that reclaims PNGs whose Scene was discarded — verified by running the existing GC test suite against a discard-after-capture scenario.
+- **SC-005**: All existing Scene-capture, Storyboard-edit, and save-flow tests pass without weakening their assertions. Tests that previously asserted per-capture `item.json` mutation are migrated to assert "PNG written on capture, asset entry merged on save" — and the migrated tests pass.
+- **SC-006**: A failed save (e.g. read-only filesystem) preserves the in-memory buffer so a subsequent successful save persists the same set of pending entries — verified by an automated test that injects a save failure and then succeeds on retry.
+
+## Assumptions
+
+- The PNG files for captured Scenes continue to be written to disk eagerly during the capture flow, exactly as they are today. Only the `item.json` asset-entry registration is deferred. This preserves the Storyboard panel's existing path-based render strategy and limits the scope to the boundary problem the backlog item identifies.
+- The existing orphan-asset garbage-collection pass (`gcOrphanAssets`) is sufficient to reclaim PNGs from discarded captures. No new GC mechanism is required.
+- Multi-plot sessions already have per-plot session state isolation; this feature follows the same isolation pattern for the buffer.
+- The save flow already exists as the canonical place where on-disk plot mutations are committed (today it commits `features.geojson`, session-state files, and plot thumbnails). This feature adds Scene-thumbnail asset entries to that same flow.
+- "Save" here means the user-initiated save of the active session/plot — the same trigger that flushes `features.geojson` today. No new user-facing save concept is introduced.
+- The buffer is held in memory only and is not itself persisted across editor restarts. A crash or hard close discards pending captures — a deliberate match for the existing behaviour of unsaved features.

--- a/specs/219-buffer-asset-entries/tasks.md
+++ b/specs/219-buffer-asset-entries/tasks.md
@@ -1,0 +1,288 @@
+---
+description: "Task list for feature 219 — Buffer Scene-Thumbnail Asset Entries Until Save"
+---
+
+# Tasks: Buffer Scene-Thumbnail Asset Entries Until Save
+
+**Input**: Design documents from `/specs/219-buffer-asset-entries/`
+**Prerequisites**: plan.md, spec.md (User Stories 1–3, all P1), research.md, data-model.md, contracts/scene-thumbnail-buffer.md, quickstart.md
+
+**Tests**: Tests are written first for every behaviour change (Constitution Article VII — Test-Driven AI Collaboration). The buffer service is new code and gets unit tests from day one (Article VI). Existing test files for `sceneThumbnailService`, `captureScene`, and the storyboard panel are migrated rather than weakened (FR-013); a new `saveSession.test.ts` is added because none exists today.
+
+**Organization**: Three independent acceptance angles on a single architectural change. US1, US2, and US3 are all P1 — they fall out of the same code change but have distinct, independently verifiable acceptance criteria. The task ordering reflects dependency, not priority: the buffer service blocks everything; US1 (capture-side refactor) makes US2 (panel render proof) and US3 (save-side merge) testable.
+
+---
+
+## Evidence Requirements
+
+> **Purpose**: Capture artifacts that demonstrate the architectural fix. Because this feature has no UI surface, evidence emphasises the *invariant being restored* (`item.json` byte-identity across discard) and the *single-write metric* (per-save `item.json` rewrites drop from N to 1) rather than screenshots.
+
+**Evidence Directory**: `specs/219-buffer-asset-entries/evidence/`
+**Media Directory**: `specs/219-buffer-asset-entries/media/`
+
+### Feature type → Integration / architectural refactor
+
+Per the Quality Rubric in `.specify/templates/tasks-template.md`: this falls into the **Integration** band (end-to-end flow + sequence diagram), supplemented by **Schema Change**-style round-trip proof — except that the round-trip subject is `item.json` byte-identity across capture/discard/save cycles, not a LinkML schema.
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| `evidence/opening-context.md` | Cached opener (3 prose sections) — already written during `/speckit.plan`. | (already captured) |
+| `evidence/test-summary.md` | Vitest results for `sceneThumbnailBuffer`, `sceneThumbnailService` (migrated), `captureScene` (migrated), `saveSession` (new), `storyboardPanelView` (extended). YAML front matter with `feature`, `captured_at`, `git_sha`, `tests_passed`, `tests_failed`, `tests_skipped`, `coverage_pct`. | After all tests pass |
+| `evidence/usage-example.md` | Walkthrough of the three flows from `quickstart.md` §4 (capture-then-discard, capture-then-save, capture-then-undo-then-save) with the actual `jq` diff outputs. | After implementation works on a sample plot |
+| `evidence/itemjson-discard-before-after.md` | Sample `item.json.assets` snippets: pre-session, post-three-captures (still pre-session), post-discard. Proves byte-identity for the headline acceptance scenario (US1). | After US1 implementation lands |
+| `evidence/integration-flow.md` | End-to-end capture→buffer→save→commit sequence with a Mermaid diagram. References the touched files (sceneThumbnailService, sceneThumbnailBuffer, captureScene, saveSession, extension) and the lifecycle hooks (plot close, save failure retry). | After all stories implemented |
+| `media/shipped-post.md` | Feature post combining cached opener + ship-time evidence. | Polish phase |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| `evidence/opening-context.md` | Cached opener (What We're Building, How It Fits, Key Decisions) | During /speckit.plan (already done) |
+| `media/shipped-post.md` | Feature post — first three sections copied verbatim from cached opener; By the Numbers + Lessons Learned + What's Next written from `evidence/test-summary.md` and `evidence/integration-flow.md`. | During Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR in `debrief/debrief-future` including all evidence and the migrated tests. | Final task in Polish phase (T029) |
+| Blog PR | PR in `debrief.github.io` publishing `media/shipped-post.md`. | Triggered by `/speckit.pr` |
+
+> **Why no screenshots / GIFs**: This is a backend / architectural-boundary change. The user-visible payoff (discard leaves `item.json` untouched) is best demonstrated as a `jq` diff, not a screenshot. The Storyboard panel render path is unchanged — capturing screenshots would not differentiate before/after states and would dilute the actual evidence (the byte-identity proof). Per the Quality Rubric, "Integration" features ship with a sequence diagram, not screenshots.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Sanity-check the workspace state. This feature introduces zero new runtime dependencies and zero new tooling — the change is a refactor inside `apps/vscode/src/`.
+
+- [ ] T001 Confirm working tree is on the feature branch and `.specify/.active-feature` resolves to `219-buffer-asset-entries`. Run `git status` and `cat .specify/.active-feature`. No file changes; gate task only.
+- [ ] T002 Confirm no new runtime dependencies are required by reviewing `plan.md` Technical Context against `apps/vscode/package.json`. No file changes; documentation gate.
+
+**Checkpoint**: Workspace ready. No project scaffolding needed — proceed to Foundation.
+
+## Phase 2: Foundation — `SceneThumbnailBuffer` service (Blocking Prerequisites)
+
+**Purpose**: Build the new in-memory buffer that all three user stories depend on. Pure module — no filesystem, no VS Code API. Contract per `contracts/scene-thumbnail-buffer.md` §1.
+
+**⚠️ CRITICAL**: User-story phases (3, 4, 5) cannot begin until the buffer service exists and its tests are green. Foundation work is sequential: tests → implementation → green-bar verification.
+
+### Tests for Foundation
+
+> **NOTE: Write tests FIRST. They MUST fail (or fail to compile) before T004 lands the implementation.** Per Constitution Article VII: tests define "done."
+
+- [ ] T003 [test] Write unit tests for `SceneThumbnailBuffer` covering the full contract surface — `enqueue` (idempotency on key, insertion-order preservation), `pending` (snapshot, never undefined), `peekLive` (filter against a `LivePredicate`, drops non-live entries from the buffer as a side-effect), `commit` (drops listed keys, forgiving of missing keys), `clear` (per-plot, no cross-plot leak), `clearAll`. Include explicit per-plot isolation tests (operations on plot A do not affect plot B's buffer) `apps/vscode/tests/unit/sceneThumbnailBuffer.test.ts`
+
+### Implementation for Foundation
+
+- [ ] T004 Implement `SceneThumbnailBuffer` per contract — concrete `class SceneThumbnailBuffer` with private `Map<string, Map<string, PendingAssetEntry>>` state. Public methods: `enqueue`, `pending`, `peekLive`, `commit`, `clear`, `clearAll`. Zero filesystem imports. All types concrete (no `any`). Export the `PendingAssetEntry` interface and `LivePredicate` type alias `apps/vscode/src/services/sceneThumbnailBuffer.ts`
+- [ ] T005 Run buffer test suite and confirm green: `pnpm --filter @debrief/vscode test sceneThumbnailBuffer`
+
+**Checkpoint**: Buffer service is testable in isolation and fully green. User stories can now begin.
+
+### Parallel Opportunities (Phase 2)
+
+None within this phase — T003 (tests) must precede T004 (implementation), which must precede T005 (verification).
+
+## Phase 3: User Story 1 — Discarding unsaved scene captures leaves the persisted plot untouched (Priority: P1)
+
+**Goal**: Capturing N Scenes and then discarding the session leaves `item.json` byte-identical to its pre-session state. PNGs may exist on disk (orphans, GC'd by the existing `gcOrphanAssets` pass), but the on-disk plot descriptor is unchanged.
+
+**Independent Test**: From `quickstart.md` §4 steps 1–8 — `jq -S '.assets | keys' item.json` produces identical output before opening the plot and after discarding three captured Scenes. Buffer is cleared on plot close.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST. They MUST fail before T009/T010/T011 land.** Tests assert the new contract: capture writes PNGs only; `item.json` is untouched until save; the buffer is cleared on plot close.
+
+- [ ] T006 [P][test][US1] Migrate `sceneThumbnailService.test.ts` — replace assertions of the form "after `writeSceneThumbnail`, `item.json.assets` contains `scene-thumbnail-{id}` and `scene-thumbnail-{id}-sm` keys" with the new contract: (a) PNGs written atomically to `{stacItemPath}/scene-thumbnails/scene-{id}.png` and `-sm.png`, (b) `item.json` byte-identical to its pre-call state, (c) returned `WriteSceneThumbnailResult.pendingEntries` contains exactly two entries with the correct keys / hrefs / type / title / roles. Drop tests for `item-json-unreadable` and `item-json-malformed` errors raised from `writeSceneThumbnail` (those reasons remain valid for `deleteSceneThumbnail` and `gcOrphanAssets`) `apps/vscode/tests/unit/sceneThumbnailService.test.ts`
+- [ ] T007 [P][test][US1] Migrate `captureScene.test.ts` — extend `CaptureCommandDeps` test fixture to inject a fake `SceneThumbnailBuffer` (a small spy implementing `enqueue`); assert that a successful capture (i) writes the two PNGs, (ii) calls `buffer.enqueue(stacItemPath, [largeEntry, smallEntry])` exactly once, (iii) leaves `item.json` byte-identical, (iv) records the `LogService` activity unchanged from today. Update existing failure-path tests (thumbnail capture failed, mapPanel returns empty PNG) to assert `buffer.enqueue` was NOT called `apps/vscode/tests/unit/captureScene.test.ts`
+- [ ] T008 [test][US1] Add a plot-close test asserting that the buffer's `clear(stacItemPath)` is called when the active plot is closed without saving. Test target depends on where the plot-close hook lives — most likely a small dedicated test inside the new `apps/vscode/tests/unit/sceneThumbnailBuffer.test.ts` (a unit test exercising the `clear` API plus a wiring assertion that the extension activates a plot-close handler that calls it). If existing test infrastructure prefers a different location, prefer extending `storyboardEditService.test.ts` where the existing `gcOrphanAssets` plot-close call is already covered `apps/vscode/tests/unit/sceneThumbnailBuffer.test.ts`
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Refactor `writeSceneThumbnail` in `apps/vscode/src/services/sceneThumbnailService.ts` per contract §2: drop the internal `readItemJson` + assets-merge + atomic rewrite of `itemJsonPath`; the function MUST NOT touch `item.json`. Keep the existing PNG write atomicity (tmp + fsync + rename via `writeAtomic`). Extend `WriteSceneThumbnailResult` with `pendingEntries: readonly [PendingAssetEntry, PendingAssetEntry]`. Remove the now-unused `validateStacItemPath` call's reliance on `item.json` existence (still validate that the directory exists, but not that `item.json` is readable — capture should not fail on a malformed item.json that the save path will re-read anyway). Preserve `deleteSceneThumbnail` and `gcOrphanAssets` unchanged `apps/vscode/src/services/sceneThumbnailService.ts`
+- [ ] T010 [US1] Update `apps/vscode/src/commands/captureScene.ts`: add `buffer: SceneThumbnailBuffer` to `CaptureCommandDeps` (alongside the existing `writeSceneThumbnail` injection point); after `await deps.writeSceneThumbnail(...)` returns successfully, call `deps.buffer.enqueue(stacItemPath, result.pendingEntries)` BEFORE the call to `createScene`. Failure modes: if `writeSceneThumbnail` throws, `enqueue` is never called (the existing rejected-with-thumbnail-failed path is preserved unchanged) `apps/vscode/src/commands/captureScene.ts`
+- [ ] T011 [US1] Wire the buffer in `apps/vscode/src/extension.ts`: instantiate a singleton `SceneThumbnailBuffer` at activation; pass it into the `setThumbnailService.captureThumbnail` port implementation (around line 269) — the port impl calls `writeSceneThumbnail` then `buffer.enqueue` and returns `{ assetKey }`; pass the same singleton through to `createSaveSessionCommand` (extension.ts call-site for the save command); add `buffer.clear(stacItemPath)` to the existing plot-close hook alongside `sceneThumbnailGcOrphanAssets`. Use `path.join(store.path, plot.itemPath)` to derive `stacItemPath` consistently with the existing wiring `apps/vscode/src/extension.ts`
+- [ ] T012 [US1] Run US1 test bundle and confirm green: `pnpm --filter @debrief/vscode test sceneThumbnailService captureScene sceneThumbnailBuffer`
+
+**Checkpoint**: US1 acceptance scenario 1 (capture-then-discard leaves item.json byte-identical) is provable via the migrated `sceneThumbnailService.test.ts` and `captureScene.test.ts` plus the plot-close test. The user-visible behaviour change is now testable independently of US2 and US3.
+
+### Parallel Opportunities (Phase 3)
+
+- T006 and T007 touch different test files and can run in parallel.
+- T009, T010, T011 have a strict ordering: T009 (the service refactor) defines the new return type; T010 (the capture command) consumes it; T011 (the extension wiring) wires both T009 and T010 into the runtime. Sequential.
+
+## Phase 4: User Story 2 — Storyboard panel and existing surfaces continue to render thumbnails for unsaved Scenes (Priority: P1)
+
+**Goal**: While the buffer is non-empty (captures pending, session unsaved), the Storyboard panel and any other thumbnail consumer continue to render Scene thumbnails. Zero functional or visual difference from saved Scenes.
+
+**Independent Test**: Capture a Scene; without saving, observe the Scene's thumbnail in the Storyboard panel. The render path resolves the PNG by file convention (`{stacItemPath}/scene-thumbnails/scene-{id}.png`) — no item.json lookup — so eager PNG writes are sufficient. A unit test confirms `resolveThumbnailHref` works against an unsaved buffered Scene.
+
+### Tests for User Story 2
+
+- [ ] T013 [test][US2] Extend `storyboardPanelView.test.ts` with a test asserting that `resolveThumbnailHref` produces a non-empty `webview.asWebviewUri(...)`-style file URI for a Scene whose buffered entries are pending — i.e. no `scene-thumbnail-*` keys exist in `item.json.assets`, but the PNG is on disk at the expected convention path. The test proves the panel never depended on `item.json.assets` for rendering and therefore satisfies FR-004 transitively from the eager-PNG decision in US1 `apps/vscode/tests/unit/storyboardPanelView.test.ts`
+
+### Implementation for User Story 2
+
+> **No code change required.** US2's behaviour is delivered by the design choice in research.md R-5 (PNGs stay eager) plus US1's implementation. This phase is verification-only.
+
+- [ ] T014 [US2] Run storyboard-panel test bundle and confirm green: `pnpm --filter @debrief/vscode test storyboardPanelView storyboardEditService`. The new test from T013 plus all existing storyboard-panel and storyboard-edit tests MUST pass without code changes outside `apps/vscode/tests/unit/`.
+
+**Checkpoint**: US2 acceptance scenarios are provable. Render parity between buffered and saved Scenes is verified.
+
+### Parallel Opportunities (Phase 4)
+
+None — single test, single verification step.
+
+## Phase 5: User Story 3 — Save reconciles all buffered asset changes in a single atomic write (Priority: P1)
+
+**Goal**: On save, every buffered asset entry whose Scene still exists in the in-memory plot is committed into `item.json` in a single atomic rewrite. On success the buffer drains; on failure the buffer is preserved for retry. Filter-on-flush silently drops entries for Scenes that were undone or deleted before save.
+
+**Independent Test**: From `quickstart.md` §4 steps 9–12 — capture two Scenes, save: `item.json.assets` gains exactly four new keys (large + small per Scene). Inject a write failure: buffer survives, retry succeeds. Capture-then-undo-then-save: no new asset keys appear.
+
+### Tests for User Story 3
+
+> **NOTE: Write tests FIRST. They MUST fail before T017/T018/T019 land.** A new `saveSession.test.ts` is created — no existing file to migrate.
+
+- [ ] T015 [P][test][US3] Create `apps/vscode/tests/unit/saveSession.test.ts` with happy-path coverage: (a) capture two Scenes (enqueue four entries — large + small per Scene), then save; assert exactly one `item.json` rewrite happens during save and `item.json.assets` contains the original keys plus four new `scene-thumbnail-*` keys; (b) on save success, `buffer.commit(stacItemPath, committedKeys)` is called with all four keys; (c) `buffer.pending(stacItemPath)` is `[]` after save success `apps/vscode/tests/unit/saveSession.test.ts`
+- [ ] T016 [P][test][US3] Extend `saveSession.test.ts` with failure-mode coverage: (a) inject an `fs.writeFileSync` failure on the `item.json` rewrite; assert the save command surfaces the error to the user, `buffer.commit(...)` is NOT called, and `buffer.pending(stacItemPath)` still contains all four entries; (b) on a subsequent successful retry, all four entries are committed and the buffer drains; (c) filter-on-flush — capture-then-undo (the in-memory plot's Scene has no `thumbnail_asset_ref` matching the buffered key) followed by save: `peekLive` drops the entry, `item.json.assets` gains nothing for that Scene, and `buffer.pending(stacItemPath)` is `[]` (the non-live entry is dropped from the buffer as a side-effect of `peekLive` per contract §3 Final API note) `apps/vscode/tests/unit/saveSession.test.ts`
+
+### Implementation for User Story 3
+
+- [ ] T017 [US3] Extend `storeThumbnails` in `apps/vscode/src/commands/saveSession.ts` per contract §3: add a fifth parameter `pendingSceneEntries: readonly PendingAssetEntry[]`; merge each entry into `itemData.assets` alongside the plot-level `thumbnail` / `thumbnail-sm` keys (existing entries preserved). Single `fs.writeFileSync(itemJsonPath, JSON.stringify(itemData, null, 2))` call — preserve the all-or-nothing guarantee `apps/vscode/src/commands/saveSession.ts`
+- [ ] T018 [US3] Extend `createSaveSessionCommand` factory in `apps/vscode/src/commands/saveSession.ts` to accept `buffer: SceneThumbnailBuffer`. In the save handler, after step 5 (plot thumbnail capture), before step 7 (`storeThumbnails` call): build a `LivePredicate` over the active in-memory features (use `MapPanel.getCurrentFeatures()` and the same closed-form predicate as `gcOrphanAssets`: `assetKey === f.properties.thumbnail_asset_ref || assetKey === f.properties.thumbnail_asset_ref + '-sm'`), call `buffer.peekLive(stacItemPath, livePredicate)`, pass the result into `storeThumbnails`. After `storeThumbnails` returns successfully, call `buffer.commit(stacItemPath, peekedEntries.map(e => e.key))`. On `storeThumbnails` failure, the existing error-message path runs and the buffer is left intact (FR-007) `apps/vscode/src/commands/saveSession.ts`
+- [ ] T019 [US3] Update the call-site in `apps/vscode/src/extension.ts` for `createSaveSessionCommand` to pass the buffer singleton (already wired in T011). Verify the order: buffer is constructed before either the capture port impl or the save command factory is invoked `apps/vscode/src/extension.ts`
+- [ ] T020 [US3] Run US3 test bundle and confirm green: `pnpm --filter @debrief/vscode test saveSession sceneThumbnailBuffer`
+
+**Checkpoint**: All three user stories are independently provable. The headline metric (per-save `item.json` rewrites = 1) is verified by T015. Save-failure recovery is verified by T016. Filter-on-flush undo handling is verified by T016.
+
+### Parallel Opportunities (Phase 5)
+
+- T015 and T016 both write to the new `saveSession.test.ts` file — but each is a distinct `describe` block. They can be authored in parallel ([P]) by two collaborators or two passes, but committed in a single edit cycle to avoid file conflicts.
+- T017 and T018 both modify `apps/vscode/src/commands/saveSession.ts` and MUST be sequential (T017 defines the helper signature T018 calls).
+- T019 (`extension.ts`) is sequential after T018.
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Run the full quality gate, walk the manual end-to-end, capture the evidence artifacts the architecture rubric demands, and ship.
+
+### Cross-cutting verification
+
+- [ ] T021 Run the full extension test suite and confirm no regression in any neighbouring module: `pnpm --filter @debrief/vscode test`
+- [ ] T022 Run the project-wide CI gate (matches what CI runs): `task verify` (or, if `task` is unavailable, run the four-step fallback documented in `CLAUDE.md` §"Before Pushing")
+- [ ] T023 Walk through `quickstart.md` §4 manually against a sample plot from `preview/workspace/samples/local-store/` — record the three `jq` diff outcomes (capture-then-discard empty diff, capture-then-save four new keys, capture-then-undo-then-save empty diff). Attach the raw outputs into the evidence file in T026.
+
+### Evidence Collection
+
+- [ ] T024 Capture test results using the template `.specify/templates/evidence/test-summary-template.md` `specs/219-buffer-asset-entries/evidence/test-summary.md`. YAML front matter MUST include `feature: 219-buffer-asset-entries`, `captured_at`, `git_sha`, `tests_passed`, `tests_failed`, `tests_skipped`, `coverage_pct`. Body MUST list the suites covered (`sceneThumbnailBuffer`, `sceneThumbnailService`, `captureScene`, `saveSession`, `storyboardPanelView`, plus the unaltered storyboard-edit suite) with one-line key-scenarios-verified per suite (e.g. "save preserves buffer on failure", "capture leaves item.json byte-identical").
+- [ ] T025 Create usage demonstration `specs/219-buffer-asset-entries/evidence/usage-example.md`. Walk through the three flows from `quickstart.md` §4 with the concrete `jq` diff outputs and a short narrative for each. This is the user-readable counterpart to the test-summary's metric.
+- [ ] T026 [P] Capture before/after `item.json.assets` snippets `specs/219-buffer-asset-entries/evidence/itemjson-discard-before-after.md`. Three snippets: pre-session (baseline), post-three-captures-pre-discard (still byte-identical to baseline — the headline proof), post-discard (identical to baseline). Use a real sample plot and paste the actual JSON.
+- [ ] T027 [P] Capture the integration flow `specs/219-buffer-asset-entries/evidence/integration-flow.md`. Include a Mermaid `sequenceDiagram` covering: capture → writeSceneThumbnail (PNG only) → buffer.enqueue; save → buffer.peekLive → storeThumbnails (single item.json rewrite) → buffer.commit; plot close → buffer.clear → gcOrphanAssets. Reference the touched files (`sceneThumbnailService.ts`, `sceneThumbnailBuffer.ts`, `captureScene.ts`, `saveSession.ts`, `extension.ts`) with line ranges where relevant.
+
+### Media Content
+
+- [ ] T028 Create feature blog post `specs/219-buffer-asset-entries/media/shipped-post.md`. The Content Specialist (`.claude/agents/media/content.md`) writes this. The first three sections (`## What We're Building`, `## How It Fits`, `## Key Decisions`) MUST be copied verbatim from `specs/219-buffer-asset-entries/evidence/opening-context.md` (cached during `/speckit.plan`). Subsequent sections (`## Screenshots`, `## By the Numbers`, `## Lessons Learned`, `## What's Next`) are written from the evidence captured in T024–T027. Note: the `## Screenshots` section may be omitted or re-purposed for this feature — consider an `item.json` diff or a Mermaid sequence excerpt instead, per the rubric override declared in the Evidence Requirements above. Track: `[credibility]` with optional `momentum` flavour.
+
+### PR Creation
+
+- [ ] T029 Create PR and publish blog: run `/speckit.pr`. This task creates the feature PR in `debrief/debrief-future` (with all evidence attached and the migrated tests committed) AND publishes `media/shipped-post.md` to `debrief.github.io`. **Dependencies**: ALL prior tasks (T001–T028) MUST be complete.
+
+**Checkpoint**: Feature shipped. PR open, blog post live, evidence archived.
+
+### Parallel Opportunities (Phase 6)
+
+- T026 and T027 are independent files and can be authored in parallel ([P]).
+- T024 and T025 must follow T021–T023 (evidence captures the test-suite output and the manual walkthrough), so they are sequential after the verification block.
+- T028 (blog post) depends on T024 and T025 (numbers + walkthrough feed the post body) but can begin once those are done.
+- T029 (PR) is strictly the last task — no parallelism.
+
+## Dependencies
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — sanity-checks only.
+- **Phase 2 (Foundation)**: Depends on Phase 1 (workspace ready). **Blocks every user-story phase.**
+- **Phase 3 (US1)**: Depends on Phase 2 (buffer service exists and is green).
+- **Phase 4 (US2)**: Depends on Phase 3 (the eager-PNG-write decision lands in T009; T013 then verifies the panel renders against buffered-only state).
+- **Phase 5 (US3)**: Depends on Phase 3 (T010/T011 wire the buffer into the capture path; T018/T019 are the save-side counterpart). Could overlap Phase 4 if staffed in parallel — same code change set, but tests live in a different file.
+- **Phase 6 (Polish)**: Depends on Phase 3, 4, and 5 all green.
+
+### Cross-phase critical path
+
+```text
+T001 → T002 → T003 → T004 → T005           (Foundation green)
+                              ↓
+                   T006/T007/T008  →  T009 → T010 → T011 → T012  (US1 green)
+                                                              ↓
+                                                ┌─────────────┴─────────────┐
+                                                ↓                           ↓
+                                         T013 → T014                 T015/T016 → T017 → T018 → T019 → T020
+                                          (US2)                               (US3)
+                                                ↓                           ↓
+                                                └────────────┬──────────────┘
+                                                             ↓
+                                                T021 → T022 → T023        (verification)
+                                                             ↓
+                                            T024 → T025 → T026/T027       (evidence)
+                                                             ↓
+                                                          T028             (blog post)
+                                                             ↓
+                                                          T029             (PR)
+```
+
+### Within-task dependencies of note
+
+- **T009 → T010**: The capture command (T010) depends on the new `WriteSceneThumbnailResult.pendingEntries` shape introduced in T009.
+- **T011 ↔ T019**: Both edit `extension.ts`. Sequence them: T011 first (instantiates the buffer singleton and adds the plot-close hook), T019 second (passes the singleton through to `createSaveSessionCommand`). Or fold both into a single edit cycle if implemented in one PR pass.
+- **T015/T016 → T017/T018**: Tests-first per Constitution Article VII. Tests for the save-side merge are written before the implementation that makes them pass.
+- **T024 ← T021/T022**: The test-summary YAML front matter requires real pass/fail counts and coverage % from the suite runs.
+- **T028 ← T024/T025/T026/T027**: The "By the Numbers" and "Lessons Learned" sections of the blog post draw from these evidence files.
+
+## Implementation Strategy
+
+### Incremental delivery
+
+Although all three user stories are P1, they don't ship as separate increments — they're three angles on the same architectural change. Practical delivery order:
+
+1. **Foundation green** (T001–T005): Buffer service exists and passes its own tests in isolation. No production wiring yet.
+2. **US1 lands first** (T006–T012): The capture-side refactor is the core change. Migrating the existing `sceneThumbnailService` and `captureScene` test files is what makes the rest of the change safe — the tests assert the new contract verbatim. After T012 the unsaved-state behaviour is correct; saves still rely on the next phase.
+3. **US2 verifies passively** (T013–T014): No new code. The single test in T013 confirms the panel render path was always file-path-based, which is why eager PNG writes are sufficient.
+4. **US3 closes the loop** (T015–T020): The save side merges the buffer. After T020 the round-trip (capture → discard, capture → save, capture → undo → save) is provable from end to end.
+5. **Polish** (T021–T029): Full quality gate, evidence, blog post, PR.
+
+### Parallel team strategy
+
+This change is small and tightly coupled — best done by one person in one PR. If staffed by two:
+
+- Developer A: Foundation (T002–T005), then US1 implementation (T009–T012).
+- Developer B: writes US1 tests (T006–T008) ahead of A's implementation, then US3 tests (T015–T016) ahead of A's US3 implementation. Picks up US2 verification (T013–T014).
+
+Both converge in Phase 6.
+
+### Test-first ordering (Constitution Article VII)
+
+Every user-story phase writes tests before implementation. Specifically:
+
+- T003 (Foundation tests) → T004 (Foundation impl)
+- T006/T007/T008 (US1 tests) → T009/T010/T011 (US1 impl)
+- T015/T016 (US3 tests) → T017/T018/T019 (US3 impl)
+
+This is the cadence Constitution Article VII mandates: tests define done.
+
+### Risk mitigation
+
+- **Risk**: Existing `sceneThumbnailService.test.ts` covers many edge cases (malformed item.json, missing dirs, ULID validation). Migration could weaken coverage.
+  - **Mitigation**: The migration in T006 explicitly preserves error-path tests where they remain valid (PNG write failures, invalid-scene-id, missing stac-item dir) and DROPS only those that the new contract makes irrelevant (`item-json-unreadable` / `item-json-malformed` from `writeSceneThumbnail`'s call path — those reasons remain valid for `deleteSceneThumbnail` and `gcOrphanAssets`).
+- **Risk**: The save command's new dependency on `MapPanel.getCurrentFeatures()` could fail under timing edge cases (mapPanel not yet ready, or returning a stale snapshot).
+  - **Mitigation**: T018 uses the same `MapPanel.getCurrentFeatures()` call the existing storyboard-edit and capture flows already trust. No new failure surface introduced.
+- **Risk**: Multi-plot save flows could leak buffer entries across plots.
+  - **Mitigation**: T003 explicitly tests per-plot isolation; T015 captures-on-plot-A-don't-flush-with-plot-B is implicit in the `stacItemPath` keying — call this out as an explicit case in T015.
+- **Risk**: A captured-but-not-saved Scene survives a crash as an orphan PNG that the GC pass should reclaim, but the GC pass is keyed to `item.json.assets` membership — so a PNG never registered in `item.json` would never be GC'd.
+  - **Mitigation**: Read the existing `gcOrphanAssets` body in `sceneThumbnailService.ts:361-417` carefully. It iterates `item.json.assets` and reclaims entries with no matching live Scene. PNGs that were *never registered* in `item.json` are NOT reclaimed by the current implementation. **This is a real concern.** Add an addendum task: T027 (integration-flow.md) MUST call out that orphan-PNG-from-discarded-capture reclaim is a known gap, and that a follow-up backlog item should extend `gcOrphanAssets` to also walk the `scene-thumbnails/` directory and reclaim files whose key is not present in `item.json.assets`. See "Notes & Follow-ups" below.
+
+### Notes & Follow-ups
+
+- The orphan-PNG-from-discard reclaim gap noted above is **not a regression** — today's behaviour is the opposite (discarded captures leave stale `item.json` entries pointing at PNGs that DO get GC'd). This change tightens the in-memory boundary at the cost of leaving orphan files on disk for discarded sessions. Net: cleanlier `item.json`, slightly more orphan PNGs. The mitigation is a small follow-up to `gcOrphanAssets` to scan the directory side as well as the asset-map side. Capture this as a backlog item after T027.
+- Per Constitution Article XIV (pre-release freedom), no deprecation period is required for the contract change to `writeSceneThumbnail`'s return shape.
+- Per Constitution Article XV (strict type safety), every new type (`PendingAssetEntry`, `LivePredicate`, the extended `WriteSceneThumbnailResult`) is concrete with no `any`.


### PR DESCRIPTION
## Summary

Restore the in-memory-session-vs-persisted-plot boundary by deferring scene-thumbnail asset-entry registration from capture-time to save-time. Today, every Scene capture immediately rewrites `item.json` to register `scene-thumbnail-{id}` entries, violating the architectural pattern where plot mutations are flushed only at save. This change keeps PNG writes eager (so rendering continues to work) but buffers the asset-entry metadata in-memory until the save path flushes it atomically into `item.json`.

## Key Changes

- **New `SceneThumbnailBuffer` service** (`apps/vscode/src/services/sceneThumbnailBuffer.ts`): A singleton in-memory buffer holding pending asset entries per plot. Provides `enqueue()`, `pending()`, `peekLive()`, `commit()`, `clear()`, and `clearAll()` methods. Implements per-plot isolation and idempotent entry insertion.

- **Refactored `writeSceneThumbnail()`** (`apps/vscode/src/services/sceneThumbnailService.ts`): No longer reads or mutates `item.json`. Writes PNGs atomically and returns `pendingEntries` for the caller to enqueue into the buffer. Removes `item-json-unreadable` and `item-json-malformed` error cases (those remain in `gcOrphanAssets` and `deleteSceneThumbnail`).

- **Updated capture path** (`apps/vscode/src/commands/captureScene.ts`): After `writeSceneThumbnail()` succeeds, enqueues the returned pending entries into the buffer via `buffer.enqueue(stacItemPath, pendingEntries)`.

- **Extended save path** (`apps/vscode/src/commands/saveSession.ts`): 
  - Calls `buffer.peekLive(stacItemPath, livePredicate)` to obtain live pending entries before the save.
  - Passes these entries to `storeThumbnails()` for merge into `item.json`.
  - Calls `buffer.commit(stacItemPath, committedKeys)` on successful save to drain the buffer.
  - On save failure, the buffer is left intact for retry.

- **Extension activation** (`apps/vscode/src/extension.ts`): Instantiates a single `SceneThumbnailBuffer` and injects it into both the capture and save paths.

## Behavioral Changes

- **Discard-leaves-no-trace**: Closing a plot without saving now leaves `item.json` byte-identical to its pre-session state. Captured Scenes' buffered entries are dropped on plot close.
- **Single atomic save**: The save command performs one atomic `item.json` rewrite (via the existing tmp + fsync + rename helper), merging both plot-level thumbnails and all buffered scene-thumbnail entries.
- **Undo/delete reconciliation**: Entries for undone or deleted Scenes are filtered out at flush time via a `LivePredicate` that checks whether any in-memory Scene Feature still references the asset key.
- **Rendering unaffected**: Scene thumbnails continue to render from disk paths (`{stacItemPath}/scene-thumbnails/scene-{id}.png`) — no buffer awareness needed by rendering surfaces.

## Testing

- New unit tests for `SceneThumbnailBuffer` covering idempotency, per-plot isolation, insertion-order preservation, and the two-phase peek/commit pattern.
- Migrated tests for `sceneThumbnailService`, `captureScene`, and new `saveSession` tests assert the new contract: PNGs written, `item.json` untouched until save, pending entries returned and buffered.
- All existing storyboard-edit, GC, and save-flow tests remain green.

## Specification Documents

This change is fully specified in `/specs/219-buffer-asset-entries/`:
- `spec.md` — User stories and acceptance scenarios
- `plan.md` — Technical context and implementation strategy
- `contracts/scene-thumbnail-buffer.md` — TypeScript API contract
- `data-model.md` — In-memory data structures
-

https://claude.ai/code/session_01Nc2dbqaRNu38bVEK8QSuv2