### PR TITLE
chore(backlog-navigator): bootstrap scaffold + deployment workflow trio (precursor to #580)

### DIFF
--- a/.github/workflows/backlog-navigator-comment.yml
+++ b/.github/workflows/backlog-navigator-comment.yml
@@ -1,0 +1,70 @@
+name: Backlog Navigator Comment
+
+# Posts (or updates) a sticky PR comment pointing reviewers at the
+# production Backlog Navigator keyed to this PR, whenever the PR touches
+# BACKLOG.md. Code-only PRs are silent.
+#
+# The Backlog Navigator is a static SPA at
+#   https://debrief.github.io/debrief-future/backlog-navigator/
+# that reads ?pr=<number> at runtime and fetches BACKLOG.md from the PR's
+# head branch via the GitHub API — no per-branch build required.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'BACKLOG.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post or update Backlog Navigator comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const marker = '<!-- backlog-navigator-comment -->';
+            const navUrl = `https://debrief.github.io/debrief-future/backlog-navigator/?pr=${prNumber}`;
+
+            const body = [
+              marker,
+              '## 📋 Backlog Navigator',
+              '',
+              `Review this PR's BACKLOG.md edits interactively:`,
+              '',
+              `👉 **[Open in Backlog Navigator](${navUrl})**`,
+              '',
+              `<sub>Updated for ${headSha.substring(0, 7)} — the navigator reads BACKLOG.md live from this PR's head branch, so no rebuild is needed.</sub>`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated comment ${existing.id}`);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created comment ${created.id}`);
+            }

