### PR TITLE
spec(281): UI review follow-up — remaining P1 &amp; all P2 fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ Only updated when a feature introduces a technology not already listed here.
 - TypeScript 5.x (strict), Node 20 runtime (VS Code extension host); React 18.x (renderer + panel) + `@debrief/components` (StoryboardPanel), `@debrief/stac-writer` (web-shell reads), `@debrief/schemas` (LinkML types — consumed, not changed), JSZip 3.10.1 (already present), VS Code Extension API ^1.85.0, `react-leaflet`/Leaflet (renderer map), Vite 5.x (web-shell + renderer) (273-storyboard-preview-button)
 - Python 3.11 (`generate.py` post-processor), TypeScript 5.x (generated types + consumers) — no new technology; extends the existing LinkML `gen-typescript` post-processor to emit `debrief:`-prefixed extension-property slot keys (256-prefix-aware-stac-typing)
 - TypeScript 5.x (strict; Article XV). No Python change. + `@debrief/stac-writer` (interface + core), `node:fs`/`node:crypto` (fs adaptor — existing), `idb` (web-shell adaptor — existing), `@debrief/schemas` (`FeatureCollection`, `StacItem`), VS Code Extension API (`window.showWarningMessage`). **No new runtime dependencies.** (268-save-atomicity)
+- TypeScript 5.x (strict mode, Article XV); React 18.x. No + `golden-layout` v2 (analysis + catalog layouts), (281-ui-review-p1-p2-fixes)
 
 ## Before Pushing
 
@@ -303,6 +304,6 @@ Each wrapper:
 Note: `vitest` does not catch TypeScript type errors — only `tsc` (run during typecheck) does. The `pnpm build` step also runs `tsc`, but typecheck is the explicit CI gate.
 
 ## Recent Changes
+- 281-ui-review-p1-p2-fixes: Added TypeScript 5.x (strict mode, Article XV); React 18.x. No + `golden-layout` v2 (analysis + catalog layouts),
 - 256-prefix-aware-stac-typing: One schema-driven step in the LinkML `gen-typescript` post-processor (`shared/schemas/scripts/generate.py`) rewrites modelled slot keys to their on-disk `debrief:` `slot_uri` across `StacExtensionProperties`, `StacSummaries`, and `StacAsset`, so the STAC writers' `props['debrief:*']` / `asset['debrief:toolId']` access sites gain typed slots on read **and** write (both hosts' write-path `props` re-typed to `StacItemProperties`). Models `debrief:toolId` + `debrief:snapshotTimestamp` as `StacAsset` slots (additive Pydantic regen); `debrief:label` excluded (feature/annotation key, not STAC). On-disk JSON unchanged; reuses the existing `src/generated` drift gate.
 - 268-save-atomicity: Added TypeScript 5.x (strict; Article XV). No Python change. + `@debrief/stac-writer` (interface + core), `node:fs`/`node:crypto` (fs adaptor — existing), `idb` (web-shell adaptor — existing), `@debrief/schemas` (`FeatureCollection`, `StacItem`), VS Code Extension API (`window.showWarningMessage`). **No new runtime dependencies.**
-- 267-tolerant-playhead-import: Relaxes spec-261 FR-018 strict-on-import for one recoverable case — orphaned playhead (out-of-window `current_time`) clamps to nearest window edge + non-blocking notification; incoherent window (`start>end`) still hard-fails. No schema change, no new dependency.

--- a/specs/281-ui-review-p1-p2-fixes/checklists/requirements.md
+++ b/specs/281-ui-review-p1-p2-fixes/checklists/requirements.md
@@ -1,0 +1,59 @@
+# Specification Quality Checklist: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## UI Feature Validation *(only if User Interface Flow section present)*
+
+- [x] Decision Analysis section completed with primary goal and key decisions
+- [x] Screen Progression table covers the happy path (at least 3 steps)
+- [x] UI States defined for empty, loading, error, and success conditions
+- [x] User decision inputs are identified (what information helps users decide)
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- **UI Feature Validation items only apply if the spec contains a "User Interface Flow" section**
+- Specs without UI sections should skip the UI Feature Validation checklist entirely
+
+### Validation outcome (2026-06-06)
+
+All checklist items pass on the first iteration. Specific notes:
+
+- **No [NEEDS CLARIFICATION] markers**: Every potentially-ambiguous decision had
+  a reasonable default available (WCAG AAA 7:1 target, ~280px / ~360–400px rail
+  bands, first-run "shown after first dataset" rule, persistence reuse). These
+  are documented in the Assumptions section rather than blocking on a question.
+- **Implementation-detail check**: File paths and component names surfaced during
+  reconnaissance were deliberately kept out of the spec body; they belong in
+  `plan.md`. The spec references surfaces (catalog, analysis view, header) and
+  outcomes only.
+- **Bounded scope**: An explicit "Out of Scope" section excludes all P3 items and
+  VS Code-host-specific layout, and a Context table lists exactly the six
+  in-scope review IDs.

--- a/specs/281-ui-review-p1-p2-fixes/contracts/module-contracts.md
+++ b/specs/281-ui-review-p1-p2-fixes/contracts/module-contracts.md
@@ -1,0 +1,118 @@
+# Module Contracts: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+This feature has **no network/API surface**. The relevant "contracts" are the
+TypeScript module interfaces that change. Each is listed with its current and
+target shape so the implementation and tests have a precise target.
+
+---
+
+## 1. `shared/components/src/PanelWorkspace/defaultLayout.ts`
+
+**Current**
+```ts
+export const DEFAULT_LAYOUT_CONFIG: LayoutConfig; // static 25% / 75%
+```
+
+**Target** (additive — keep the const for back-compat)
+```ts
+/**
+ * Build the default analysis-view layout for a given viewport width.
+ * Sidebar width is derived from a target px rail per band:
+ *   ≤1366px  → ~280px rail
+ *   ≥1600px  → ~360–400px rail
+ *   between  → interpolated
+ * Map always retains the majority of horizontal width.
+ */
+export function getDefaultLayout(viewportWidth: number): LayoutConfig;
+
+/** Back-compat default (≈ getDefaultLayout of a typical desktop width). */
+export const DEFAULT_LAYOUT_CONFIG: LayoutConfig;
+```
+
+**Invariants**
+- `sidebarWidthPct < contentWidthPct` for all `viewportWidth ≥ 1024`.
+- Pure function, no `window` access inside (caller passes width → testable).
+- No `any`; GL content typed via `LayoutItemConfig`.
+
+---
+
+## 2. `shared/components/src/PanelWorkspace/layoutPersistence.ts`
+
+**Current**
+```ts
+export const LAYOUT_VERSION: number;            // current
+export function loadLayout(): LayoutConfig | null;
+```
+
+**Target**
+```ts
+export const LAYOUT_VERSION: number;            // BUMPED — legacy layouts discarded
+// loadLayout() unchanged in signature; returns null for stale version
+```
+
+**Invariant**: `loadLayout()` MUST return `null` (not a stale config) when the
+persisted version != `LAYOUT_VERSION`, so `PanelWorkspace` applies
+`getDefaultLayout(...)`.
+
+---
+
+## 3. `shared/components/src/ActivityPanel/ActivityPanel.tsx`
+
+**Behavioural contract** (no prop signature change required if height is read
+internally; if a prop is preferred, add an optional one — must default to
+current behaviour):
+- When measured available height < threshold AND a feature is selected → upper
+  flexible sections collapse so the Properties section is visible.
+- When height ≥ ~900px → no adaptation.
+- Manual section toggles always win over the automatic adaptation.
+- Existing `data-testid`s preserved (no test breakage on the happy path).
+
+---
+
+## 4. `shared/components/src/ExerciseListView/ExerciseListView.tsx`
+
+**Behavioural contract**:
+- On `rowHeight` change (derived from `thumbnailSize`), the virtualizer MUST
+  re-measure (`virtualizer.measure()`), so rendered row heights change.
+- Thumbnail imagery dimensions MUST follow `THUMBNAIL_SIZE_CONFIGS[size]`
+  (raster/spatial), not only row height.
+- No prop signature change; `thumbnailSize` prop already exists.
+
+---
+
+## 5. `shared/components/src/StacBrowser/StacBrowser.tsx`
+
+**Behavioural contract**:
+- `thumbnailSize` state hydrates from a versioned `localStorage` key on mount and
+  writes on change (new persistence — additive).
+- The Timeline/Map collapse control is rendered with a discoverable label
+  (chevron + tooltip) and the restore control is equally visible.
+- First-run default (no saved layout): bottom row **shown** once a dataset
+  context exists; Reset Layout reapplies this.
+- Hidden-panel state continues to persist via `BROWSER_LAYOUT_KEY`.
+
+---
+
+## 6. `apps/web-shell/src/App.css` + `tokens.css`
+
+**Behavioural contract**:
+- `.web-shell__header-link` consumes a theme-aware link token whose HC-light
+  value yields ≥7:1 against the header background.
+- `[data-theme^='high-contrast'] .web-shell__header-link` adds underline +
+  heavier weight.
+- Light / dark / HC-dark header links remain legible (no regression).
+
+---
+
+## Test contracts (acceptance, machine-verifiable)
+
+| ID | Assertion | Where |
+|----|-----------|-------|
+| SC-001 | All HC-light header links measure ≥7:1 | `ui-review-contrast.spec.ts` (axe-core) |
+| SC-002 | properties-screenshots passes 10/10 first-attempt, retries off | `properties-screenshots.spec.ts` (+CI run config) |
+| SC-003 | ≥1600px: 0 truncated tool labels in activity column | `ui-review-layout.spec.ts` |
+| SC-004 | ≤1366px: sidebar ≈280px, map keeps majority | `ui-review-layout.spec.ts` |
+| SC-005 | 1280×720: Properties reachable with feature selected | `ui-review-layout.spec.ts` |
+| SC-006 | Collapse expands list; restore returns row; survives reload | `ui-review-catalog.spec.ts` |
+| SC-007 | S/M/L produce distinct row sizes; survives reload | `ui-review-catalog.spec.ts` |
+| SC-008 | No regression in resolved P1s / other surfaces | existing E2E suites green |

--- a/specs/281-ui-review-p1-p2-fixes/data-model.md
+++ b/specs/281-ui-review-p1-p2-fixes/data-model.md
@@ -1,0 +1,112 @@
+# Phase 1 Data Model: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+This feature has **no domain data model, no schema, and no persistence of
+plot/STAC data**. The only "entities" are client-side UI configuration and
+preference state held in component state and mirrored to `localStorage`. They are
+documented here for completeness and to pin down validation / version rules.
+
+---
+
+## Entity: Header link appearance (P1.3)
+
+Not a data entity — a **styling contract** expressed in CSS custom properties.
+
+| Token | Scope | Light | Dark | HC-light | HC-dark |
+|-------|-------|-------|------|----------|---------|
+| `--debrief-link-fg` (new or reused) | header links | existing link blue | existing link blue | **dark blue ≥7:1 on header bg** | existing HC-dark link |
+| link affordance | `.web-shell__header-link` | none/colour | none/colour | **underline + bolder weight** | **underline + bolder weight** |
+
+**Validation rule**: HC-light link contrast ratio against its rendered header
+background MUST be ≥ 7:1 (asserted by axe-core / contrast audit).
+
+---
+
+## Entity: Analysis-view layout configuration (P2.1 / P2.2)
+
+Held by `PanelWorkspace` (GoldenLayout `LayoutConfig`), persisted via
+`layoutPersistence` under `LAYOUT_STORAGE_KEY` with `LAYOUT_VERSION`.
+
+| Field | Type | Rule |
+|-------|------|------|
+| `sidebarWidthPct` (derived) | number (GL relative width) | computed from target px / viewport width; ~280px @ ≤1366, ~360–400px @ ≥1600, interpolated; map always retains majority (`contentWidthPct > sidebarWidthPct`) |
+| `LAYOUT_VERSION` | integer | bumped this feature so legacy fixed-25% layouts are discarded → responsive default applied |
+| saved layout | `LayoutConfig \| null` | when present **and** version-current → used verbatim (FR-011); else `getDefaultLayout(viewportWidth)` |
+
+**State transition (default resolution)**:
+```
+load → loadLayout()
+  ├─ null            → getDefaultLayout(viewportWidth)
+  ├─ stale version   → discard → getDefaultLayout(viewportWidth)
+  └─ current version → use saved layout verbatim
+Reset Layout        → getDefaultLayout(viewportWidth)  (ignores saved)
+```
+
+**ActivityPanel short-height adaptation (P2.2)** — derived UI state, not
+persisted:
+
+| Condition | Effect |
+|-----------|--------|
+| availableHeight < threshold (~720px-derived) AND feature selected | upper flex sections (Tools, then Layers) auto-collapsed so Properties visible |
+| availableHeight ≥ ~900px | no adaptation; all sections expanded |
+| user manually toggles a section | manual state wins (adaptation does not re-force) |
+
+---
+
+## Entity: Catalog layout / panel visibility (P2.3)
+
+Held by `StacBrowser`, persisted via `BROWSER_LAYOUT_KEY` (`BROWSER_LAYOUT_VERSION`).
+
+| Field | Type | Rule |
+|-------|------|------|
+| `hidden` panels | `Set<'timeline' \| 'map'>` | drives `buildLayoutForVisiblePanels`; persisted as part of saved GL layout |
+| bottom-row visibility (first run) | boolean | default **shown** once a dataset context exists; applied when no saved layout (FR-017) |
+| persisted layout | via `BROWSER_LAYOUT_KEY` | collapsed/restored state survives reload (FR-016) |
+
+**State transition**:
+```
+collapse control → add panel to hidden → rebuild layout → list expands → debounced save
+restore control  → remove panel from hidden → rebuild layout → row returns → debounced save
+reload           → restore hidden set from saved layout
+Reset Layout     → first-run default (row shown)
+```
+
+---
+
+## Entity: Thumbnail size preference (P2.4)
+
+Held by `StacBrowser` (`thumbnailSize` state), consumed by `ExerciseListView`.
+
+| Field | Type | Rule |
+|-------|------|------|
+| `thumbnailSize` | `'small' \| 'medium' \| 'large'` | drives `THUMBNAIL_SIZE_CONFIGS[size]` (raster/spatial dims + rowHeight) |
+| persistence key (new) | `localStorage` string, versioned | written on change, hydrated on mount (FR-020) |
+| virtualizer measurement | side-effect | `virtualizer.measure()` called when `rowHeight` changes so list re-flows (FR-018) |
+
+`THUMBNAIL_SIZE_CONFIGS` (existing, unchanged):
+
+| size | rasterW×H | spatialW×H | rowHeight |
+|------|-----------|------------|-----------|
+| small | 60×45 | 56×56 | 80 |
+| medium | 120×90 | 112×112 | 135 |
+| large | 180×135 | 168×168 | 190 |
+
+**State transition**:
+```
+click S/M/L → setThumbnailSize → persist → ExerciseListView re-render
+            → rowHeight changes → virtualizer.measure() → rows + thumbnails resize
+reload      → hydrate thumbnailSize from localStorage
+```
+
+---
+
+## Persistence keys summary
+
+| Key | Owner | Change in this feature |
+|-----|-------|------------------------|
+| `LAYOUT_STORAGE_KEY` / `LAYOUT_VERSION` | PanelWorkspace | **version bump** (discard legacy fixed split) |
+| `BROWSER_LAYOUT_KEY` / `BROWSER_LAYOUT_VERSION` | StacBrowser | unchanged (verify hidden-set persists) |
+| `SPLIT_STORAGE_KEY` | StacBrowser preview split | unchanged |
+| thumbnail-size key (NEW) | StacBrowser | **added**, versioned |
+
+All keys hold **UI preference state only** — no domain/plot data — consistent
+with existing patterns and outside Article IV.4.

