### PR TITLE
Add discard button to mobile sticky push bar

### DIFF
--- a/apps/backlog-navigator/src/components/mobile/StickyPushBar.tsx
+++ b/apps/backlog-navigator/src/components/mobile/StickyPushBar.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '../../state/store';
+import { strings } from '../../strings';
 
 interface StickyPushBarProps {
   /** Open the push dialog (same callback the desktop PendingFooter uses). */
@@ -30,9 +31,13 @@ interface StickyPushBarProps {
  * desktop (FR-016).
  */
 export function StickyPushBar({ onPushChanges, variant = 'idle' }: StickyPushBarProps): JSX.Element | null {
-  const { edits } = useStore();
+  const { edits, clearStaging } = useStore();
   const n = edits.length;
   if (n === 0) return null;
+
+  const onDiscard = (): void => {
+    if (window.confirm(strings.pending.confirmDiscard)) clearStaging();
+  };
 
   return (
     <div
@@ -45,6 +50,15 @@ export function StickyPushBar({ onPushChanges, variant = 'idle' }: StickyPushBar
       <span className="sticky-push-bar-count" data-testid="sticky-push-bar-count">
         {n === 1 ? '1 unsynced edit' : `${n} unsynced edits`}
       </span>
+      <button
+        type="button"
+        className="sticky-push-bar-discard"
+        data-testid="discard-button"
+        onClick={onDiscard}
+        aria-label={`Discard ${n} pending edit${n === 1 ? '' : 's'}`}
+      >
+        {strings.pending.discardAll}
+      </button>
       <button
         type="button"
         className="sticky-push-bar-button"

--- a/apps/backlog-navigator/src/components/mobile/__tests__/StickyPushBar.test.tsx
+++ b/apps/backlog-navigator/src/components/mobile/__tests__/StickyPushBar.test.tsx
@@ -9,7 +9,7 @@ import {
   type PendingEdit,
 } from '../../../types';
 
-function makeStoreApi(edits: PendingEdit[]): StoreApi {
+function makeStoreApi(edits: PendingEdit[], clearStaging: () => void = () => undefined): StoreApi {
   return {
     state: { status: 'loading' },
     setState: () => undefined,
@@ -20,7 +20,7 @@ function makeStoreApi(edits: PendingEdit[]): StoreApi {
     projected: null,
     stageEdit: () => undefined,
     undoEdit: () => undefined,
-    clearStaging: () => undefined,
+    clearStaging,
     persistenceWarning: null,
   };
 }
@@ -77,6 +77,35 @@ describe('StickyPushBar', () => {
     );
     fireEvent.click(screen.getByTestId('push-button'));
     expect(onPush).toHaveBeenCalled();
+  });
+
+  it('discard button calls clearStaging when confirmed', () => {
+    const clearStaging = vi.fn();
+    const api = makeStoreApi([sampleEdit], clearStaging);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(
+      <StoreProvider value={api}>
+        <StickyPushBar onPushChanges={() => undefined} />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByTestId('discard-button'));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(clearStaging).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('discard button is a no-op when the user cancels the confirm', () => {
+    const clearStaging = vi.fn();
+    const api = makeStoreApi([sampleEdit], clearStaging);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(
+      <StoreProvider value={api}>
+        <StickyPushBar onPushChanges={() => undefined} />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByTestId('discard-button'));
+    expect(clearStaging).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 
   it('exposes data-state for variant styling (idle | conflict | success)', () => {

--- a/apps/backlog-navigator/src/styles/mobile.css
+++ b/apps/backlog-navigator/src/styles/mobile.css
@@ -176,8 +176,13 @@
     padding: 12px 16px calc(12px + env(safe-area-inset-bottom)) 16px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 8px;
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  .sticky-push-bar-count {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .sticky-push-bar[data-state='conflict'] {
@@ -192,6 +197,15 @@
     color: #1f1f1f;
     font-weight: 600;
     border: none;
+  }
+
+  .sticky-push-bar-discard {
+    min-height: 44px;
+    padding: 8px 12px;
+    border-radius: 4px;
+    background: transparent;
+    color: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.6);
   }
 
   /* ─── Discard-confirm modal (used by both editors) ──────────────────── */


### PR DESCRIPTION
## Summary
Added a "Discard All" button to the mobile sticky push bar that allows users to clear all pending edits with confirmation.

## Key Changes
- **StickyPushBar component**: Added a new discard button that calls `clearStaging()` after user confirmation via `window.confirm()`
- **Store API mock**: Updated `makeStoreApi()` test helper to accept an optional `clearStaging` callback parameter for better test control
- **Test coverage**: Added two new test cases:
  - Verify discard button calls `clearStaging` when user confirms the action
  - Verify discard button is a no-op when user cancels the confirmation dialog
- **Styling**: 
  - Changed sticky push bar layout from `justify-content: space-between` to `gap: 8px` for better spacing control
  - Added flex properties to `.sticky-push-bar-count` to allow it to grow and fill available space
  - Styled the new discard button with transparent background, white text, and a subtle border

## Implementation Details
- The discard action uses `window.confirm()` with a localized confirmation message from `strings.pending.confirmDiscard`
- The discard button includes proper accessibility with an `aria-label` that accounts for singular/plural edit counts
- The button is positioned before the main push button in the layout, with consistent spacing via flexbox gap

https://claude.ai/code/session_01CJApY45kXuKrJqnNCC7eKY