### PR TITLE
Fix story capture: persist storyboard features and capture map tiles

### DIFF
--- a/apps/vscode/src/commands/captureScene.ts
+++ b/apps/vscode/src/commands/captureScene.ts
@@ -10,6 +10,8 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { ulid } from 'ulid';
 import {
   createStoryboard,
@@ -64,6 +66,10 @@ export interface CaptureCommandDeps {
     largePngBase64: string,
     smallPngBase64: string,
   ) => Promise<WriteSceneThumbnailResult>;
+  readonly writeFeatureCollection?: (
+    stacItemPath: string,
+    features: DebriefFeature[],
+  ) => Promise<void>;
   readonly generateUlid?: () => string;
   readonly now?: () => string;
   readonly logError?: (line: string) => void;
@@ -94,9 +100,21 @@ interface ResolvedDeps {
   setStatusBarMessage: NonNullable<CaptureCommandDeps['setStatusBarMessage']>;
   executeCommand: NonNullable<CaptureCommandDeps['executeCommand']>;
   writeSceneThumbnail: NonNullable<CaptureCommandDeps['writeSceneThumbnail']>;
+  writeFeatureCollection: NonNullable<CaptureCommandDeps['writeFeatureCollection']>;
   generateUlid: () => string;
   now: () => string;
   logError: (line: string) => void;
+}
+
+async function defaultWriteFeatureCollection(
+  stacItemPath: string,
+  features: DebriefFeature[],
+): Promise<void> {
+  const fc = { type: 'FeatureCollection' as const, features };
+  await fs.writeFile(
+    path.join(stacItemPath, 'features.geojson'),
+    `${JSON.stringify(fc, null, 2)}\n`,
+  );
 }
 
 function resolveDeps(input: CaptureCommandDeps | undefined): ResolvedDeps {
@@ -110,6 +128,8 @@ function resolveDeps(input: CaptureCommandDeps | undefined): ResolvedDeps {
       i.setStatusBarMessage ?? vscode.window.setStatusBarMessage,
     executeCommand: i.executeCommand ?? vscode.commands.executeCommand,
     writeSceneThumbnail: i.writeSceneThumbnail ?? writeSceneThumbnail,
+    writeFeatureCollection:
+      i.writeFeatureCollection ?? defaultWriteFeatureCollection,
     generateUlid: i.generateUlid ?? ((): string => ulid()),
     now: i.now ?? ((): string => new Date().toISOString()),
     logError: i.logError ?? ((line: string): void => console.error(line)),
@@ -289,6 +309,7 @@ async function captureSceneInner(
       // eslint-disable-next-line no-restricted-syntax -- #216: StoryboardPlotFeature ↔ DebriefFeature boundary — both are GeoJSON Features (see ADR-019).
       result.plot.features as unknown as DebriefFeature[],
     );
+    await persistFeatureCollection(context, deps, mapPanel.getCurrentFeatures());
     const withUndo = sessionStore.getState();
     withUndo.markDirty();
     void deps.executeCommand('debrief.storyboardPanel.focus');
@@ -304,6 +325,33 @@ async function captureSceneInner(
       'Capture failed — unexpected error. See Debrief output channel for details.',
     );
     return { status: 'rejected', reason: 'unexpected', error: err };
+  }
+}
+
+/**
+ * Eagerly persist the post-create FeatureCollection to features.geojson so
+ * the captured Storyboard / Scene survives a reload without requiring the
+ * user to run "Save Session" first. Mirrors the eager scene-PNG write that
+ * already happened in step 8.
+ *
+ * Best-effort: write failures are logged + surfaced as a non-modal warning,
+ * but do not roll back the in-memory capture (the user can retry via Save
+ * Session, and the scene PNG is already on disk).
+ */
+async function persistFeatureCollection(
+  context: CaptureCommandContext,
+  deps: ResolvedDeps,
+  features: DebriefFeature[],
+): Promise<void> {
+  try {
+    await deps.writeFeatureCollection(context.stacItemPath, features);
+  } catch (err) {
+    deps.logError(
+      `[captureScene] features.geojson write failed: ${stringifyError(err)}`,
+    );
+    void vscode.window.showWarningMessage(
+      'Scene captured, but features.geojson could not be written. Run Save Session to retry.',
+    );
   }
 }
 
@@ -413,6 +461,7 @@ async function retryCreateScene(
       // eslint-disable-next-line no-restricted-syntax -- #216: StoryboardPlotFeature ↔ DebriefFeature boundary — both are GeoJSON Features (see ADR-019).
       result.plot.features as unknown as DebriefFeature[],
     );
+    await persistFeatureCollection(context, deps, context.mapPanel.getCurrentFeatures());
     const withUndo = context.sessionStore.getState();
     withUndo.markDirty();
     void deps.executeCommand('debrief.storyboardPanel.focus');

--- a/apps/vscode/src/commands/saveSession.ts
+++ b/apps/vscode/src/commands/saveSession.ts
@@ -13,6 +13,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { saveSession, type SessionStoreWithUndo } from '@debrief/session-state';
+import type { DebriefFeature } from '@debrief/components';
 import type { SessionManager } from '../services/sessionManager';
 import type { MapPanel } from '../webview/mapPanel';
 import { parseStacUri } from '../types/stac';
@@ -38,6 +39,32 @@ function deriveSessionPath(plotUri: string, storePath: string): string | null {
 
   // Combine with store path
   return `${storePath}/${itemPath}`;
+}
+
+/**
+ * Write the in-memory FeatureCollection back to `<item-dir>/features.geojson`.
+ *
+ * Captured Storyboard/Scene features (and any other in-session mutations)
+ * live only in the MapPanel until this point — there is no separate
+ * persistence path. Mirrors the eager write that `writeSceneThumbnail`
+ * already does for scene PNGs so the two stay in sync after a save.
+ */
+export function storeFeatureCollection(
+  storePath: string,
+  plotUri: string,
+  features: DebriefFeature[],
+): void {
+  const parsed = parseStacUri(plotUri);
+  if (!parsed) {
+    return;
+  }
+  const itemDir = path.join(storePath, path.dirname(parsed.itemPath));
+  const featuresPath = path.join(itemDir, 'features.geojson');
+  const fc = {
+    type: 'FeatureCollection' as const,
+    features,
+  };
+  fs.writeFileSync(featuresPath, `${JSON.stringify(fc, null, 2)}\n`);
 }
 
 /**
@@ -152,17 +179,26 @@ export function createSaveSessionCommand(
         `Session saved to ${result.path}`
       );
 
-      // Capture thumbnails after successful save (#174)
       const mapPanel = getMapPanel?.();
-      if (mapPanel) {
+      const parsed = parseStacUri(plotUri);
+      const storePath = parsed ? getStorePath(parsed.storeId) : undefined;
+
+      // Persist in-memory features back to features.geojson so captured
+      // Storyboard/Scene features (and any other mutations) survive reload.
+      if (mapPanel && parsed && storePath) {
         try {
-          const parsed = parseStacUri(plotUri);
-          const storePath = parsed ? getStorePath(parsed.storeId) : undefined;
-          if (parsed && storePath) {
-            const { largePngBase64, smallPngBase64 } = await mapPanel.requestThumbnailCapture(5000);
-            if (largePngBase64 && smallPngBase64) {
-              storeThumbnails(storePath, plotUri, largePngBase64, smallPngBase64);
-            }
+          storeFeatureCollection(storePath, plotUri, mapPanel.getCurrentFeatures());
+        } catch (err) {
+          console.warn('[debrief] features.geojson write failed (non-blocking):', err);
+        }
+      }
+
+      // Capture thumbnails after successful save (#174)
+      if (mapPanel && parsed && storePath) {
+        try {
+          const { largePngBase64, smallPngBase64 } = await mapPanel.requestThumbnailCapture(5000);
+          if (largePngBase64 && smallPngBase64) {
+            storeThumbnails(storePath, plotUri, largePngBase64, smallPngBase64);
           }
         } catch (err) {
           console.warn('[debrief] Thumbnail capture failed (non-blocking):', err);

--- a/apps/vscode/src/webview/mapPanel.ts
+++ b/apps/vscode/src/webview/mapPanel.ts
@@ -1486,7 +1486,7 @@ export class MapPanel {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src ${cspSource} data: https:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; img-src ${cspSource} data: https:; connect-src https:;">
   <title>Debrief Map</title>
   <link rel="stylesheet" href="${stylesUri.toString()}">
   <style>

--- a/apps/vscode/tests/unit/captureScene.test.ts
+++ b/apps/vscode/tests/unit/captureScene.test.ts
@@ -153,6 +153,7 @@ function depsFor(overrides: Partial<CaptureCommandDeps> = {}): CaptureCommandDep
       largePath: `/tmp/large-${sceneId}.png`,
       smallPath: `/tmp/small-${sceneId}.png`,
     })),
+    writeFeatureCollection: vi.fn(async () => undefined),
     generateUlid: vi.fn(() => '01HW0XGE7Z4YQZ2QZ6KMN9VPJK'),
     now: vi.fn(() => '2026-04-20T14:35:00.000Z'),
     logError: vi.fn(),
@@ -196,6 +197,17 @@ describe('captureScene — happy paths', () => {
     expect(markDirty).toHaveBeenCalledTimes(1);
     expect(deps.executeCommand).toHaveBeenCalledWith('debrief.storyboardPanel.focus');
     expect(sink.calls).toEqual([true, false]);
+
+    // features.geojson is persisted eagerly so the captured scene survives
+    // a reload without requiring "Save Session" first.
+    expect(deps.writeFeatureCollection).toHaveBeenCalledTimes(1);
+    const writeArgs = (deps.writeFeatureCollection as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(writeArgs[0]).toBe('/store/item');
+    const writtenKinds = (writeArgs[1] as DebriefFeature[]).map(
+      (f) => (f.properties as { kind?: string }).kind,
+    );
+    expect(writtenKinds.filter((k) => k === 'STORYBOARD')).toHaveLength(1);
+    expect(writtenKinds.filter((k) => k === 'STORYBOARD_SCENE')).toHaveLength(1);
 
     // Inspect stored features: one Storyboard + one Scene were appended.
     const kinds = mapPanel.features.map(

--- a/apps/vscode/tests/unit/saveSession.storeFeatureCollection.test.ts
+++ b/apps/vscode/tests/unit/saveSession.storeFeatureCollection.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit test for `storeFeatureCollection` — the eager features.geojson
+ * persistence that Save Session uses to make captured Storyboard/Scene
+ * features survive a reload (bug: features.json missing storyboard).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { storeFeatureCollection } from '../../src/commands/saveSession';
+import type { DebriefFeature } from '@debrief/components';
+
+describe('storeFeatureCollection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'debrief-save-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes features.geojson alongside item.json with the supplied features', () => {
+    const itemSubpath = 'core--analysis1-areas/item.json';
+    fs.mkdirSync(path.join(tmpDir, 'core--analysis1-areas'), { recursive: true });
+
+    const storyboardFeature = {
+      type: 'Feature',
+      id: 'sb-1',
+      geometry: { type: 'Polygon', coordinates: [] },
+      properties: { kind: 'STORYBOARD', id: 'sb-1', name: 'Test Storyboard' },
+    } as unknown as DebriefFeature;
+    const sceneFeature = {
+      type: 'Feature',
+      id: 'sc-1',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[-21.7, 22.0], [-21.6, 22.0], [-21.6, 21.9], [-21.7, 21.9], [-21.7, 22.0]]],
+      },
+      properties: { kind: 'STORYBOARD_SCENE', id: 'sc-1', storyboard_id: 'sb-1' },
+    } as unknown as DebriefFeature;
+
+    storeFeatureCollection(
+      tmpDir,
+      `stac://test-store/${itemSubpath}`,
+      [storyboardFeature, sceneFeature],
+    );
+
+    const written = fs.readFileSync(
+      path.join(tmpDir, 'core--analysis1-areas/features.geojson'),
+      'utf-8',
+    );
+    const parsed = JSON.parse(written) as {
+      type: string;
+      features: Array<{ properties: { kind: string } }>;
+    };
+    expect(parsed.type).toBe('FeatureCollection');
+    expect(parsed.features.map((f) => f.properties.kind)).toEqual([
+      'STORYBOARD',
+      'STORYBOARD_SCENE',
+    ]);
+  });
+
+  it('is a no-op when the plot URI is malformed', () => {
+    const before = fs.readdirSync(tmpDir);
+    storeFeatureCollection(tmpDir, 'not-a-stac-uri', []);
+    const after = fs.readdirSync(tmpDir);
+    expect(after).toEqual(before);
+  });
+});

--- a/shared/components/src/MapView/__tests__/captureMap.test.ts
+++ b/shared/components/src/MapView/__tests__/captureMap.test.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi } from 'vitest';
 // Mock modern-screenshot before importing the module under test
 vi.mock('modern-screenshot', () => ({
   domToPng: vi.fn().mockResolvedValue('data:image/png;base64,iVBOR'),
+  waitUntilLoad: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { captureMapAsDataUrl } from '../captureMap';
-import { domToPng } from 'modern-screenshot';
+import { domToPng, waitUntilLoad } from 'modern-screenshot';
 
 describe('captureMapAsDataUrl', () => {
   it('calls domToPng with the container element and default dimensions', async () => {
@@ -38,5 +39,22 @@ describe('captureMapAsDataUrl', () => {
     const container = document.createElement('div');
     const result = await captureMapAsDataUrl(container);
     expect(result).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it('waits for tile images to load before snapshotting', async () => {
+    const container = document.createElement('div');
+    const callOrder: string[] = [];
+    (waitUntilLoad as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      callOrder.push('waitUntilLoad');
+    });
+    (domToPng as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      callOrder.push('domToPng');
+      return 'data:image/png;base64,iVBOR';
+    });
+
+    await captureMapAsDataUrl(container);
+
+    expect(waitUntilLoad).toHaveBeenCalledWith(container);
+    expect(callOrder).toEqual(['waitUntilLoad', 'domToPng']);
   });
 });

--- a/shared/components/src/MapView/captureMap.ts
+++ b/shared/components/src/MapView/captureMap.ts
@@ -3,7 +3,7 @@
  * Feature: 174-thumbnail-capture
  */
 
-import { domToPng } from 'modern-screenshot';
+import { domToPng, waitUntilLoad } from 'modern-screenshot';
 
 /** Default capture dimensions matching the large thumbnail spec (800x600). */
 const DEFAULT_WIDTH = 800;
@@ -20,7 +20,14 @@ export interface CaptureMapOptions {
  * Capture the Leaflet map container as a PNG data URL.
  *
  * Uses modern-screenshot's domToPng which handles cross-origin tiles
- * (requires crossOrigin="anonymous" on TileLayer).
+ * (requires crossOrigin="anonymous" on TileLayer + a `connect-src` CSP
+ * permissive enough to fetch each tile, since modern-screenshot inlines
+ * them as base64 data URLs).
+ *
+ * `waitUntilLoad` is called first so any tiles still streaming after a
+ * recent pan/zoom finish before the snapshot — without this, the PNG
+ * captures only the SVG/marker layer because tile <img>s aren't yet
+ * decodable.
  *
  * @param container - The DOM element containing the Leaflet map (.leaflet-container)
  * @param options - Optional capture dimensions
@@ -31,6 +38,8 @@ export async function captureMapAsDataUrl(
   options: CaptureMapOptions = {},
 ): Promise<string> {
   const { width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT } = options;
+
+  await waitUntilLoad(container);
 
   const dataUrl = await domToPng(container, {
     width,


### PR DESCRIPTION
## Summary

Two user-reported bugs after a storyboard capture:

1. **Captured scenes were lost on reload** — the storyboard/scene features lived only in `MapPanel`'s in-memory list. The scene PNG was written eagerly to `<item>/scene-thumbnails/` by `writeSceneThumbnail`, but nothing wrote the matching `STORYBOARD` / `STORYBOARD_SCENE` features back to `features.geojson`. Even running Save Session didn't help, since `saveSession` only persisted the `.debrief-session` state file.
2. **Scene thumbnail PNGs had no map tiles** — the captured PNG showed feature markers/SVG overlays on a blank background. `modern-screenshot`'s per-tile `fetch()` (used to inline each tile as base64 inside the SVG snapshot) was being silently blocked by the webview's CSP `default-src 'none'`, since no `connect-src` was declared.

## Changes

Three focused commits:

### `075a072` — `fix(saveSession): persist features.geojson on save`

Added `storeFeatureCollection()` and called it from the Save Session handler alongside the existing `storeThumbnails`. After a successful `saveSession()`, the in-memory `mapPanel.getCurrentFeatures()` is serialised to `<item-dir>/features.geojson`, mirroring the eager scene-PNG write.

### `1cbd415` — `fix(captureMap): include OSM tiles in scene thumbnails`

Two compounding gaps stripped tiles from every captured PNG:

- Webview CSP at `apps/vscode/src/webview/mapPanel.ts` had `default-src 'none'; ... img-src ${cspSource} data: https:` with no `connect-src`. Tile `<img>`s rendered fine (covered by `img-src https:`), but `modern-screenshot`'s internal per-tile `fetch()` was silently blocked, so tiles dropped out of the PNG. Added `connect-src https:`.
- `domToPng` ran without awaiting in-flight tile loads. After a recent pan/zoom, tiles still streaming would be skipped. Now `await waitUntilLoad(container)` runs before the snapshot in `shared/components/src/MapView/captureMap.ts`.

### `8aa5f1f` — `fix(captureScene): persist features.geojson eagerly on capture`

The save-time persistence in `075a072` only ran when the user explicitly chose Save Session. Closed the asymmetry: capture now writes both the PNG **and** `features.geojson` the moment `createScene` succeeds (covers both the happy path and the duplicate-timestamp retry path). Best-effort — write failures log + show a non-modal warning ("Scene captured, but features.geojson could not be written. Run Save Session to retry.") rather than rolling back the in-memory capture, since the PNG is already on disk.

The writer is injected through `CaptureCommandDeps.writeFeatureCollection` (defaults to `fs.promises.writeFile`) so tests can stub it.

## Test plan

Automated:

- [x] `apps/vscode/tests/unit/captureScene.test.ts` (15 tests) — first-capture happy path now also asserts `writeFeatureCollection` is called once with the item path and that the written features include both `STORYBOARD` and `STORYBOARD_SCENE` kinds.
- [x] `apps/vscode/tests/unit/saveSession.storeFeatureCollection.test.ts` (2 tests) — verifies features.geojson is written with the correct kinds and that a malformed `stac://` URI is a silent no-op.
- [x] `shared/components/src/MapView/__tests__/captureMap.test.ts` (4 tests) — mocks `waitUntilLoad`; new test asserts `waitUntilLoad` runs **before** `domToPng`.
- [x] `tsc --noEmit` clean for both `apps/vscode` and `shared/components`.
- [x] `eslint` clean for all changed source files.

Manual (via Code Server preview):

- [ ] Open a sample plot (e.g. Saxon Warrior: Analysis1 Areas).
- [ ] Click Capture in the Storyboard panel and name a new storyboard.
- [ ] Confirm `<store>/<item>/features.geojson` immediately contains a `STORYBOARD` and a `STORYBOARD_SCENE` feature (no Save Session required).
- [ ] Confirm `<store>/<item>/scene-thumbnails/scene-<id>.png` contains the OSM tile background (not just feature markers on white).
- [ ] Reload the plot — the captured storyboard/scene should still be present.

## Out of scope

- The `viewportToPolygon` MVP stub in `shared/components/src/storyboard/crud.ts:111` still emits a ±0.001° square around the viewport center — its in-file comment flags this for replacement under a different feature spec. Untouched here.

https://claude.ai/code/session_01J44CXqAMBrpXCxGKwYFNhf