--- a/specs/281-ui-review-p1-p2-fixes/evidence/opening-context.md
+++ b/specs/281-ui-review-p1-p2-fixes/evidence/opening-context.md
@@ -1,0 +1,26 @@
+## Hook
+
+| Before | After |
+|---|---|
+| Activity column truncates "Apply Symbol St…" in a fixed 25% rail | Tool names show in full; the rail widens on bigger screens, map keeps the majority |
+| At 1280×720 the Properties panel sits below the fold with no hint it's there | Short windows auto-collapse the upper sections so Properties is reachable |
+| The S/M/L thumbnail toggle does nothing on screen | Thumbnails actually resize, and the choice sticks between visits |
+| Catalog preview row hides behind a bare minus glyph | A labelled collapse/restore control with a sensible default and remembered state |
+| High-contrast light header links read faint and rely on colour alone | Header links route through a theme-aware token, underlined and weighted in high-contrast modes |
+
+## What We're Building
+
+This is follow-up work on the UI review we ran against the web-shell — the last two open P1 items and all four P2 items from the 2026-04-26 walk-through, re-checked on 2026-06-06. None of it is a new capability. It is the seams: the truncated tool name, the panel that hides below the fold at a common laptop resolution, the size toggle that quietly did nothing, the collapse control no one would guess was a control, and the high-contrast theme links that fell short of the WCAG AAA 7:1 bar and leaned on colour alone to signal "link".
+
+These all live on the two surfaces a first-time visitor judges us by — the catalog and the analysis view — plus the accessibility themes, which matter to a UK Defence audience where accessibility is a procurement concern rather than a nicety. Each fix is small. Together they remove the small frictions that make a tool feel unfinished, and they do it without adding a single runtime dependency.
+
+## How It Fits
+
+The fixes split between `apps/web-shell` (header markup and CSS, the Playwright specs that produce our before/after screenshots) and four reusable surfaces in `shared/components` — the panel-workspace default layout, the activity panel, the STAC browser, and the exercise list. Because the shared-component changes sit below the frontend boundary, the VS Code host picks them up transparently: fix the component once, both hosts benefit. That is the "thin frontends over shared components" arrangement working as intended — the host orchestrates, the component carries the behaviour.
+
+## Key Decisions
+
+- **No new runtime dependencies.** Every one of the six is a surgical change to code we already own. A polish pass should not grow the dependency tree.
+- **localStorage for preferences, not the writer abstraction.** Panel collapse state and thumbnail size are UI-preference state, local to a browser — not domain data — so they sit outside the writer-abstraction rule and persist via localStorage.
+- **Version the saved layout so it can't render broken.** The responsive default split replaces a fixed 25/75 layout, so a `LAYOUT_VERSION` bump invalidates any legacy saved layout rather than letting it restore into a broken render. No silent failure — that is Article I.
+- **Evidence-first, through the test suite.** The web-shell Playwright suite is the producer of the before/after screenshots, at multiple viewports and themes. Fixing the flaky `properties-screenshots` suite (P1.4) is part of the same job — a gate that fails ~2-in-13 on first attempt hides real regressions, so we add an actionability check before the row click instead of clicking and hoping.

--- a/specs/281-ui-review-p1-p2-fixes/plan.md
+++ b/specs/281-ui-review-p1-p2-fixes/plan.md
@@ -73,6 +73,26 @@ added/modified. No data-model or API surface.
 
 **No violations. No Complexity Tracking entries required.**
 
+## Review Decisions (`/speckit.review`, 2026-06-08)
+
+Binding decisions from the pre-tasks review. `/speckit.tasks` MUST encode these.
+
+| # | Area | Decision | Rationale (principle) |
+|---|------|----------|----------------------|
+| 1 | P2.1 default wiring | `DEFAULT_LAYOUT_CONFIG = getDefaultLayout(BASELINE_WIDTH)` — single panel-tree source. Switch **all three** `PanelWorkspace` call sites (parse-fail fallback, no-saved-layout, Reset Layout) to `getDefaultLayout(containerWidth)`. | DRY + minimal diff; Article XV. Prevents Reset Layout silently emitting the old fixed split (Article I). |
+| 2 | P2.2 collapse adaptation | Apply auto-collapse only as the **initial internal collapseState** when the panel is *uncontrolled* AND height < threshold. Never call `onCollapseStateChange` for it; manual toggles win and nothing is persisted. No-op when `collapseState` is controlled. | Article IV boundaries + Article I (no surprise / no silent persist). |
+| 3 | P2.1 width signal | Breakpoint keys off `containerRef.current.clientWidth` (the workspace container), **not** `window.innerWidth` — correct in the VS Code host where the workspace is narrower than the window. | Correctness across both hosts. |
+| 4 | P1.3 link colour | `.web-shell__header-link` consumes `var(--debrief-color-primary)` (already theme-aware, HC-light = `#0F4A85`) + underline/weight affordance in `[data-theme^='high-contrast']`. Add a dedicated darker token **only if** the 7:1 audit fails. | DRY + minimal diff. |
+| 5 | P2.4 thumbnail persistence | Small **typed read/write helper**, versioned like the sibling keys. On read, narrow to the `ThumbnailSize` union and fall back to `'small'` on any unexpected value. | Article XV.5 (validate untyped boundary) + Article I. |
+| 6 | Catalog `any` | Replace `const content: any[]` + `eslint-disable` in `buildLayoutForVisiblePanels` (`StacBrowser.tsx:200-201`) with the proper GoldenLayout item type while P2.3 is in this function. | Article XV (boy-scout at the edit site). |
+| 7 | P2.1 band logic | **Discrete bands**: ≤1366 → ~280 px rail; ≥1600 → ~360–400 px rail; in-between → one middle band. No continuous interpolation. | Explicit over clever; engineered-enough. |
+| 8 | P1.4 flake proof | Validate via the **10× no-retry loop**, AND configure CI to run the `properties-screenshots` suite at `retries: 0` so future flake fails loudly instead of being retried away. | Article VI (CI must catch regressions) + Article I. |
+| 9 | P2.2 invariant test | jsdom unit test: stub height < threshold → assert adaptation collapses Tools/Layers internally, **never** calls `onCollapseStateChange`, and is a no-op when `collapseState` is controlled. | Locks decision #2 against future silent-persist regression. |
+| 10 | P2.4 test layers | Unit-assert `virtualizer.measure()` fires on `rowHeight` change (spy) and that the persistence helper narrows bad input; E2E confirms visible S/M/L resize + reload. | Localise failures; don't rely on screenshot diff alone. |
+| 11 | Persistence test hygiene | Add `localStorage.clear()` to the setup/teardown of all persistence-touching unit suites (new thumbnail/layout specs + existing `ExerciseListView`/`ThumbnailSizeToggle`). | Prevent cross-test state bleed / flake. |
+| 12 | P2.4 measure gating | Call `virtualizer.measure()` only inside `useEffect(..., [rowHeight])` — never in the render path. | Avoid per-render re-measure thrash on a growing list. |
+| 13 | P2.1/P2.2 sampling | Read container `clientWidth`/`clientHeight` **once** at GL init and on Reset Layout. No continuous `ResizeObserver` re-flow (live re-flow on drag is out of scope). | Avoid forced-reflow cost for a non-requirement; matches spec 'correct on open'. |
+
 ## Project Structure
 
 ### Documentation (this feature)