--- a/.github/workflows/backlog-navigator-preview.yml
+++ b/.github/workflows/backlog-navigator-preview.yml
@@ -1,0 +1,88 @@
+name: Preview Backlog Navigator (branch)
+
+# Deploys a branch build of the Backlog Navigator to
+#   https://debrief.github.io/debrief-future/backlog-navigator-preview/<slug>/
+# Preview builds default to dry-run mode (VITE_BACKLOG_NAV_DRY_RUN=true) so
+# reviewers can exercise the UI without hitting the GitHub write path.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to preview (default: the branch this workflow was dispatched from)'
+        required: false
+        type: string
+  push:
+    branches:
+      - 'preview/**'
+    paths:
+      - 'apps/backlog-navigator/**'
+      - 'BACKLOG.md'
+      - '.github/workflows/backlog-navigator-preview.yml'
+
+jobs:
+  build-and-publish-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve branch + slug
+        id: branch
+        run: |
+          BRANCH="${{ inputs.branch || github.ref_name }}"
+          SLUG=$(printf '%s' "$BRANCH" | tr -c 'A-Za-z0-9-' '-' | sed -E 's/-+/-/g;s/^-|-$//g')
+          if [ -z "$SLUG" ]; then
+            echo "::error::Could not derive slug from branch '$BRANCH'"
+            exit 1
+          fi
+          if [ "$SLUG" = "main" ]; then
+            echo "::error::Refusing to publish 'main' as a preview — use the production workflow."
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "base_url=/debrief-future/backlog-navigator-preview/$SLUG/" >> "$GITHUB_OUTPUT"
+          echo "Resolved: branch=$BRANCH slug=$SLUG"
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build backlog-navigator (preview base URL, dry-run mode)
+        env:
+          VITE_BASE_URL: ${{ steps.branch.outputs.base_url }}
+          VITE_BACKLOG_NAV_DRY_RUN: 'true'
+        run: pnpm --filter @debrief/backlog-navigator build
+
+      - name: Deploy preview to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apps/backlog-navigator/dist
+          destination_dir: backlog-navigator-preview/${{ steps.branch.outputs.slug }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'chore(preview): deploy backlog-navigator from ${{ steps.branch.outputs.branch }}'
+
+      - name: Summarise
+        run: |
+          echo "### Preview deployed :rocket:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Branch: \`${{ steps.branch.outputs.branch }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Slug: \`${{ steps.branch.outputs.slug }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "URL: https://debrief.github.io/debrief-future/backlog-navigator-preview/${{ steps.branch.outputs.slug }}/" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backlog-navigator-publish.yml
+++ b/.github/workflows/backlog-navigator-publish.yml
@@ -1,0 +1,46 @@
+name: Publish Backlog Navigator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/backlog-navigator/**'
+      - 'BACKLOG.md'
+      - '.github/workflows/backlog-navigator-publish.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build backlog-navigator (production — real-write mode)
+        # No VITE_BACKLOG_NAV_DRY_RUN set, so the production build can hit the
+        # GitHub write path when the user supplies a PAT.
+        run: pnpm --filter @debrief/backlog-navigator build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apps/backlog-navigator/dist
+          destination_dir: backlog-navigator
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
           run_step web-shell-pw bash -c 'cd apps/web-shell && node run-playwright.mjs' || EXIT=$?
           run_step spec-nav-build pnpm --filter @debrief/spec-navigator build || EXIT=$?
           run_step spec-nav-pw bash -c 'cd apps/spec-navigator && node run-playwright.mjs' || EXIT=$?
+          run_step backlog-nav-build pnpm --filter @debrief/backlog-navigator build || EXIT=$?
+          run_step backlog-nav-pw bash -c 'cd apps/backlog-navigator && node run-playwright.mjs' || EXIT=$?
 
           exit "${EXIT:-0}"
 

--- a/apps/backlog-navigator/.eslintrc.cjs
+++ b/apps/backlog-navigator/.eslintrc.cjs
@@ -1,0 +1,56 @@
+const { rules: utilsDriftRules } = require('../../shared/eslint-rules/no-redeclare-utils-exports.cjs');
+const { rules: schemasDriftRules } = require('../../shared/eslint-rules/no-redeclare-schemas-exports.cjs');
+const { rules: componentsDriftRules } = require('../../shared/eslint-rules/no-redeclare-components-exports.cjs');
+const { rules: sessionStateDriftRules } = require('../../shared/eslint-rules/no-redeclare-session-state-exports.cjs');
+const { rules: dataDriftRules } = require('../../shared/eslint-rules/no-redeclare-data-exports.cjs');
+
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'node_modules'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/consistent-type-assertions': [
+      'warn',
+      {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'never',
+      },
+    ],
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    'no-restricted-syntax': [
+      'error',
+      ...utilsDriftRules,
+      ...schemasDriftRules,
+      ...componentsDriftRules,
+      ...sessionStateDriftRules,
+      ...dataDriftRules,
+    ],
+  },
+};

--- a/apps/backlog-navigator/.gitignore
+++ b/apps/backlog-navigator/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+test-results/
+playwright-report/
+.chromium-path

--- a/apps/backlog-navigator/README.md
+++ b/apps/backlog-navigator/README.md
@@ -1,0 +1,23 @@
+# Backlog Navigator (bootstrap scaffold)
+
+This package is the minimal scaffold that exists ahead of the main feature
+implementation in [PR #580](https://github.com/debrief/debrief-future/pull/580).
+
+It exists primarily to land:
+
+- The three GitHub Actions workflows (`backlog-navigator-{preview,publish,comment}.yml`)
+  on `main` so they can fire on subsequent PR + push events.
+- A buildable `apps/backlog-navigator/` workspace package so `task lint`,
+  `task typecheck`, `task test`, and the workflow trio all have something
+  real to operate on.
+- A first production deploy at `https://debrief.github.io/debrief-future/backlog-navigator/`
+  so the per-PR sticky comment URL resolves.
+
+The full implementation (browse / filter / group-by-epic / context-sensitive
+edit / staged push / dry-run mode / PR-mode) lands in PR #580 against this
+scaffold. See `specs/242-backlog-navigator/` for the spec.
+
+## Mirrors `apps/spec-navigator/`
+
+Layout, build/test discipline, and workflow trio all mirror
+`apps/spec-navigator/`. Keep them in lockstep.

--- a/apps/backlog-navigator/e2e/smoke.spec.ts
+++ b/apps/backlog-navigator/e2e/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@playwright/test';
+
+test('bootstrap shell renders', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByTestId('app-shell')).toBeVisible();
+  await expect(page.locator('.banner')).toContainText('Backlog Navigator');
+});

--- a/apps/backlog-navigator/index.html
+++ b/apps/backlog-navigator/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self' https://api.github.com https://raw.githubusercontent.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://raw.githubusercontent.com data:; base-uri 'self'; form-action 'none'"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backlog Navigator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/backlog-navigator/package.json
+++ b/apps/backlog-navigator/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@debrief/backlog-navigator",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:cloud": "node run-playwright.mjs",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.8.5",
+    "@playwright/test": "^1.58.0",
+    "@sparticuz/chromium": "^143.0.4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^14.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "jsdom": "^28.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/apps/backlog-navigator/playwright.config.ts
+++ b/apps/backlog-navigator/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig } from '@playwright/test';
+import { readFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const chromiumPathFile = join(__dirname, '.chromium-path');
+let chromiumPath: string | undefined = process.env.CHROMIUM_PATH;
+if (!chromiumPath && existsSync(chromiumPathFile)) {
+  chromiumPath = readFileSync(chromiumPathFile, 'utf8').trim();
+}
+const useSparticuz = !!chromiumPath;
+
+console.log(`Playwright config: useSparticuz=${useSparticuz}, chromiumPath=${chromiumPath}`);
+
+const launchOptions = useSparticuz
+  ? {
+      executablePath: chromiumPath,
+      headless: true,
+      args: [
+        '--disable-setuid-sandbox',
+        '--no-sandbox',
+        '--no-zygote',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-features=IsolateOrigins,site-per-process',
+        '--disable-site-isolation-trials',
+        '--disable-background-networking',
+        '--disable-default-apps',
+        '--disable-extensions',
+        '--disable-sync',
+        '--disable-translate',
+        '--metrics-recording-only',
+        '--mute-audio',
+        '--no-first-run',
+      ],
+    }
+  : undefined;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 1,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5175',
+    trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
+    launchOptions,
+  },
+  webServer: {
+    command: 'pnpm preview --port 5175',
+    url: 'http://localhost:5175',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60000,
+  },
+  timeout: 30000,
+});

--- a/apps/backlog-navigator/run-playwright.mjs
+++ b/apps/backlog-navigator/run-playwright.mjs
@@ -1,0 +1,39 @@
+/**
+ * Run Playwright E2E tests with @sparticuz/chromium in CI / Claude Code.
+ * Mirrors apps/spec-navigator/run-playwright.mjs.
+ */
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+
+const CHROMIUM_PATH_FILE = join(process.cwd(), '.chromium-path');
+
+async function main() {
+  console.log('Extracting chromium from @sparticuz/chromium...');
+  const chromium = (await import('@sparticuz/chromium')).default;
+  const executablePath = await chromium.executablePath();
+  console.log(`Chromium extracted to: ${executablePath}`);
+
+  if (!existsSync(dirname(CHROMIUM_PATH_FILE))) {
+    mkdirSync(dirname(CHROMIUM_PATH_FILE), { recursive: true });
+  }
+  writeFileSync(CHROMIUM_PATH_FILE, executablePath, 'utf8');
+
+  console.log('Running Playwright tests...');
+  const args = process.argv.slice(2).join(' ');
+  const command = `CHROMIUM_PATH="${executablePath}" pnpm exec playwright test ${args}`;
+
+  try {
+    execSync(command, { stdio: 'inherit', shell: true, cwd: process.cwd() });
+  } catch (error) {
+    process.exitCode = error.status || 1;
+  } finally {
+    try {
+      unlinkSync(CHROMIUM_PATH_FILE);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+main().catch(console.error);

--- a/apps/backlog-navigator/src/App.tsx
+++ b/apps/backlog-navigator/src/App.tsx
@@ -1,0 +1,23 @@
+/**
+ * Bootstrap shell for the Backlog Navigator (#242).
+ *
+ * This file is the minimal scaffold landed ahead of the main feature PR so
+ * that the per-PR preview workflow can attach to a real production deploy on
+ * `main`. The real implementation (browse / filter / group / edit / push)
+ * lands in PR #580 against this scaffold.
+ */
+export function App(): JSX.Element {
+  return (
+    <div className="app-shell" data-testid="app-shell">
+      <header className="banner">
+        <strong>Backlog Navigator</strong> &mdash; bootstrap scaffold
+      </header>
+      <main className="body">
+        <p>
+          The full navigator implementation is landing in <a href="https://github.com/debrief/debrief-future/pull/580">PR&nbsp;#580</a>.
+          This deploy proves the publish + preview workflow trio is wired up.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/backlog-navigator/src/__tests__/bootstrap.test.tsx
+++ b/apps/backlog-navigator/src/__tests__/bootstrap.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { App } from '../App';
+
+describe('bootstrap App', () => {
+  it('renders the navigator banner', () => {
+    render(<App />);
+    expect(screen.getByTestId('app-shell')).toBeTruthy();
+    expect(screen.getByText(/Backlog Navigator/i)).toBeTruthy();
+  });
+});

--- a/apps/backlog-navigator/src/main.tsx
+++ b/apps/backlog-navigator/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import './styles/app.css';
+
+const rootEl = document.getElementById('root');
+if (!rootEl) {
+  throw new Error('root element not found');
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/backlog-navigator/src/styles/app.css
+++ b/apps/backlog-navigator/src/styles/app.css
@@ -1,0 +1,29 @@
+/* Bootstrap-only styles. Real app styles arrive with PR #580. */
+:root {
+  --bg: #ffffff;
+  --fg: #1f2328;
+  --fg-muted: #4a5159;
+  --border: #b3bbc4;
+  --accent: #0550ae;
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; margin: 0; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.app-shell { padding: 24px; }
+.banner {
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #f6f8fa;
+  margin-bottom: 16px;
+}
+.body p { color: var(--fg-muted); }
+.body a { color: var(--accent); }

--- a/apps/backlog-navigator/tsconfig.json
+++ b/apps/backlog-navigator/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/backlog-navigator/tsconfig.node.json
+++ b/apps/backlog-navigator/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts"]
+}

--- a/apps/backlog-navigator/vite.config.ts
+++ b/apps/backlog-navigator/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: process.env.VITE_BASE_URL || '/debrief-future/backlog-navigator/',
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+  define: {
+    'import.meta.env.VITE_BACKLOG_NAV_DRY_RUN': JSON.stringify(
+      process.env.VITE_BACKLOG_NAV_DRY_RUN || 'false',
+    ),
+  },
+});

--- a/apps/backlog-navigator/vitest.config.ts
+++ b/apps/backlog-navigator/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/__tests__/**/*.test.tsx'],
+    exclude: ['node_modules', 'e2e', 'dist'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,67 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.30)(jsdom@28.0.0(@noble/hashes@1.8.0))
 
+  apps/backlog-navigator:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.8.5
+        version: 4.11.1(playwright-core@1.58.2)
+      '@playwright/test':
+        specifier: ^1.58.0
+        version: 1.58.2
+      '@sparticuz/chromium':
+        specifier: ^143.0.4
+        version: 143.0.4
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.3.7(@types/react@18.3.27)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.30))
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.2
+        version: 4.6.2(eslint@8.57.1)
+      jsdom:
+        specifier: ^28.0.0
+        version: 28.0.0(@noble/hashes@1.8.0)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@20.19.30)
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.30)(jsdom@28.0.0(@noble/hashes@1.8.0))
+
   apps/loader:
     dependencies:
       '@debrief/schemas':
@@ -6614,10 +6675,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -8566,8 +8623,8 @@ snapshots:
       '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.8.0))
       better-opn: 3.0.2
       browser-assert: 1.2.1
-      esbuild: 0.19.12
-      esbuild-register: 3.6.0(esbuild@0.19.12)
+      esbuild: 0.24.2
+      esbuild-register: 3.6.0(esbuild@0.24.2)
       jsdoc-type-pratt-parser: 4.8.0
       process: 0.11.10
       recast: 0.23.11
@@ -9937,7 +9994,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.18.2
+      undici: 7.25.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -10650,10 +10707,10 @@ snapshots:
   es6-error@4.1.1:
     optional: true
 
-  esbuild-register@3.6.0(esbuild@0.19.12):
+  esbuild-register@3.6.0(esbuild@0.24.2):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.19.12
+      esbuild: 0.24.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14000,8 +14057,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
-
-  undici@7.18.2: {}
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
## Summary

Precursor PR for #580 (the full Backlog Navigator implementation). Lands the minimum needed for the deployment workflow trio to attach to a real production deploy on `main`, so the per-PR sticky-comment URL resolves immediately after merge.

## Why a separate PR

GitHub Actions loads workflow files from the **default branch (main)** at trigger time. Workflows defined only on a feature branch never run. PR #580 added `backlog-navigator-{preview,publish,comment}.yml` — but until those files are on main, none of them fire. The sticky comment that #580 generates points at `https://debrief.github.io/debrief-future/backlog-navigator/?pr=580`, which 404s because main has never built it.

This PR breaks the chicken-and-egg by landing:
- The three workflows on main (so they start triggering on subsequent events).
- A minimal buildable `apps/backlog-navigator/` scaffold (so the publish workflow has something to deploy and the per-PR preview workflow has something to build).

Once this merges:
- The publish workflow runs on the merge commit and deploys the bootstrap shell to `/backlog-navigator/`. The sticky-comment URL resolves.
- PR #580 can be rebased on the new main; pushing a `preview/<slug>` branch from #580 will trigger a real per-PR preview deploy.
- Every future PR touching `BACKLOG.md` gets a working sticky-comment link.

## What's in this PR

- `.github/workflows/backlog-navigator-{preview,publish,comment}.yml` — three new workflows mirroring the spec-navigator trio.
- `apps/backlog-navigator/` — minimal Vite + React 18 scaffold rendering a single "bootstrap shell" with a link to PR #580.
  - `package.json`, `tsconfig.json` + `tsconfig.node.json`, `vite.config.ts`, `vitest.config.ts`, `playwright.config.ts`, `run-playwright.mjs`, `index.html`, `.gitignore`, `README.md`
  - `.eslintrc.cjs` with the full drift-rule wiring required by `check-eslint-drift-wiring`
  - `src/main.tsx`, `src/App.tsx`, `src/styles/app.css` (~50 lines total)
  - `src/__tests__/bootstrap.test.tsx` (1 unit test)
  - `e2e/smoke.spec.ts` (1 Playwright test)
- `ci.yml` — adds `backlog-nav-build` + `backlog-nav-pw` to the existing `Test & Lint` job (mirror of `spec-nav-build` / `spec-nav-pw`).

## Test plan

- [x] `task lint` — passes locally (incl. `check-eslint-drift-wiring`)
- [x] `pnpm --filter @debrief/backlog-navigator typecheck` — clean
- [x] `pnpm --filter @debrief/backlog-navigator test` — 1/1 passing
- [x] `pnpm --filter @debrief/backlog-navigator build` — succeeds
- [x] `cd apps/backlog-navigator && node run-playwright.mjs` — 1/1 passing (smoke E2E renders the bootstrap shell)
- [ ] After merge: confirm `https://debrief.github.io/debrief-future/backlog-navigator/` resolves (publish workflow auto-runs)

https://claude.ai/code/session_01PKG8m9mAr538y8WMdotPJE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKG8m9mAr538y8WMdotPJE)_