### PR TITLE
fix(heroku): copy shared/data into vsix-builder stage

### DIFF
--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -21,6 +21,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY shared/schemas/ ./shared/schemas/
 COPY shared/components/ ./shared/components/
 COPY shared/utils/ ./shared/utils/
+COPY shared/data/ ./shared/data/
 COPY shared/config-ts/package.json ./shared/config-ts/
 COPY services/session-state/ ./services/session-state/
 COPY apps/vscode/ ./apps/vscode/


### PR DESCRIPTION
The webview catalogOverview.tsx imports shared/data/enum-bundle.json via a
relative path, but the Dockerfile.preview vsix-builder stage was not copying
shared/data/ into the build context, causing esbuild to fail with
"Could not resolve '../../../../../shared/data/enum-bundle.json'".