@@ -138,11 +158,13 @@ involved.
   none`. In HC-light, `tokens.css` sets `--debrief-color-primary:
   var(--vscode-textLink-foreground, #0F4A85)` but the header link uses the raw
   VS Code var, not the Debrief token, and has no underline.
-- **Change**: introduce a theme-aware link token (e.g. `--debrief-link-fg` with
-  an HC override) consumed by `.web-shell__header-link`, and add an
-  underline + weight in HC modes (`[data-theme^='high-contrast'] .web-shell__header-link`).
-  Applied at the shared class/token level so all three links (and future ones)
-  inherit it (FR-003). Verify ≥7:1 against the HC-light header background.
+- **Change** (Decision #4): point `.web-shell__header-link` at the **existing**
+  theme-aware `var(--debrief-color-primary)` (HC-light = `#0F4A85`) rather than
+  inventing a new token, and add an underline + weight in HC modes
+  (`[data-theme^='high-contrast'] .web-shell__header-link`). Applied at the shared
+  class/token level so all three links (and future ones) inherit it (FR-003).
+  Verify ≥7:1 against the HC-light header background; **only if the audit fails**,
+  add a dedicated darker HC link token.
 - **Verify**: axe-core contrast audit in HC-light (SC-001) + visual evidence in
   all four themes (no regression, FR-004).
 
@@ -159,8 +181,11 @@ involved.
   actionability-aware `firstRow.click()` which already auto-waits. Keep the
   existing 15 s form-wait so genuine breakage still fails loudly (FR-007). Apply
   the same gate to the interaction-video test (lines 131-138).
-- **Verify**: 10 consecutive runs, retries disabled, 100% first-attempt pass
-  (SC-002). Note: this is a test-only change; no product behaviour changes.
+- **Verify** (Decision #8): 10 consecutive runs, retries disabled, 100%
+  first-attempt pass (SC-002). Additionally configure CI to run the
+  `properties-screenshots` suite at `retries: 0` so a future re-flake fails
+  loudly rather than being retried away. Note: this is a test-only change; no
+  product behaviour changes.
 
 ### P2.1 — Analysis layout scales to wide screens (US3)
 
@@ -168,16 +193,20 @@ involved.
   `DEFAULT_LAYOUT_CONFIG` with sidebar `width: 25` / content `width: 75`. A flat
   percentage gives an unpredictable px rail and doesn't honour the review's
   target px bands.
-- **Change**: replace the static export with a `getDefaultLayout(viewportWidth:
+- **Change**: replace the static export with a `getDefaultLayout(containerWidth:
   number): LayoutConfig` that computes the sidebar width *percentage* from a
-  target px width per band — ~280 px at ≤1366, growing to ~360–400 px at
-  ≥1600 (interpolated between) — clamped so the map always keeps the majority
-  (FR-010). Keep `DEFAULT_LAYOUT_CONFIG` as a back-compat default
-  (`getDefaultLayout(window.innerWidth)` equivalent) for existing importers.
-  `PanelWorkspace` calls the function when building the *fresh* default (only
-  when `loadLayout()` returns nothing or a stale version — FR-011). Bump
+  target px width using **discrete bands** (Decision #7): ≤1366 → ~280 px;
+  ≥1600 → ~360–400 px; in-between → one middle band — clamped so the map always
+  keeps the majority (FR-010). Derive `DEFAULT_LAYOUT_CONFIG =
+  getDefaultLayout(BASELINE_WIDTH)` so the panel tree has a single source
+  (Decision #1). Switch **all three** `PanelWorkspace` call sites — parse-fail
+  fallback, no-saved-layout, and **Reset Layout** — to call
+  `getDefaultLayout(containerWidth)`, where `containerWidth` is read **once**
+  from `containerRef.current.clientWidth` at GL init / reset (Decisions #3, #13),
+  not `window.innerWidth` (correct in the narrower VS Code host). Bump
   `LAYOUT_VERSION` so pre-existing fixed-25% saved layouts fall back to the
-  responsive default rather than persisting the old split.
+  responsive default rather than persisting the old split (FR-011 — saved custom
+  layouts still respected).
 - **Verify**: at ≥1600 the longest tool name renders without ellipsis (SC-003);
   at ≤1366 the rail is ~280 px and the map keeps the majority (SC-004); a saved
   custom layout is respected (FR-011).
@@ -188,13 +217,16 @@ involved.
   Properties stack vertically inside the Activity tab. At ~720 px tall the
   Properties section sits below the fold with no signal it exists; reaching it
   needs the user to know the column scrolls.
-- **Change**: add a height-conditional adaptation. Preferred approach
-  (confirmed in research): when the available activity-panel height is below a
-  threshold (~ derived from a 720 px viewport) **and** a feature is selected,
-  auto-collapse the upper flexible sections (Tools, and Layers if still needed)
-  so the Properties section is visible; the existing per-section collapse
-  primitive (`PaneSection`) is reused, so it remains manually overridable.
-  Adaptation is gated on available height (no effect ≥900 px — FR-013).
+- **Change** (Decision #2): add a height-conditional adaptation applied **only as
+  the initial internal `collapseState`** when the panel is *uncontrolled* AND the
+  available height (read once, `containerRef.clientHeight`, Decision #13) is below
+  a threshold (~derived from a 720 px viewport) AND a feature is selected — collapse
+  the upper flexible sections (Tools, and Layers if still needed) so Properties is
+  visible. It **must not** call `onCollapseStateChange` (nothing persisted, manual
+  toggles win) and **must be a no-op when `collapseState` is controlled**. The
+  existing per-section collapse primitive (`PaneSection`) is reused, so it remains
+  manually overridable. Adaptation is gated on available height (no effect ≥900 px
+  — FR-013).
 - **Verify**: at 1280×720 with a feature selected, Properties is visible/reachable
   without prior scroll knowledge (SC-005); at ≥900 px no adaptation forced.
 
@@ -212,7 +244,9 @@ involved.
   the hidden-panel state survives reload (it should via layout save — add a test
   to lock it in, FR-016). (c) Apply the agreed first-run default (bottom row
   **shown** once a dataset context exists; see Assumptions) when no saved layout
-  exists (FR-017). Reset Layout reapplies this default.
+  exists (FR-017). Reset Layout reapplies this default. (d) While editing this
+  function, replace its `const content: any[]` + `eslint-disable` with the proper
+  GoldenLayout item type (Decision #6, Article XV).
 - **Verify**: collapse expands the list and restore brings the row back, state
   survives reload (SC-006).
 
@@ -225,14 +259,18 @@ involved.
   caches item measurements and does **not** re-measure when `estimateSize`
   changes — so rows keep their old heights. Separately, `thumbnailSize` defaults
   to `'small'` and is **never persisted** (`StacBrowser.tsx:660`).
-- **Change**: (a) in `ExerciseListView`, call `virtualizer.measure()` in a
-  `useEffect` keyed on `rowHeight` so a size change re-flows the list (also
-  ensure the thumbnail imagery itself scales with the size config, not only row
-  height — FR-018). (b) persist `thumbnailSize` to `localStorage` (new key,
-  versioned alongside the others) and hydrate it on mount (FR-020). The toggle's
+- **Change**: (a) in `ExerciseListView`, call `virtualizer.measure()` **only**
+  inside `useEffect(..., [rowHeight])` (Decision #12 — never in the render path)
+  so a size change re-flows the list (also ensure the thumbnail imagery itself
+  scales with the size config, not only row height — FR-018). (b) persist
+  `thumbnailSize` via a **typed, versioned read/write helper** (Decision #5) that
+  narrows the stored value to the `ThumbnailSize` union on read and falls back to
+  `'small'` on anything unexpected; hydrate on mount (FR-020). The toggle's
   active-state indication already exists and is correct (FR-019).
-- **Verify**: S/M/L each produce a visibly distinct item size and the choice
-  survives reload (SC-007).
+- **Verify** (Decision #10): unit-assert `virtualizer.measure()` fires on
+  `rowHeight` change and that the persistence helper rejects bad input; E2E
+  confirms S/M/L each produce a visibly distinct item size and the choice survives
+  reload (SC-007).
 
 ## Media Components
 
@@ -273,7 +311,12 @@ behaviour, if a constrained-height story is added.
 **Testing Strategy**:
 - [x] Component renders correctly in theme variants
 - [x] Properties section visible/reachable under constrained height
+- [x] **Invariant unit test (Decision #9)**: height < threshold → adaptation
+  collapses Tools/Layers internally, never calls `onCollapseStateChange`, and is
+  a no-op when `collapseState` is controlled
 - [x] Accessibility attributes present (existing `data-testid`s reused)
+- [x] **`localStorage.clear()` in setup/teardown** for all persistence-touching
+  unit suites, incl. existing `ExerciseListView`/`ThumbnailSizeToggle` (Decision #11)
 - [x] Screenshots captured for evidence
 
 **Test File Location**: `shared/components/e2e/ActivityPanel.spec.ts` (only if a

--- a/specs/281-ui-review-p1-p2-fixes/plan.md
+++ b/specs/281-ui-review-p1-p2-fixes/plan.md
@@ -1,0 +1,312 @@
+# Implementation Plan: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+**Branch**: `281-ui-review-p1-p2-fixes` | **Date**: 2026-06-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/281-ui-review-p1-p2-fixes/spec.md`
+
+## Summary
+
+Six independent UI-quality fixes drawn from the 2026-04-26 UI review (re-walked
+2026-06-06): the two still-open P1 items and all four P2 items. Each is a small,
+surgical change to existing web-shell / shared-component code — no new runtime
+dependencies, no schema change, no service change. The work splits cleanly into
+four touch areas:
+
+1. **Theme tokens / CSS** (P1.3) — give web-shell header links a high-contrast
+   token + non-colour affordance so they meet WCAG AAA (7:1) in HC-light.
+2. **Playwright test reliability** (P1.4) — re-gate the `properties-screenshots`
+   spec so the row-click is preceded by an actionability wait, killing the flake.
+3. **GoldenLayout default layout** (P2.1, P2.2) — make the analysis-view default
+   split a function of viewport width, and make the Properties section reachable
+   at short heights.
+4. **Catalog StacBrowser** (P2.3, P2.4) — make the timeline+map collapse
+   discoverable + persisted + sensibly defaulted, and make the thumbnail S/M/L
+   toggle actually resize the list (virtualizer re-measure + preference
+   persistence).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode, Article XV); React 18.x. No
+Python change.
+**Primary Dependencies**: `golden-layout` v2 (analysis + catalog layouts),
+`@tanstack/react-virtual` (exercise-list virtualisation), `@debrief/components`
+(`PanelWorkspace`, `ActivityPanel`, `StacBrowser`, `ExerciseListView`,
+`ThumbnailSizeToggle`), web-shell `App.tsx`/`App.css`, `@playwright/test` +
+`@axe-core/playwright` (contrast audit). **No new runtime dependencies.**
+**Storage**: Browser `localStorage` for UI layout + view preferences (existing
+pattern — `BROWSER_LAYOUT_KEY`, `LAYOUT_STORAGE_KEY`/`LAYOUT_VERSION`,
+`SPLIT_STORAGE_KEY`). This is ephemeral UI state, not domain/plot data, so it is
+**not** subject to the Article IV.4 writer-abstraction rule.
+**Testing**: Vitest (unit — layout-builder + persistence pure functions),
+Playwright (web-shell E2E — flake fix, layout/viewport evidence, collapse +
+thumbnail behaviour, axe contrast audit), Storybook + Playwright (ActivityPanel
+short-height behaviour where applicable).
+**Target Platform**: Web-shell (browser SPA). Shared-component changes
+(`PanelWorkspace` default layout, `ActivityPanel`, `StacBrowser`,
+`ExerciseListView`) also benefit the VS Code host transparently, but no
+VS Code-host-specific layout work is in scope.
+**Project Type**: Web (frontend monorepo — pnpm workspaces).
+**Performance Goals**: No regression to the review's measured cold-load (<1.5 s
+analysis render); layout/preference changes must reflow without visible jank.
+**Constraints**: Offline-only (Article I); strict typing, no new `any` (Article
+XV); existing saved layouts must not break (graceful version handling).
+**Scale/Scope**: 4 touch areas, ~6 source files changed, ~4 test files
+added/modified. No data-model or API surface.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Article | Relevance | Status |
+|---------|-----------|--------|
+| I. Defence-Grade Reliability | All changes are offline, client-side. No network introduced. Saved-layout version handling avoids silent breakage. | ✅ Pass |
+| II. Schema Integrity | No schema touched. | ✅ N/A |
+| III. Data Sovereignty | No data transformation; no provenance surface affected. | ✅ N/A |
+| IV. Architectural Boundaries | Changes are frontend-only display/orchestration. `localStorage` use is **UI preference state** (layout, thumbnail size), not domain data — IV.4 writer-abstraction applies to plot/STAC writes, which are untouched. No new divergent persistence path for domain data. | ✅ Pass |
+| V. Extensibility | No extension surface changed. | ✅ N/A |
+| VI. Testing | Each story ships unit and/or E2E coverage; P1.4 *is* a test-reliability fix. Visual evidence captured. | ✅ Pass (planned) |
+| VII. Test-Driven AI Collaboration | Acceptance scenarios + success criteria are the executable definition of done; contrast audit and 10×-no-retry run are machine-verifiable. | ✅ Pass |
+| VIII. Documentation | Plan + research + quickstart; ADR not required (no architectural decision — all reuse existing patterns). Evidence + blog opener captured. | ✅ Pass |
+| IX. Dependencies | **No new runtime dependencies.** `@axe-core/playwright` already used by spec-/backlog-navigator E2E. | ✅ Pass |
+| X. Security | No secrets, no network. | ✅ N/A |
+| XI. Internationalisation | No new hard-coded user-facing strings beyond existing patterns; any new control labels (collapse/restore) use the same inline-string convention as the surrounding code (no i18n framework exists yet). | ✅ Pass (consistent) |
+| XV. Strict Type Safety | No new `any`. The catalog layout builder currently has one `eslint-disable @typescript-eslint/no-explicit-any` for GL content arrays; new code will use a typed `LayoutItemConfig[]` instead of widening that pattern. | ✅ Pass |
+
+**No violations. No Complexity Tracking entries required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/281-ui-review-p1-p2-fixes/
+├── plan.md              # This file
+├── research.md          # Phase 0 — root-cause findings & decisions per item
+├── data-model.md        # Phase 1 — UI state/config entities (no DB)
+├── quickstart.md        # Phase 1 — how to verify each fix
+├── contracts/
+│   └── module-contracts.md  # Changed module interfaces (layout fn, persistence keys, tokens)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+└── evidence/
+    ├── opening-context.md   # Cached blog opener (Phase 2)
+    └── screenshots/         # Captured by Playwright specs (FR-022)
+```
+
+### Source Code (repository root)
+
+```text
+apps/web-shell/
+├── src/
+│   ├── App.tsx                     # Header links markup (P1.3); analysis-view PanelWorkspace mount (P2.1/P2.2)
+│   └── App.css                     # .web-shell__header-link styling (P1.3)
+└── playwright/
+    └── tests/
+        ├── properties-screenshots.spec.ts   # P1.4 — re-gate the row-click
+        ├── ui-review-layout.spec.ts          # NEW — P2.1/P2.2 viewport evidence
+        ├── ui-review-catalog.spec.ts         # NEW — P2.3 collapse + P2.4 thumbnail evidence
+        └── ui-review-contrast.spec.ts        # NEW — P1.3 axe contrast audit (HC-light)
+
+shared/components/
+├── src/
+│   ├── PanelWorkspace/
+│   │   ├── defaultLayout.ts        # P2.1 — make default a fn of viewport width
+│   │   └── layoutPersistence.ts    # P2.1 — respect saved layout / version guard (verify)
+│   ├── ActivityPanel/
+│   │   └── ActivityPanel.tsx       # P2.2 — short-height adaptation (auto-collapse / reach Properties)
+│   ├── StacBrowser/
+│   │   ├── StacBrowser.tsx         # P2.3 collapse discoverability+persist; P2.4 thumbnail state persist
+│   │   └── ThumbnailSizeToggle.tsx # P2.4 — (likely unchanged; affordance only)
+│   ├── ExerciseListView/
+│   │   └── ExerciseListView.tsx    # P2.4 — virtualizer.measure() on rowHeight change
+│   └── styles/
+│       └── tokens.css              # P1.3 — HC link token (--debrief-link-hc or equivalent)
+└── e2e/                            # (optional) ActivityPanel short-height story test
+```
+
+**Structure Decision**: Pure frontend monorepo change. The fixes live in
+`apps/web-shell` (header markup/styling, mount point, Playwright specs) and
+`shared/components` (the four reusable surfaces: PanelWorkspace, ActivityPanel,
+StacBrowser, ExerciseListView). No new packages, no service or schema directory
+involved.
+
+## Implementation approach per item
+
+### P1.3 — HC-light header link contrast (US1)
+
+- **Current state**: `.web-shell__header-link` (App.css:81) uses
+  `color: var(--vscode-textLink-foreground, #3794ff)` with `text-decoration:
+  none`. In HC-light, `tokens.css` sets `--debrief-color-primary:
+  var(--vscode-textLink-foreground, #0F4A85)` but the header link uses the raw
+  VS Code var, not the Debrief token, and has no underline.
+- **Change**: introduce a theme-aware link token (e.g. `--debrief-link-fg` with
+  an HC override) consumed by `.web-shell__header-link`, and add an
+  underline + weight in HC modes (`[data-theme^='high-contrast'] .web-shell__header-link`).
+  Applied at the shared class/token level so all three links (and future ones)
+  inherit it (FR-003). Verify ≥7:1 against the HC-light header background.
+- **Verify**: axe-core contrast audit in HC-light (SC-001) + visual evidence in
+  all four themes (no regression, FR-004).
+
+### P1.4 — properties-screenshots flake (US2)
+
+- **Current state** (`properties-screenshots.spec.ts:96-105`): waits for
+  `exercise-list-item-row` to exist, then immediately `.first().click()`, then
+  waits for `properties-form`. The row is rendered inside a **virtualised** list
+  (TanStack) and the click can race list re-render / handler attachment — the
+  form-wait then times out intermittently.
+- **Change**: gate on the row being *actionable* before the click —
+  `await expect(firstRow).toBeVisible()` (and, if needed,
+  `await firstRow.scrollIntoViewIfNeeded()`) — and use Playwright's
+  actionability-aware `firstRow.click()` which already auto-waits. Keep the
+  existing 15 s form-wait so genuine breakage still fails loudly (FR-007). Apply
+  the same gate to the interaction-video test (lines 131-138).
+- **Verify**: 10 consecutive runs, retries disabled, 100% first-attempt pass
+  (SC-002). Note: this is a test-only change; no product behaviour changes.
+
+### P2.1 — Analysis layout scales to wide screens (US3)
+
+- **Current state** (`PanelWorkspace/defaultLayout.ts`): static
+  `DEFAULT_LAYOUT_CONFIG` with sidebar `width: 25` / content `width: 75`. A flat
+  percentage gives an unpredictable px rail and doesn't honour the review's
+  target px bands.
+- **Change**: replace the static export with a `getDefaultLayout(viewportWidth:
+  number): LayoutConfig` that computes the sidebar width *percentage* from a
+  target px width per band — ~280 px at ≤1366, growing to ~360–400 px at
+  ≥1600 (interpolated between) — clamped so the map always keeps the majority
+  (FR-010). Keep `DEFAULT_LAYOUT_CONFIG` as a back-compat default
+  (`getDefaultLayout(window.innerWidth)` equivalent) for existing importers.
+  `PanelWorkspace` calls the function when building the *fresh* default (only
+  when `loadLayout()` returns nothing or a stale version — FR-011). Bump
+  `LAYOUT_VERSION` so pre-existing fixed-25% saved layouts fall back to the
+  responsive default rather than persisting the old split.
+- **Verify**: at ≥1600 the longest tool name renders without ellipsis (SC-003);
+  at ≤1366 the rail is ~280 px and the map keeps the majority (SC-004); a saved
+  custom layout is respected (FR-011).
+
+### P2.2 — Properties reachable at 720-tall (US4)
+
+- **Current state** (`ActivityPanel.tsx`): Time Controller / Tools / Layers /
+  Properties stack vertically inside the Activity tab. At ~720 px tall the
+  Properties section sits below the fold with no signal it exists; reaching it
+  needs the user to know the column scrolls.
+- **Change**: add a height-conditional adaptation. Preferred approach
+  (confirmed in research): when the available activity-panel height is below a
+  threshold (~ derived from a 720 px viewport) **and** a feature is selected,
+  auto-collapse the upper flexible sections (Tools, and Layers if still needed)
+  so the Properties section is visible; the existing per-section collapse
+  primitive (`PaneSection`) is reused, so it remains manually overridable.
+  Adaptation is gated on available height (no effect ≥900 px — FR-013).
+- **Verify**: at 1280×720 with a feature selected, Properties is visible/reachable
+  without prior scroll knowledge (SC-005); at ≥900 px no adaptation forced.
+
+### P2.3 — Catalog timeline+map row collapsible & discoverable (US5)
+
+- **Current state** (`StacBrowser.tsx`): a per-panel **hide** button is injected
+  into the Timeline/Map GL headers, and filter-bar "+ Timeline"/"+ Map" restore
+  chips exist; `buildLayoutForVisiblePanels(hidden)` rebuilds the layout, and the
+  whole GL layout (including which panels are present) persists via
+  `BROWSER_LAYOUT_KEY`. So collapse/restore + persistence largely exist; the gap
+  is **discoverability** and a sensible **first-run default**.
+- **Change**: (a) make the collapse affordance obvious — a clearly-labelled
+  collapse control on the bottom row (e.g. a chevron with tooltip) rather than a
+  bare minus glyph; ensure the restore control is equally visible. (b) Confirm
+  the hidden-panel state survives reload (it should via layout save — add a test
+  to lock it in, FR-016). (c) Apply the agreed first-run default (bottom row
+  **shown** once a dataset context exists; see Assumptions) when no saved layout
+  exists (FR-017). Reset Layout reapplies this default.
+- **Verify**: collapse expands the list and restore brings the row back, state
+  survives reload (SC-006).
+
+### P2.4 — Thumbnail S/M/L toggle resizes the list (US6)
+
+- **Root cause** (confirmed): `ExerciseListView` *does* receive the new
+  `thumbnailSize` (the GL bridge re-renders the panel on context change,
+  `StacBrowser.tsx:770-778`) and recomputes `rowHeight`
+  (`ExerciseListView.tsx:53`), but the `@tanstack/react-virtual` virtualizer
+  caches item measurements and does **not** re-measure when `estimateSize`
+  changes — so rows keep their old heights. Separately, `thumbnailSize` defaults
+  to `'small'` and is **never persisted** (`StacBrowser.tsx:660`).
+- **Change**: (a) in `ExerciseListView`, call `virtualizer.measure()` in a
+  `useEffect` keyed on `rowHeight` so a size change re-flows the list (also
+  ensure the thumbnail imagery itself scales with the size config, not only row
+  height — FR-018). (b) persist `thumbnailSize` to `localStorage` (new key,
+  versioned alongside the others) and hydrate it on mount (FR-020). The toggle's
+  active-state indication already exists and is correct (FR-019).
+- **Verify**: S/M/L each produce a visibly distinct item size and the choice
+  survives reload (SC-007).
+
+## Media Components
+
+The change touches three reusable visual surfaces with existing Storybook
+stories. The most demonstrable for the blog post is the catalog thumbnail-size
+behaviour and the responsive analysis layout, but those are best shown via
+web-shell workflow screenshots (below) rather than isolated Storybook stories.
+The one component-level story worth bundling is the `ActivityPanel` short-height
+behaviour, if a constrained-height story is added.
+
+| Component | Story Source | Bundle Name | Purpose |
+|-----------|--------------|-------------|---------|
+| ActivityPanel (short-height) | `shared/components/src/ActivityPanel/ActivityPanel.stories.tsx` | `activity-panel.js` | Show Properties reachable at constrained height (P2.2) |
+
+**Inclusion Criteria Applied**:
+- [x] Significant visual change (P2.2 adaptation, P2.4 resize)
+- [ ] New visual component
+- [x] Interactive demo adds narrative value (thumbnail resize, collapse)
+
+**Bundleability Verified**:
+- [x] Stories exist in Storybook (ActivityPanel, StacBrowser, ExerciseListView)
+- [x] Components render standalone
+- [x] Reasonable bundle size expected (< 500KB)
+
+**Storybook Link**: `https://debrief.github.io/debrief-future/storybook/?path=/story/components-activitypanel`
+
+> Author confirmation: the primary blog narrative will lean on **web-shell
+> workflow screenshots** (catalog + analysis at multiple viewports/themes), with
+> the ActivityPanel story as an optional interactive aside. Confirm during
+> `/speckit.tasks` whether to add the constrained-height story.
+
+## Storybook E2E Testing
+
+| Story | Test Coverage | Theme Variants | Interactions |
+|-------|--------------|----------------|--------------|
+| `ActivityPanel.stories.tsx` (constrained height) | Properties section reachable at ~720px-equivalent height | light, dark | none (layout assertion) |
+
+**Testing Strategy**:
+- [x] Component renders correctly in theme variants
+- [x] Properties section visible/reachable under constrained height
+- [x] Accessibility attributes present (existing `data-testid`s reused)
+- [x] Screenshots captured for evidence
+
+**Test File Location**: `shared/components/e2e/ActivityPanel.spec.ts` (only if a
+constrained-height story is added; otherwise P2.2 is covered by the web-shell
+`ui-review-layout.spec.ts` at a real 1280×720 viewport).
+
+## Web-Shell E2E Testing
+
+This is the primary evidence path (FR-022). All in-scope behaviours are
+verifiable by driving the real web-shell at specific viewports/themes.
+
+| Workflow | Panels/Components Involved | Key Selectors | Interactions |
+|----------|---------------------------|---------------|--------------|
+| HC-light header contrast | header links | `.web-shell__header-link`, `[data-theme]` | set HC-light, run axe contrast, screenshot |
+| Properties row open (de-flaked) | StacBrowser list, properties slot | `[data-testid="exercise-list-item-row"]`, `[data-testid="properties-form"]` | gate→click→assert form, 10× |
+| Analysis layout scaling | PanelWorkspace, ActivityPanel, MapView | `[data-testid="panel-workspace"]`, activity tool labels, `.leaflet-container` | open plot at 1280/1440/1920, assert rail width + no tool-name truncation |
+| Properties reachable (720-tall) | ActivityPanel | activity sections, `[data-testid="properties-form"]` | open plot at 1280×720, select feature, assert Properties reachable |
+| Catalog row collapse | StacBrowser timeline/map | collapse/restore controls, `[data-testid="stac-browser-list"]` | collapse, assert list grows, reload, assert persisted |
+| Thumbnail resize | ExerciseListView | `[data-testid="thumbnail-size-{small,medium,large}"]`, `[data-testid="exercise-list-item-row"]` | click L/M/S, assert row height changes, reload, assert persisted |
+
+**Testing Strategy**:
+- [x] Workflows run end-to-end in the web-shell
+- [x] Page objects in `apps/web-shell/playwright/pages/` extended (reuse
+  `CatalogPage` / `AnalysisPage`) for new selectors rather than duplicating
+- [x] Screenshots written directly into `specs/281-ui-review-p1-p2-fixes/evidence/screenshots/`
+  following the path pattern in `properties-screenshots.spec.ts`
+
+**Test File Location**: `apps/web-shell/playwright/tests/ui-review-*.spec.ts`
+
+**Run Commands**:
+- Cloud: `cd apps/web-shell && node run-playwright.mjs ui-review-layout` (etc.)
+- Local: `pnpm --filter @debrief/web-shell test ui-review-layout`
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/281-ui-review-p1-p2-fixes/quickstart.md
+++ b/specs/281-ui-review-p1-p2-fixes/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Verifying the UI Review Follow-up Fixes
+
+How to build, run, and verify each of the six fixes. All steps are offline.
+
+## Prerequisites
+
+```sh
+# Build the shared workspace packages the web-shell depends on
+pnpm -r --filter '@debrief/utils' --filter '@debrief/schemas' \
+  --filter '@debrief/components' --filter '@debrief/session-state' \
+  --filter '@debrief/data' build
+```
+
+## Run the web-shell
+
+```sh
+cd apps/web-shell && pnpm dev      # http://localhost:5173
+```
+
+## Manual verification per item
+
+### P1.3 — HC-light header links
+1. Open the web-shell; switch the theme to **high-contrast light**.
+2. Look at the top-right links ("Component Storybook →", "VS Code Preview →",
+   "⚙ Edit Backlog →").
+3. **Expect**: clearly readable dark links with an underline; not faint blue on
+   near-white.
+
+### P2.1 — Wide-screen analysis layout
+1. Open a plot (e.g. a Saxon Warrior dataset) at a 1920×1080 window.
+2. **Expect**: the activity column shows full tool names (e.g. "Apply Symbol
+   Style") without truncation; the map keeps the majority of the width.
+3. Narrow the window to ~1280 and Reset Layout → the rail is ~280px, map keeps
+   the majority.
+
+### P2.2 — Properties at 720-tall
+1. Resize the window to ~1280×720, open a plot, select a feature.
+2. **Expect**: the Properties panel is visible/reachable without you having to
+   know the activity column scrolls (upper sections auto-collapse on short
+   screens).
+
+### P2.3 — Catalog timeline+map collapse
+1. On the catalog, find the clearly-labelled collapse control on the
+   timeline+map row; activate it.
+2. **Expect**: the row collapses and the exercise list expands. A visible restore
+   control brings it back. Reload → your choice is remembered.
+
+### P2.4 — Thumbnail size toggle
+1. On the catalog exercise list, click **L**, then **M**, then **S**.
+2. **Expect**: list items (thumbnail + row height) visibly change size at each
+   step. Reload → the chosen size is remembered.
+
+## Automated verification (Playwright — works in cloud sessions)
+
+```sh
+cd apps/web-shell
+
+# P1.4 — de-flaked properties screenshots (run repeatedly, retries off)
+node run-playwright.mjs properties-screenshots
+
+# P1.3 — HC-light contrast audit
+node run-playwright.mjs ui-review-contrast
+
+# P2.1 / P2.2 — layout scaling + Properties reachability at multiple viewports
+node run-playwright.mjs ui-review-layout
+
+# P2.3 / P2.4 — catalog collapse + thumbnail resize
+node run-playwright.mjs ui-review-catalog
+```
+
+Screenshots land in `specs/281-ui-review-p1-p2-fixes/evidence/screenshots/`.
+
+### Flake check (P1.4 — must be 10/10)
+```sh
+cd apps/web-shell
+for i in $(seq 1 10); do \
+  node run-playwright.mjs properties-screenshots || { echo "FAILED on run $i"; break; }; \
+done
+```
+
+## Unit tests
+
+```sh
+# Layout builder + persistence version guard
+pnpm --filter @debrief/components test -- defaultLayout
+pnpm --filter @debrief/components test -- layoutPersistence
+```
+
+## Full CI gate before pushing
+
+```sh
+task verify        # lint + typecheck + test (or the 4-step fallback in CLAUDE.md)
+```

--- a/specs/281-ui-review-p1-p2-fixes/research.md
+++ b/specs/281-ui-review-p1-p2-fixes/research.md
@@ -1,0 +1,193 @@
+# Phase 0 Research: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+This feature is bug/polish work against existing code, so "research" here is
+**root-cause confirmation** for each item plus the decision on the fix approach.
+All findings come from reading the current source on `main`/the feature branch.
+
+---
+
+## P1.3 — HC-light header link contrast
+
+**Decision**: Route `.web-shell__header-link` through a theme-aware link token
+and add a non-colour affordance (underline + weight) in high-contrast modes.
+
+**Rationale**:
+- `apps/web-shell/src/App.css:81-92` hard-codes
+  `color: var(--vscode-textLink-foreground, #3794ff)` with
+  `text-decoration: none`. It bypasses the Debrief token layer entirely.
+- `shared/components/src/styles/tokens.css:157-172` defines the HC-light
+  variant. `--debrief-color-primary` resolves to `#0F4A85` there, but the
+  header link never consumes it, and even `#0F4A85` on a near-white header may
+  not clear 7:1 depending on the actual header background.
+- WCAG AAA (7:1 for normal text) is the platform's stated HC bar (review P1.3).
+  Colour alone is also insufficient for link identification — an underline /
+  weight is the robust fix and auto-applies to future links (FR-003).
+
+**Alternatives considered**:
+- *Per-link inline styling* — rejected; violates FR-003 (future links wouldn't
+  inherit) and the constitution's preference for shared treatment.
+- *Bump the existing colour only* — rejected; the review explicitly asks for a
+  non-colour affordance, and a pure colour swap is fragile against header-bg
+  changes.
+
+---
+
+## P1.4 — properties-screenshots E2E flake
+
+**Decision**: Add an actionability gate (`expect(firstRow).toBeVisible()` +
+optional `scrollIntoViewIfNeeded()`) immediately before the row click in both
+the screenshot loop and the interaction-video test; keep the existing 15 s
+form-wait.
+
+**Rationale**:
+- `apps/web-shell/playwright/tests/properties-screenshots.spec.ts:96-105` waits
+  only for the row to *exist in the DOM*, then `.first().click()` immediately,
+  then waits for `properties-form`. The list is **virtualised**
+  (`ExerciseListView` uses `@tanstack/react-virtual`), so the row node can be
+  re-created / its click handler not yet attached at the moment of click — the
+  click is swallowed and the subsequent form-wait times out (the review's
+  observed ~2/13 flake). The wait gate is on the wrong event (form appearance
+  *after* the click) rather than row-readiness *before* it.
+- Gating on visibility lets Playwright's auto-waiting actionability checks settle
+  the virtualised row before clicking. This is the review's recommended two-line
+  fix and matches FR-006.
+
+**Alternatives considered**:
+- *Increase the form-wait timeout* — rejected; masks real breakage (FR-007) and
+  doesn't address the swallowed click.
+- *Disable virtualisation in test* — rejected; changes the thing under test and
+  is more invasive than the gate.
+
+---
+
+## P2.1 — Analysis layout scaling
+
+**Decision**: Replace the static `DEFAULT_LAYOUT_CONFIG` with a
+`getDefaultLayout(viewportWidth)` builder that computes the sidebar width as a
+percentage derived from a target px width per viewport band (~280 px ≤1366,
+~360–400 px ≥1600, interpolated between), clamped so the map keeps the majority.
+Bump `LAYOUT_VERSION` so legacy fixed-25% saved layouts fall back to the new
+default.
+
+**Rationale**:
+- `shared/components/src/PanelWorkspace/defaultLayout.ts:44-110` is a static
+  `row` with sidebar `width: 25` / content `width: 75`. A flat percentage gives
+  an unpredictable px rail and doesn't match the review's target bands; the
+  longest tool name ("Apply Symbol Style") truncates because the rail width is
+  not chosen against tool-label length.
+- GoldenLayout v2 sizes siblings by relative `width` numbers; computing the
+  sidebar percentage from `targetPx / viewportWidth` at build time gives a
+  px-accurate rail while staying within GL's percentage model (the review's
+  exact suggestion).
+- A `LAYOUT_VERSION` bump is the established mechanism
+  (`layoutPersistence.ts`) for invalidating stale persisted layouts safely
+  (Article I — no silent breakage).
+
+**Alternatives considered**:
+- *CSS `min-width` on the sidebar only* — rejected; GL controls panel sizing
+  imperatively, so CSS min-width fights the layout engine and doesn't set the
+  default split.
+- *Live ResizeObserver re-flow on every window resize* — deferred; the spec
+  requires correctness on open/reset only (Assumptions), and continuous re-flow
+  risks clobbering a user's manual resize. Can be a future enhancement.
+
+---
+
+## P2.2 — Properties reachable at 720-tall
+
+**Decision**: Add a height-conditional adaptation in `ActivityPanel` — when
+available height is below a ~720 px-derived threshold **and** a feature is
+selected, auto-collapse the upper flexible sections (Tools, then Layers) using
+the existing `PaneSection` collapse primitive so Properties becomes visible;
+no adaptation at ≥900 px.
+
+**Rationale**:
+- `ActivityPanel.tsx` stacks Time Controller (fixed), Tools (flex), Layers
+  (flex), Properties (fixed) vertically. At 720 px the Properties section falls
+  below the fold with no signal, so users miss it entirely (review P2.2).
+- The component already has per-section collapse (`PaneSection` toggles), so the
+  adaptation reuses an existing, user-overridable primitive rather than
+  introducing a new layout mode — lowest-risk, smallest surface.
+- Gating on available height (not a hard viewport media query) keeps the
+  behaviour correct when the panel is resized within a tall window (FR-013).
+
+**Alternatives considered**:
+- *Float Properties into a separate right-side dock* — rejected for this feature;
+  larger structural change, and the VS Code host mirrors this panel (out of
+  scope to diverge).
+- *Always-visible "scroll for more" chevron only* — viable but weaker; a passive
+  hint is less reliable than making Properties actually visible. May be added as
+  a complement.
+
+---
+
+## P2.3 — Catalog timeline+map collapsibility
+
+**Decision**: Treat as discoverability + first-run default + persistence
+verification. Keep the existing hide/restore machinery; make the collapse
+control obviously labelled (chevron + tooltip), ensure restore is equally
+visible, lock persistence with a test, and apply the agreed first-run default.
+
+**Rationale**:
+- `StacBrowser.tsx` already injects a per-panel **hide** button into Timeline/Map
+  GL headers (lines ~836+), exposes filter-bar restore chips, and rebuilds the
+  layout via `buildLayoutForVisiblePanels(hidden)` (lines 191-209). The whole GL
+  layout persists via `BROWSER_LAYOUT_KEY` (lines 121-122, 237-258), so a
+  collapsed row should already survive reload.
+- The review's complaint is that the collapse is **not discoverable** (a bare
+  minus glyph) and there's no deliberate first-run default — not that collapse is
+  absent. So the work is affordance + default + a regression test, not new
+  collapse logic. This keeps scope minimal (review status: "Unchanged" but
+  mechanism partly present).
+
+**Alternatives considered**:
+- *Build a brand-new collapsible panel system* — rejected; duplicates existing
+  capability. The review even notes "the Reset Layout button proves the panel
+  system supports it; expose the toggle."
+
+---
+
+## P2.4 — Thumbnail S/M/L toggle no-op
+
+**Decision**: Call `virtualizer.measure()` when `rowHeight` changes in
+`ExerciseListView`, ensure thumbnail imagery scales with the size config (not
+only row height), and persist `thumbnailSize` to `localStorage`.
+
+**Rationale**:
+- `ExerciseListView.tsx:53` reads `rowHeight` from
+  `THUMBNAIL_SIZE_CONFIGS[thumbnailSize]` and feeds it to the virtualizer's
+  `estimateSize` (lines 77-82). The toggle *does* propagate: `StacBrowser.tsx`
+  rebuilds `contextValue` with `thumbnailSize` in deps (line 767) and the GL
+  bridge re-renders the list panel on context change (lines 770-778). So the
+  prop reaches the component.
+- **The bug is the virtualizer**: `@tanstack/react-virtual` caches measured item
+  sizes and does **not** re-measure when the `estimateSize` function reference
+  changes — it keeps the old heights, so the list looks unchanged. Calling
+  `virtualizer.measure()` on `rowHeight` change resets the cache and re-flows.
+- Separately, `thumbnailSize` initialises to `'small'`
+  (`StacBrowser.tsx:660`) and is **never written to `localStorage`**, so FR-020
+  (persistence) is unmet. Add a versioned preference key + hydrate on mount.
+- `THUMBNAIL_SIZE_CONFIGS` already carries `rasterWidth/Height` +
+  `spatialWidth/Height` per size, so scaling the imagery is a matter of ensuring
+  the row renderer consumes those (they exist; verify they're applied — FR-018).
+
+**Alternatives considered**:
+- *Remove the toggle* (the review's fallback) — rejected; the capability is
+  desired and the fix is small.
+- *Replace virtualisation with plain rendering* — rejected; the list can be long
+  (11+ Saxon Warrior datasets and growing); virtualisation stays.
+
+---
+
+## Cross-cutting decisions
+
+- **No new runtime dependencies** (Article IX). `@axe-core/playwright` for the
+  P1.3 contrast audit is already a dev-dependency used by the spec-navigator and
+  backlog-navigator E2E suites.
+- **Persistence is UI-preference state**, not domain data — `localStorage` use
+  is consistent with existing layout/split persistence and outside Article IV.4.
+- **Saved-layout safety** (Article I): every default-changing item (P2.1, P2.3,
+  P2.4) must degrade gracefully for users with pre-existing persisted
+  state — version bumps / additive keys, never a silent broken render.
+- **Evidence-first** (Articles VI/VII): the Playwright specs are the producers of
+  the before/after screenshots that satisfy FR-022 and the blog post.

--- a/specs/281-ui-review-p1-p2-fixes/spec.md
+++ b/specs/281-ui-review-p1-p2-fixes/spec.md
@@ -1,0 +1,433 @@
+# Feature Specification: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+**Feature Branch**: `281-ui-review-p1-p2-fixes`
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: User description: "produce a plan to resolve the remaining P1 and all of the P2 issues identified in the UI review: docs/ui-review-2026-04-26.md"
+
+## Context
+
+The 2026-04-26 UI review (re-walked 2026-06-06) produced a prioritised punch
+list of fourteen findings. As of the 2026-06-06 re-review, three of the five
+P1 items are confirmed resolved on `main` (track symbology, properties dark
+theme, VS Code toast pile-up). This feature closes the **remaining two P1
+items** and **all four P2 items**. The P3 items are explicitly out of scope.
+
+In-scope findings (review IDs):
+
+| Review ID | Title | Surface | Review status |
+|-----------|-------|---------|---------------|
+| P1.3 | High-contrast LIGHT theme header links are below the contrast target | web-shell | Partially resolved — header re-skinned, link contrast still wants a fix/audit |
+| P1.4 | `properties-screenshots` E2E suite is flaky | E2E | Unchanged — open |
+| P2.1 | Default analysis-view split doesn't scale to wide screens | web-shell | Unchanged — open |
+| P2.2 | At 720-tall viewports the Properties panel is hidden below the fold | web-shell | Unchanged — open |
+| P2.3 | Catalog timeline + map preview row not (discoverably) collapsible | web-shell | Unchanged — open |
+| P2.4 | Thumbnail S/M/L size toggle has no visible effect | web-shell | Unchanged — open |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Readable header links in high-contrast light mode (Priority: P1)
+
+An analyst working in a bright environment (or with a vision-accessibility
+requirement) switches the web-shell to the high-contrast **light** theme. The
+header navigation links ("Component Storybook →", "VS Code Preview →", "Edit
+Backlog →") must be clearly readable against the near-white background, meeting
+the platform's accessibility commitment for its UK Defence audience.
+
+**Why this priority**: P1 — accessibility/contrast failures erode trust and can
+be a procurement blocker for the target audience. The review flags WCAG AAA in
+high-contrast mode as "non-negotiable."
+
+**Independent Test**: Switch to the high-contrast light theme and verify, by
+automated contrast measurement, that every header link meets the contrast
+target against its background; confirm visually that links are distinguishable
+as links (not just coloured text).
+
+**Acceptance Scenarios**:
+
+1. **Given** the web-shell in high-contrast light theme, **When** the header is
+   rendered, **Then** each header link's text-to-background contrast ratio is at
+   least 7:1 (WCAG AAA for normal-size text).
+2. **Given** the high-contrast light theme, **When** a user views the header
+   links, **Then** each link carries a non-colour affordance (underline and/or
+   bolder weight) so it is identifiable as a link without relying on colour
+   alone.
+3. **Given** any of the four shipped themes (light, dark, high-contrast light,
+   high-contrast dark), **When** the header links are rendered, **Then** all
+   links remain legible (no regression introduced by the high-contrast fix).
+4. **Given** a future header link is added to the same group, **When** it is
+   rendered in high-contrast light mode, **Then** it inherits the same readable
+   treatment automatically (the fix is applied at the shared link/token level,
+   not per-link).
+
+---
+
+### User Story 2 - Reliable properties-screenshots E2E run (Priority: P1)
+
+A developer runs the `properties-screenshots` E2E suite as part of CI or a
+pre-push check. The suite must pass deterministically on the first attempt, so
+that a real regression in the properties form (for any feature type) is caught
+rather than masked by retry-passing flake.
+
+**Why this priority**: P1 — a flaky gate hides real regressions. The review
+notes a ~2/13 first-attempt failure rate, which means a properties regression
+affecting one feature type could slip through unnoticed.
+
+**Independent Test**: Run the properties-screenshots suite repeatedly (e.g. 10
+consecutive runs) with no retries permitted, and confirm a 100% first-attempt
+pass rate.
+
+**Acceptance Scenarios**:
+
+1. **Given** the properties-screenshots suite, **When** it is run 10 times
+   consecutively with retries disabled, **Then** it passes on the first attempt
+   every time.
+2. **Given** a row is clicked to open the properties form, **When** the test
+   proceeds, **Then** it waits for the correct, reliably-present anchor element
+   *before* the click that opens the form, rather than waiting for the form
+   itself in a way that races the click.
+3. **Given** the properties form genuinely fails to render after a row click,
+   **When** the test runs, **Then** it fails with a clear, actionable assertion
+   (the fix must not paper over real breakage by simply extending timeouts).
+
+---
+
+### User Story 3 - Analysis layout uses wide-screen space well (Priority: P2)
+
+An analyst on a typical 1920×1080 display opens a plot in the analysis view.
+The activity column (Time Controller, Tools, Layers, Properties) must be wide
+enough to show its longest tool names (e.g. "Apply Symbol Style") without
+truncation, while the map still gets the majority of the space. On narrower
+displays (≤1366 wide) the activity column must not steal space the map needs.
+
+**Why this priority**: P2 — wasted/awkward space at the analyst's most common
+resolution lowers perceived polish but does not block core tasks.
+
+**Independent Test**: Open the analysis view at 1280, 1440, and 1920 widths and
+verify the activity column width adapts to the viewport band and that tool names
+are fully visible at the wide band.
+
+**Acceptance Scenarios**:
+
+1. **Given** a viewport ≥1600px wide, **When** the analysis view opens with its
+   default layout, **Then** the activity column is wide enough that the longest
+   tool name is fully visible without truncation or ellipsis.
+2. **Given** a viewport ≤1366px wide, **When** the analysis view opens with its
+   default layout, **Then** the activity column stays compact (around a 280px
+   rail) so the map retains usable space.
+3. **Given** a user has previously customised and saved the layout, **When**
+   they reopen the analysis view, **Then** their saved layout is respected (the
+   responsive default applies only when no saved layout exists or the layout is
+   reset).
+4. **Given** any supported viewport width, **When** the default layout is
+   applied, **Then** the map retains the majority share of horizontal space.
+
+---
+
+### User Story 4 - Properties panel is discoverable on short laptops (Priority: P2)
+
+An analyst on a 1280×720 laptop opens a plot. They must be able to discover and
+reach the Properties panel without realising on their own that the activity
+column scrolls — i.e. there is a clear affordance that more content exists below
+the fold, or the layout adapts so Properties is reachable.
+
+**Why this priority**: P2 — a user may not realise a Properties panel exists at
+all on a short screen, which hides a whole capability, but it is reachable for
+users who know to scroll.
+
+**Independent Test**: Open the analysis view at 1280×720, select a feature, and
+verify that the Properties panel is either visible or its presence is clearly
+signalled (and reachable) without prior knowledge that the column scrolls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a 720px-tall viewport with a feature selected, **When** the
+   analysis view is shown, **Then** the user can reach the Properties panel
+   through a discoverable affordance (e.g. auto-collapsed upper sections, a
+   visible scroll/"more below" hint, or a relocated Properties surface).
+2. **Given** a 720px-tall viewport, **When** a feature is selected, **Then** the
+   selected feature's properties are surfaced without the user needing to know
+   in advance that the activity column is scrollable.
+3. **Given** a taller viewport (≥900px) where everything already fits, **When**
+   the analysis view is shown, **Then** no short-viewport adaptation is forced
+   (the adaptation is conditional on available height).
+
+---
+
+### User Story 5 - Catalog timeline + map row is discoverably collapsible (Priority: P2)
+
+A user browsing the catalog with a long exercise list wants to reclaim the
+vertical space taken by the bottom timeline + map preview row. They must be able
+to collapse that row (and restore it) through a discoverable control, so a tall
+list is not forced into a small scroll area while half the screen shows a sparse
+timeline.
+
+**Why this priority**: P2 — the row consumes ~50% of vertical estate while often
+conveying little; reclaiming it is a meaningful quality-of-life gain but the
+catalog is usable without it.
+
+**Independent Test**: From the catalog, collapse the timeline + map row via a
+discoverable control, confirm the exercise list expands into the reclaimed
+space, then restore the row.
+
+**Acceptance Scenarios**:
+
+1. **Given** the catalog with the timeline + map row visible, **When** the user
+   activates a clearly-visible collapse control on the row, **Then** the row
+   collapses and the exercise list expands to use the reclaimed vertical space.
+2. **Given** the row is collapsed, **When** the user looks for a way to bring it
+   back, **Then** a clearly-visible restore control is present and restores the
+   row.
+3. **Given** a first-time user with no saved catalog layout, **When** the
+   catalog first loads, **Then** the default visibility of the bottom row
+   follows the agreed first-run default (see Assumptions) and is remembered
+   thereafter.
+4. **Given** the user has collapsed or restored the row, **When** they reload
+   the catalog, **Then** their choice is remembered.
+
+---
+
+### User Story 6 - Thumbnail S/M/L toggle visibly resizes the list (Priority: P2)
+
+A user in the catalog clicks the S / M / L thumbnail-size toggle to make the
+exercise-list thumbnails larger or smaller. The change must be immediately
+visible — both the thumbnail imagery and the row sizing must respond — so the
+control is honest about what it does.
+
+**Why this priority**: P2 — a half-wired control is "worse than no control"
+(review). It undermines confidence in the whole catalog surface.
+
+**Independent Test**: In the catalog, click S, then M, then L, and verify that
+the exercise-list items visibly change size (thumbnail and row) at each step.
+
+**Acceptance Scenarios**:
+
+1. **Given** the catalog exercise list, **When** the user selects "L", **Then**
+   the list items (thumbnail and row height) become visibly larger than at "M".
+2. **Given** the catalog exercise list, **When** the user selects "S", **Then**
+   the list items become visibly smaller than at "M".
+3. **Given** the user has chosen a thumbnail size, **When** the catalog is
+   reloaded, **Then** the chosen size is remembered.
+4. **Given** the toggle is shown, **When** the user inspects it, **Then** the
+   currently-active size is clearly indicated and matches the rendered list
+   size.
+
+---
+
+### Edge Cases
+
+- **No saved layout vs. stale saved layout**: When a stored layout predates the
+  responsive-default change (older layout version), the responsive default
+  should apply rather than a broken legacy split.
+- **Reset Layout**: Pressing "Reset Layout" must reapply the new responsive
+  default (US3/US4) and the agreed first-run state for the catalog bottom row
+  (US5), not the old fixed defaults.
+- **Resize across breakpoints mid-session**: Behaviour when a window is dragged
+  from a narrow band to a wide band — the spec requires the *default* to be
+  correct on open; live re-flow on drag is desirable but not required (see
+  Assumptions).
+- **High-contrast dark links**: The contrast fix for high-contrast light must
+  not regress high-contrast dark, dark, or light header links.
+- **Thumbnail toggle with missing thumbnails**: When an exercise has no
+  thumbnail image, selecting a larger size must still resize the row
+  consistently (placeholder scales too) without layout breakage.
+- **Collapsed row with empty catalog**: Collapsing the bottom row when the
+  exercise list is empty must not leave an unusable blank screen.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**P1.3 — High-contrast light header link contrast**
+
+- **FR-001**: In the high-contrast light theme, every header navigation link
+  MUST meet a text-to-background contrast ratio of at least 7:1 (WCAG AAA for
+  normal-size text).
+- **FR-002**: Header links in high-contrast modes MUST carry a non-colour
+  affordance (underline and/or bolder weight) identifying them as links.
+- **FR-003**: The contrast fix MUST be applied at the shared link/theme-token
+  level so that newly-added header links inherit the readable treatment without
+  per-link styling.
+- **FR-004**: The fix MUST NOT reduce legibility of header links in the light,
+  dark, or high-contrast dark themes.
+
+**P1.4 — properties-screenshots E2E reliability**
+
+- **FR-005**: The properties-screenshots E2E suite MUST pass on the first
+  attempt across 10 consecutive runs with retries disabled.
+- **FR-006**: The suite MUST gate on a reliably-present anchor element before the
+  row-click that opens the properties form, rather than racing the form's own
+  appearance.
+- **FR-007**: The fix MUST preserve the suite's ability to fail loudly when the
+  properties form genuinely does not render (no masking real breakage by
+  blanket timeout increases).
+
+**P2.1 / P2.2 — Analysis-view layout scaling and Properties discoverability**
+
+- **FR-008**: When no saved analysis-view layout exists (or after Reset Layout),
+  the default activity-column width MUST scale with viewport width: compact
+  (~280px) at ≤1366px wide and wider (~360–400px) at ≥1600px wide.
+- **FR-009**: At the wide band, the activity column MUST be wide enough to show
+  the longest tool name without truncation.
+- **FR-010**: At every supported width, the map MUST retain the majority share
+  of horizontal space.
+- **FR-011**: A user's previously-saved layout MUST be respected; the responsive
+  default applies only when no valid saved layout is present.
+- **FR-012**: At short viewports (~720px tall), the Properties panel MUST be
+  reachable through a discoverable affordance without the user needing prior
+  knowledge that the activity column scrolls.
+- **FR-013**: The short-viewport adaptation MUST be conditional on available
+  height (not applied when everything already fits, e.g. ≥900px tall).
+
+**P2.3 — Catalog timeline + map row collapsibility**
+
+- **FR-014**: The catalog MUST provide a clearly-visible control to collapse the
+  bottom timeline + map preview row, reclaiming its vertical space for the
+  exercise list.
+- **FR-015**: The catalog MUST provide a clearly-visible control to restore the
+  bottom row after it has been collapsed.
+- **FR-016**: The collapsed/restored state of the bottom row MUST persist across
+  catalog reloads.
+- **FR-017**: The first-run default visibility of the bottom row MUST follow the
+  agreed default (see Assumptions) and be applied when no saved catalog layout
+  exists.
+
+**P2.4 — Thumbnail size toggle**
+
+- **FR-018**: Selecting S, M, or L in the thumbnail-size toggle MUST produce an
+  immediately visible change in exercise-list item size (both thumbnail imagery
+  and row sizing).
+- **FR-019**: The toggle MUST clearly indicate the currently-active size, and
+  that indication MUST match the rendered list size.
+- **FR-020**: The chosen thumbnail size MUST persist across catalog reloads.
+
+**Cross-cutting**
+
+- **FR-021**: All changes MUST preserve existing functionality (no regression to
+  the now-resolved P1 items — track symbology, properties dark theme, VS Code
+  toasts — nor to the catalog filter bar, storyboard, or log panel surfaces).
+- **FR-022**: Visual evidence (screenshots) MUST be captured for each in-scope
+  finding demonstrating the before/after state at the relevant viewport(s) and
+  theme(s).
+
+### Key Entities
+
+- **Theme tokens**: The set of colour/affordance variables that drive header
+  link appearance per theme variant; the unit changed for P1.3.
+- **Analysis-view layout configuration**: The default and persisted panel split
+  (activity column vs map) for the analysis view; the unit changed for P2.1/P2.2.
+- **Catalog layout configuration**: The default and persisted visibility/size of
+  the catalog's exercise list, timeline, and map panels; the unit changed for
+  P2.3.
+- **Thumbnail size preference**: The S/M/L selection and its mapping to list
+  item rendering; the unit changed for P2.4.
+
+## User Interface Flow
+
+### Decision Analysis
+
+- **Primary Goal**: Make the web-shell's first-impression surfaces (catalog and
+  analysis view) read as polished and trustworthy at the analyst's real
+  viewports and in accessibility themes.
+- **Key Decision(s)**:
+  1. (Analyst) How much screen space to give the activity column vs the map —
+     the responsive default should make a good first choice on the user's
+     behalf, with manual override preserved.
+  2. (Analyst) Whether to keep the catalog's timeline + map preview visible, or
+     reclaim that space for a long exercise list.
+  3. (Analyst) How large to render exercise-list thumbnails (S / M / L).
+- **Decision Inputs**: Current viewport size, whether a saved layout exists,
+  the length of the exercise list, the longest tool name, and the active theme.
+
+### Screen Progression
+
+| Step | Screen/State | User Action | Result |
+|------|--------------|-------------|--------|
+| 1 | Catalog cold start (no saved layout) | Open the web-shell | Bottom row shown/collapsed per first-run default; thumbnails at default size; layout fits viewport |
+| 2 | Catalog | Click the timeline+map collapse control | Row collapses; exercise list expands into reclaimed space; choice remembered |
+| 3 | Catalog | Click S / M / L thumbnail toggle | Exercise-list items visibly resize; active size indicated; choice remembered |
+| 4 | Analysis view at ≥1600px wide | Open a plot | Activity column widens enough to show full tool names; map keeps the majority |
+| 5 | Analysis view at 1280×720 | Select a feature | Properties panel is discoverable/reachable without hidden-scroll knowledge |
+| 6 | High-contrast light theme | View header | Header links are clearly readable (≥7:1) and identifiable as links |
+
+### UI States
+
+- **Empty State**: Catalog with no exercises — collapse/restore and thumbnail
+  controls remain coherent; no blank unusable screen when the bottom row is
+  collapsed.
+- **Loading State**: Existing loading affordances unchanged; layout defaults
+  apply once content is available.
+- **Error State**: If a saved layout is invalid/stale, the responsive default is
+  applied silently rather than rendering a broken split.
+- **Success State**: At each common viewport and in each theme, the catalog and
+  analysis view read as intentionally laid out — no truncated tool names, no
+  hidden Properties panel, no half-wired controls, no low-contrast links.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of header links in the high-contrast light theme measure ≥7:1
+  contrast against their background (automated audit).
+- **SC-002**: The properties-screenshots E2E suite passes on the first attempt
+  in 10/10 consecutive runs with retries disabled.
+- **SC-003**: At ≥1600px wide, the longest tool name in the activity column is
+  fully visible (0 truncated/ellipsised tool labels) in the default layout.
+- **SC-004**: At ≤1366px wide, the default activity column occupies roughly a
+  280px rail and the map retains the majority of horizontal width.
+- **SC-005**: At 1280×720 with a feature selected, a first-time user can reach
+  the Properties panel without being told the column scrolls (verified in
+  usability walkthrough / captured evidence).
+- **SC-006**: A user can collapse and restore the catalog timeline + map row
+  using on-screen controls, and the state survives a reload (verified by
+  reload).
+- **SC-007**: Selecting each of S/M/L produces a visibly distinct exercise-list
+  item size, and the chosen size survives a reload.
+- **SC-008**: No regression in the previously-resolved P1 items or other
+  catalog/analysis surfaces (existing E2E + visual evidence confirm parity).
+
+## Assumptions
+
+- **Scope boundary**: Only the remaining P1 items (P1.3, P1.4) and all P2 items
+  (P2.1–P2.4) are in scope. The P3 items (#10–#15 in the revised punch list,
+  including the new read-only-banner observation) are explicitly out of scope.
+- **P1.1/P1.2/P1.5/P1.6 are already resolved** on `main` and are not revisited
+  except to guard against regression (FR-021).
+- **P1.4 surface**: The flaky suite is the web-shell `properties-screenshots`
+  Playwright spec; the fix is a test-reliability fix (wait-gate), not a product
+  behaviour change.
+- **P2.3 partial existing mechanism**: A per-panel hide control and filter-bar
+  restore affordance already exist for the catalog timeline/map panels. This
+  feature treats P2.3 as a *discoverability + default + persistence* problem
+  (make the collapse obvious, pick a sensible first-run default, remember the
+  choice) rather than building collapse from scratch.
+- **P2.4 root cause**: The toggle already drives an internal row-height value but
+  does not visibly change the list; this feature treats P2.4 as ensuring the
+  selection is actually applied and visible (thumbnail + row), not merely adding
+  a new control.
+- **First-run default for catalog bottom row**: Default **shown** once a dataset
+  context exists, matching the review's "default open after the first dataset is
+  loaded" suggestion; a first-time empty catalog may default collapsed. The
+  precise first-run rule can be refined in planning but must satisfy FR-017.
+- **Responsive default timing**: The responsive layout default must be correct
+  *on open / reset*. Live re-flow when dragging a window across breakpoints is
+  desirable but not a hard requirement for this feature.
+- **Contrast target**: 7:1 (WCAG AAA, normal text) is the bar for high-contrast
+  modes, per the review's stated commitment.
+- **Persistence mechanism**: Layout and preference persistence reuses the
+  existing per-surface saved-layout/preference storage already in place; no new
+  cross-device sync is introduced.
+- **Surfaces**: All in-scope items are web-shell / shared-component changes.
+  P2.1/P2.2 layout improvements benefit the VS Code host only insofar as it
+  reuses the same shared components; VS Code-specific layout is not in scope.
+
+## Out of Scope
+
+- All P3 items: double `+` map icons (#10), active-vs-disabled tool affordance
+  (#11), LOG-tab discoverability (#12), filter-type picker grouping (#13),
+  VS Code boot loading-state consistency (#14), and the read-only-banner noise
+  observation (#15).
+- VS Code-host-specific layout, profiles, or toasts (the P1.5 toast work is
+  already done).
+- Any change to the symbology pipeline, theming engine internals beyond the
+  header-link token, or the catalog filter system.

--- a/specs/281-ui-review-p1-p2-fixes/tasks.md
+++ b/specs/281-ui-review-p1-p2-fixes/tasks.md
@@ -1,0 +1,265 @@
+# Tasks: UI Review Follow-up — Remaining P1 & All P2 Fixes
+
+**Feature**: `281-ui-review-p1-p2-fixes` | **Branch**: `claude/pensive-cerf-XEoXN`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+> Six independent UI-quality fixes (2 remaining P1, all 4 P2). Each user story is
+> independently testable and shippable. The 13 binding decisions from
+> `/speckit.review` (see plan.md → **Review Decisions**) are encoded inline below
+> and referenced as `[Decision #N]`.
+
+> **⚠️ PLAYWRIGHT WORKS IN CLOUD SESSIONS** — Do NOT skip or omit Playwright E2E
+> tasks because you think browsers can't be installed. The project bundles
+> `@sparticuz/chromium` via npm. Standard browser CDN downloads are blocked (403),
+> but the bundled binary works fully. Run
+> `cd apps/web-shell && node run-playwright.mjs <spec-basename>` to extract and
+> configure. Full details: `docs/project_notes/playwright-installation-research.md`.
+
+## Evidence Requirements
+
+**Evidence Directory**: `specs/281-ui-review-p1-p2-fixes/evidence/`
+**Media Directory**: `specs/281-ui-review-p1-p2-fixes/media/`
+
+### Planned Artifacts
+
+| Artifact | Description | Captured When |
+|----------|-------------|---------------|
+| test-summary.md | Vitest + Playwright results (unit + E2E), YAML front matter | After all tests pass |
+| usage-example.md | How each fix manifests for an analyst (per-item walkthrough) | After all stories complete |
+| screenshots/header-hc-light.png | Header links in HC-light, post-fix (P1.3) | After US1 |
+| screenshots/analysis-1920.png | Analysis layout at 1920 — full tool names, map majority (P2.1) | After US3 |
+| screenshots/analysis-1366.png | Analysis layout at ≤1366 — ~280px rail (P2.1) | After US3 |
+| screenshots/properties-720.png | Properties reachable at 1280×720 (P2.2) | After US4 |
+| screenshots/catalog-collapse.png | Catalog bottom row collapsed, list expanded (P2.3) | After US5 |
+| screenshots/thumbnail-sizes.png | S/M/L exercise rows side-by-side (P2.4) | After US6 |
+| screenshots/interaction.gif | Catalog collapse + thumbnail resize flow (<5s, <2MB) | After US5/US6 |
+| flake-proof.txt | 10× no-retry run output for properties-screenshots (P1.4, SC-002) | After US2 |
+
+### Media Content
+
+| Artifact | Description | Created When |
+|----------|-------------|--------------|
+| evidence/opening-context.md | Cached opener (What We're Building, How It Fits, Key Decisions) | ✅ During /speckit.plan |
+| media/shipped-post.md | Feature post combining cached opener + ship-time evidence | Polish phase |
+
+### PR Creation
+
+| Action | Description | Created When |
+|--------|-------------|--------------|
+| Feature PR | PR #667 in debrief-future (already open — updated with evidence) | Final task |
+| Blog PR | PR in debrief.github.io with shipped-post.md | Triggered by /speckit.pr |
+
+## Phase 1: Setup & Test Infrastructure
+
+**Goal**: Prepare shared test scaffolding before touching product code. No product behaviour changes here.
+
+- [ ] T001 [P] Add `thumbnail-size-{small,medium,large}` and bottom-row collapse/restore selectors to the catalog page object `apps/web-shell/playwright/pages/CatalogPage.ts`
+- [ ] T002 [P] Add activity-column rail-width + tool-label and Properties-reachability helpers to the analysis page object `apps/web-shell/playwright/pages/AnalysisPage.ts`
+- [ ] T003 [P] Add `.web-shell__header-link` + `[data-theme]` switch helpers to the Stac browser page object `apps/web-shell/playwright/pages/StacBrowserPage.ts`
+
+**Parallel**: T001, T002, T003 touch different page-object files — run together.
+
+## Phase 2: Foundational (shared test infrastructure)
+
+**Goal**: Cross-cutting test-hygiene change relied on by the US3/US4/US6 unit suites. ⚠️ Blocks the unit-test tasks in those stories.
+
+- [ ] T004 Add `localStorage.clear()` to `beforeEach`/`afterEach` in the shared component unit test setup so persistence-touching suites don't bleed state `[Decision #11]` `shared/components/vitest.setup.ts`
+
+> If no shared `vitest.setup.ts` exists, add the `localStorage.clear()` hooks
+> directly to each persistence-touching suite created in Phases 5/8 instead, and
+> mark T004 done by inclusion. Existing `ExerciseListView.test.tsx` and
+> `__tests__/ThumbnailSizeToggle.test.tsx` must also get the clear hook.
+
+## Phase 3: US1 — Readable header links in HC-light (P1.3)
+
+**Story goal**: Header nav links meet ≥7:1 contrast in HC-light and carry a non-colour affordance, applied at the shared token/class level (FR-001–FR-004).
+
+**Independent test**: Switch web-shell to HC-light; axe-core measures every `.web-shell__header-link` at ≥7:1; visual check confirms underline/weight affordance; no regression in light/dark/HC-dark.
+
+### Tests
+
+- [ ] T005 [test] Write the HC-light contrast audit E2E: set HC-light, run axe-core `color-contrast` against the real themed root, assert 0 violations on header links (SC-001); screenshot all four themes for regression `apps/web-shell/playwright/tests/ui-review-contrast.spec.ts`
+
+### Implementation
+
+- [ ] T006 Point `.web-shell__header-link` at `var(--debrief-color-primary)` (drop the raw `--vscode-textLink-foreground`) and add `[data-theme^='high-contrast'] .web-shell__header-link` underline + heavier weight `[Decision #4]` `apps/web-shell/src/App.css`
+- [ ] T007 Verify/confirm `--debrief-color-primary` HC-light value (`#0F4A85`) clears 7:1 on the header background; **only if the audit fails**, add a dedicated darker HC link token here and consume it from App.css `[Decision #4]` `shared/components/src/styles/tokens.css`
+- [ ] T008 Run `cd apps/web-shell && node run-playwright.mjs ui-review-contrast` and confirm SC-001 passes; capture `screenshots/header-hc-light.png` into evidence `apps/web-shell/playwright/tests/ui-review-contrast.spec.ts`
+
+**Checkpoint**: HC-light header links ≥7:1 with affordance; other themes unregressed. US1 shippable.
+
+## Phase 4: US2 — Reliable properties-screenshots E2E (P1.4)
+
+**Story goal**: `properties-screenshots` passes first-attempt 10/10 with retries off, by gating on a reliably-present, actionable anchor before the row-click — without masking real breakage (FR-005–FR-007).
+
+**Independent test**: Run the suite 10× with `retries: 0`; 100% first-attempt pass.
+
+### Implementation
+
+- [ ] T009 Gate the row-click on actionability before clicking: `await expect(firstRow).toBeVisible()` (+ `scrollIntoViewIfNeeded()` if needed) then `firstRow.click()`; keep the existing 15s `properties-form` wait so genuine breakage still fails loudly. Apply the same gate to the interaction-video test `[FR-006/FR-007]` `apps/web-shell/playwright/tests/properties-screenshots.spec.ts`
+- [ ] T010 Configure the `properties-screenshots` suite to run at `retries: 0` in CI (project/grep override) so a future re-flake fails loudly instead of being retried away `[Decision #8]` `apps/web-shell/playwright/playwright.config.ts`
+
+### Verification
+
+- [ ] T011 Run the suite 10× consecutively with retries disabled via `cd apps/web-shell && node run-playwright.mjs properties-screenshots`; confirm 10/10 first-attempt pass (SC-002) and save the run output to `specs/281-ui-review-p1-p2-fixes/evidence/flake-proof.txt`
+
+**Checkpoint**: SC-002 met; flake proven gone with retries off. US2 shippable.
+
+## Phase 5: US3 — Analysis layout scales to wide screens (P2.1)
+
+**Story goal**: The default analysis-view activity-column width scales with the workspace **container** width via discrete bands; saved layouts respected; map keeps the majority (FR-008–FR-011).
+
+**Independent test**: Open analysis at 1280/1440/1920 — rail ≈280px at ≤1366, ≈360–400px at ≥1600 with no truncated tool name, map majority at all widths; a saved custom layout is used verbatim.
+
+### Tests
+
+- [ ] T012 [P][test] Unit-test `getDefaultLayout(width)`: discrete bands (≤1366→~280px, ≥1600→~360–400px, middle band), `sidebarWidthPct < contentWidthPct` for width ≥1024, pure (no `window` access) `[Decision #7]` `shared/components/src/PanelWorkspace/defaultLayout.test.ts`
+- [ ] T013 [P][test] Unit-test the version bump: `loadLayout()` returns `null` for a persisted layout at the old `LAYOUT_VERSION` (legacy fixed-25% discarded) `shared/components/src/PanelWorkspace/layoutPersistence.test.ts`
+- [ ] T014 [test] E2E layout-scaling spec: assert rail width per band, 0 ellipsised tool labels at ≥1600 (SC-003), ~280px rail + map majority at ≤1366 (SC-004), and a saved layout respected (FR-011) `apps/web-shell/playwright/tests/ui-review-layout.spec.ts`
+
+### Implementation
+
+- [ ] T015 Replace the static `DEFAULT_LAYOUT_CONFIG` with `getDefaultLayout(containerWidth: number): LayoutConfig` using discrete bands; derive `DEFAULT_LAYOUT_CONFIG = getDefaultLayout(BASELINE_WIDTH)` as the single panel-tree source; type GL content as `LayoutItemConfig[]` (no `any`) `[Decisions #1, #7]` `shared/components/src/PanelWorkspace/defaultLayout.ts`
+- [ ] T016 Bump `LAYOUT_VERSION` so legacy fixed-25% saved layouts fall back to the responsive default `shared/components/src/PanelWorkspace/layoutPersistence.ts`
+- [ ] T017 Switch **all three** `PanelWorkspace` call sites (parse-fail fallback, no-saved-layout, Reset Layout) to `getDefaultLayout(containerWidth)`, reading `containerRef.current.clientWidth` **once** at GL init / reset (not `window.innerWidth`) `[Decisions #1, #3, #13]` `shared/components/src/PanelWorkspace/PanelWorkspace.tsx`
+
+### Verification
+
+- [ ] T018 Run `cd apps/web-shell && node run-playwright.mjs ui-review-layout`; confirm SC-003/SC-004; capture `screenshots/analysis-1920.png` and `screenshots/analysis-1366.png` into evidence `apps/web-shell/playwright/tests/ui-review-layout.spec.ts`
+
+**Parallel**: T012, T013 are independent unit files. T015→T016→T017 are sequential (same/linked modules + call sites). **Checkpoint**: US3 shippable.
+
+## Phase 6: US4 — Properties discoverable on short laptops (P2.2)
+
+**Story goal**: At ~720px-tall viewports with a feature selected, Properties is reachable via a discoverable adaptation; no adaptation ≥900px; manual toggles always win and nothing is persisted (FR-012, FR-013).
+
+**Independent test**: Open analysis at 1280×720, select a feature — Properties is visible/reachable without prior scroll knowledge; at ≥900px no adaptation forced.
+
+### Tests
+
+- [ ] T019 [test] Invariant unit test: with container height stubbed `< threshold` and a feature selected, adaptation collapses Tools/Layers **internally**, never calls `onCollapseStateChange`, is a no-op when `collapseState` is controlled, and is a no-op at ≥900px `[Decisions #2, #9]` `shared/components/src/ActivityPanel/__tests__/ActivityPanel.shortHeight.test.tsx`
+- [ ] T020 [test] Extend the E2E layout spec: at 1280×720 with a feature selected, assert `properties-form` is reachable (SC-005) `apps/web-shell/playwright/tests/ui-review-layout.spec.ts`
+
+### Implementation
+
+- [ ] T021 Add the short-height adaptation: when **uncontrolled** AND container `clientHeight` (read once, `[Decision #13]`) `< threshold` AND a feature is selected, set the initial internal `collapseState` to collapse upper flex sections (Tools, then Layers) so Properties is visible; never call `onCollapseStateChange`; no-op when controlled or ≥900px `[Decisions #2, #13]` `shared/components/src/ActivityPanel/ActivityPanel.tsx`
+- [ ] T022 [P] (Optional, confirm at this point) Add a constrained-height `ActivityPanel` Storybook story demonstrating Properties reachable, for the blog aside `shared/components/src/ActivityPanel/ActivityPanel.stories.tsx`
+
+### Verification
+
+- [ ] T023 Run `cd apps/web-shell && node run-playwright.mjs ui-review-layout`; confirm SC-005; capture `screenshots/properties-720.png` into evidence `apps/web-shell/playwright/tests/ui-review-layout.spec.ts`
+
+**Checkpoint**: US4 shippable; the never-persist/respect-controlled invariant is locked by T019.
+
+## Phase 7: US5 — Catalog timeline+map row discoverably collapsible (P2.3)
+
+**Story goal**: Make the existing collapse/restore of the timeline+map row discoverable, sensibly defaulted (shown once a dataset context exists), and persisted across reloads (FR-014–FR-017).
+
+**Independent test**: From the catalog, activate a clearly-visible collapse control → list expands; restore control returns the row; state survives reload.
+
+### Tests
+
+- [ ] T024 [test] E2E catalog spec: discoverable collapse control collapses the row and grows the list, restore control returns it, and the state survives a reload (SC-006) `apps/web-shell/playwright/tests/ui-review-catalog.spec.ts`
+
+### Implementation
+
+- [ ] T025 Replace the `const content: any[]` + `eslint-disable` in `buildLayoutForVisiblePanels` with the proper GoldenLayout item type while in this function `[Decision #6]` `shared/components/src/StacBrowser/StacBrowser.tsx`
+- [ ] T026 Make the collapse affordance discoverable (labelled chevron + tooltip rather than a bare glyph) and ensure the restore control is equally visible; apply the first-run default (bottom row **shown** once a dataset context exists) when no saved layout exists, and have Reset Layout reapply it `[FR-014/FR-015/FR-017]` `shared/components/src/StacBrowser/StacBrowser.tsx`
+
+### Verification
+
+- [ ] T027 Run `cd apps/web-shell && node run-playwright.mjs ui-review-catalog`; confirm SC-006; capture `screenshots/catalog-collapse.png` into evidence `apps/web-shell/playwright/tests/ui-review-catalog.spec.ts`
+
+**Note**: T025 and T026 edit the same file — keep sequential. **Checkpoint**: US5 shippable.
+
+## Phase 8: US6 — Thumbnail S/M/L toggle visibly resizes list (P2.4)
+
+**Story goal**: Selecting S/M/L visibly resizes the exercise-list items (thumbnail + row) and the choice persists across reloads (FR-018–FR-020).
+
+**Independent test**: Click S, then M, then L — items visibly change size at each step; reload remembers the choice.
+
+### Tests
+
+- [ ] T028 [P][test] Unit-test the typed persistence helper: writes the size, narrows a stored value to the `ThumbnailSize` union on read, falls back to `'small'` on any unexpected value; versioned key `[Decisions #5, #11]` `shared/components/src/StacBrowser/thumbnailSizePreference.test.ts`
+- [ ] T029 [P][test] Unit-test that `virtualizer.measure()` fires on `rowHeight` change via a spy (and is gated to the `[rowHeight]` effect, not per render) `[Decisions #10, #12]` `shared/components/src/ExerciseListView/ExerciseListView.test.tsx`
+- [ ] T030 [test] E2E catalog spec: S/M/L produce visibly distinct row heights and the choice survives reload (SC-007) `apps/web-shell/playwright/tests/ui-review-catalog.spec.ts`
+
+### Implementation
+
+- [ ] T031 [P] Add the typed, versioned `thumbnailSize` read/write helper (narrow to union on read, fall back to `'small'`) `[Decision #5]` `shared/components/src/StacBrowser/thumbnailSizePreference.ts`
+- [ ] T032 Call `virtualizer.measure()` only inside `useEffect(..., [rowHeight])` (never in the render path) so a size change re-flows the list; ensure thumbnail imagery scales via `THUMBNAIL_SIZE_CONFIGS[size]`, not only row height `[Decisions #10, #12]` `shared/components/src/ExerciseListView/ExerciseListView.tsx`
+- [ ] T033 Hydrate `thumbnailSize` from the helper on mount and persist on change in `StacBrowser` `[FR-020]` `shared/components/src/StacBrowser/StacBrowser.tsx`
+
+### Verification
+
+- [ ] T034 Run `cd apps/web-shell && node run-playwright.mjs ui-review-catalog`; confirm SC-007; capture `screenshots/thumbnail-sizes.png` and the `screenshots/interaction.gif` (collapse + resize flow) into evidence `apps/web-shell/playwright/tests/ui-review-catalog.spec.ts`
+
+**Parallel**: T028, T029 (different test files); T031 is independent of T032. T033 depends on T031. **Checkpoint**: US6 shippable.
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+### Regression guard
+
+- [ ] T035 Run the full local CI gate (`task verify`, then the Playwright step) and confirm no regression in the resolved P1 items or other catalog/analysis/storyboard/log surfaces (SC-008) `apps/web-shell/playwright/tests/`
+
+### Evidence Collection
+
+- [ ] T036 Capture test results using the template (`.specify/templates/evidence/test-summary-template.md`) with YAML front matter (`git_sha`, `captured_at`, pass/fail/skip counts) `specs/281-ui-review-p1-p2-fixes/evidence/test-summary.md`
+- [ ] T037 [P] Create the per-item usage demonstration (how each fix manifests for an analyst) `specs/281-ui-review-p1-p2-fixes/evidence/usage-example.md`
+- [ ] T038 [P] Confirm all screenshots + `interaction.gif` (<5s, <2MB) + `flake-proof.txt` are present in `specs/281-ui-review-p1-p2-fixes/evidence/screenshots/`
+
+### Media Content
+
+- [ ] T039 Create the feature blog post via the Content Specialist agent — first three sections copied verbatim from `evidence/opening-context.md`, remaining sections from evidence `specs/281-ui-review-p1-p2-fixes/media/shipped-post.md`
+
+### PR Creation
+
+- [ ] T040 Create PR and publish blog: run `/speckit.pr` (updates the already-open PR #667 with evidence; opens the debrief.github.io blog PR)
+
+**Task T040 must run last. It depends on all evidence (T036–T038) and media (T039) tasks being complete.**
+
+## Dependencies
+
+**Story independence**: US1–US6 are independent and can ship in any order. The
+recommended order follows priority: **US1 (P1.3) → US2 (P1.4) → US3 (P2.1) →
+US4 (P2.2) → US5 (P2.3) → US6 (P2.4)**.
+
+**Hard dependencies**:
+- Phase 1 (page objects) precedes the E2E tasks that use them (T005, T014, T020, T024, T030).
+- T004 (localStorage hygiene) precedes the persistence-touching unit suites (T028, T029, and the existing thumbnail/exercise suites).
+- **US3 internal**: T015 → T016 → T017 (linked modules + the three call sites).
+- **US4 internal**: T021 before T020/T023 verification; T019 can be written first (TDD).
+- **US5 internal**: T025 → T026 (same file); both before T024/T027.
+- **US6 internal**: T031 → T033 (helper before consumer); T032 independent; tests before/with impl per TDD.
+- **Polish**: T035 after all stories; T036–T039 after T035; **T040 last** (depends on all).
+
+**No cross-story code coupling** — different files per story except StacBrowser.tsx
+(shared by US5 T025/T026 and US6 T033 — sequence those edits).
+
+## Implementation Strategy
+
+**Incremental delivery** — each user story is an independently shippable
+increment with its own E2E proof and evidence screenshot. Suggested cadence:
+
+1. **MVP slice (accessibility + reliability)**: US1 + US2 first — these are the
+   remaining P1 items (contrast + flake) and unblock CI confidence.
+2. **Layout polish**: US3 then US4 — both touch `PanelWorkspace`/`ActivityPanel`
+   and share the `ui-review-layout.spec.ts` E2E file.
+3. **Catalog polish**: US5 then US6 — both touch `StacBrowser`/`ExerciseListView`
+   and share the `ui-review-catalog.spec.ts` E2E file; sequence the two
+   `StacBrowser.tsx` edits.
+4. **Polish phase**: regression gate, evidence, blog post, PR.
+
+**TDD posture**: where a `[test]` task precedes its implementation, write the
+failing test first (esp. T019 invariant, T012/T013/T028/T029 unit tests).
+
+**Parallelisation**: Phase 1 page objects (T001–T003) run together; within
+stories, `[P]`-tagged unit-test files run together. Two developers could take the
+layout pair (US3/US4) and the catalog pair (US5/US6) concurrently with no file
+conflicts.
+
+**Pre-push gate**: run `task verify` + the Playwright wrappers (per CLAUDE.md
+"Before Pushing") before each push; the PR (#667) is already open and updated on
+push. Per `/speckit.review`, the `properties-screenshots` suite runs at
+`retries: 0` (T010) so the de-flake stays honest in CI.
+


### PR DESCRIPTION
## Summary

Adds the feature specification for **spec 281 — UI Review Follow-up**, which scopes resolution of the **two remaining P1 items** and **all four P2 items** from the [2026-04-26 UI review](https://github.com/debrief/debrief-future/blob/main/docs/ui-review-2026-04-26.md) (re-walked 2026-06-06).

This PR is **spec only** — no implementation yet. It's the `/speckit.specify` output, ready for `/speckit.clarify` → `/speckit.plan`.

## Scope

Per the review's revised punch list (2026-06-06), three of five P1 items are already resolved on `main`. In scope here:

| Review ID | Item | Surface |
|-----------|------|---------|
| **P1.3** | High-contrast light header link contrast (≥7:1, link affordance) | web-shell |
| **P1.4** | `properties-screenshots` E2E flake (wait-gate fix) | E2E |
| **P2.1** | Analysis-view layout doesn't scale to wide screens | web-shell |
| **P2.2** | Properties panel hidden below the fold at 720-tall | web-shell |
| **P2.3** | Catalog timeline + map row not discoverably collapsible | web-shell |
| **P2.4** | Thumbnail S/M/L toggle has no visible effect | web-shell |

**Out of scope:** all P3 items and VS Code-host-specific layout (P1.5 toast work already shipped).

## Notes from reconnaissance

The spec is grounded in a code sweep that surfaced two nuances worth flagging for planning:

- **P2.3** — a per-panel hide control + filter-bar restore already exist; the spec reframes this as a *discoverability + sensible default + persistence* problem rather than building collapse from scratch.
- **P2.4** — the toggle already drives an internal row-height value but doesn't visibly change the list; the spec treats this as wiring the selection through to a visible result (thumbnail + row), not adding a new control.

## Artefacts

- `specs/281-ui-review-p1-p2-fixes/spec.md` — 6 prioritised user stories, 22 FRs, 8 success criteria, UI flow, assumptions, out-of-scope.
- `specs/281-ui-review-p1-p2-fixes/checklists/requirements.md` — quality checklist, all items pass on first iteration (no `[NEEDS CLARIFICATION]` markers; defaults documented in Assumptions).

## Next steps

`/speckit.clarify` (optional — defaults are documented) then `/speckit.plan`.

https://claude.ai/code/session_01FKkpSXMWAJwrHp7qbuak63

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKkpSXMWAJwrHp7qbuak63)_